### PR TITLE
prevent call on empty values

### DIFF
--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -53,6 +53,11 @@ class Geocoder implements GeocoderInterface
      */
     public function geocode($value)
     {
+        if (empty($value)) {
+            // let's save a request
+            return $this->returnResult(array());
+        }
+
         $result = $this->retrieve($value);
 
         if (null === $result) {
@@ -70,6 +75,11 @@ class Geocoder implements GeocoderInterface
      */
     public function reverse($latitude, $longitude)
     {
+        if (empty($latitude) || empty($longitude)) {
+            // let's save a request
+            return $this->returnResult(array());
+        }
+
         $result = $this->retrieve($value);
 
         if (null === $result) {

--- a/tests/Geocoder/Tests/GeocoderTest.php
+++ b/tests/Geocoder/Tests/GeocoderTest.php
@@ -107,6 +107,25 @@ class GeocoderTest extends TestCase
         $this->assertEquals(1, $this->geocoder->countCallGetProvider);
         $this->assertEquals(1, count($store));
     }
+
+    public function testEmpty()
+    {
+        $this->geocoder->registerProvider(new MockProviderWithRequestCount('test2'));
+        $this->assertEmptyResult($this->geocoder->geocode(''));
+        $this->assertEquals(0, $this->geocoder->getProvider('test2')->geocodeCount);
+        $this->assertEmptyResult($this->geocoder->geocode(null));
+        $this->assertEquals(0, $this->geocoder->getProvider('test2')->geocodeCount);
+    }
+
+    protected function assertEmptyResult($result)
+    {
+        $this->assertEquals(0, $result->getLatitude());
+        $this->assertEquals(0, $result->getLongitude());
+        $this->assertEquals('', $result->getCity());
+        $this->assertEquals('', $result->getZipcode());
+        $this->assertEquals('', $result->getRegion());
+        $this->assertEquals('', $result->getCountry());
+    }
 }
 
 class MockProvider implements ProviderInterface
@@ -142,6 +161,16 @@ class MockProviderWithData extends MockProvider
             'latitude' => 123,
             'longitude' => 456
         );
+    }
+}
+
+class MockProviderWithRequestCount extends MockProvider
+{
+    public $geocodeCount = 0;
+
+    public function getGeocodedData($address)
+    {
+        $this->geocodeCount++;
     }
 }
 


### PR DESCRIPTION
no more service call when value to geocode is empty.
