### PR TITLE
Use non-locale aware type modifier %F in sprintf() for coordinates

### DIFF
--- a/src/Geocoder/Provider/BingMapsProvider.php
+++ b/src/Geocoder/Provider/BingMapsProvider.php
@@ -64,7 +64,7 @@ class BingMapsProvider extends AbstractProvider implements ProviderInterface
             throw new \RuntimeException('No API Key provided');
         }
 
-        $query = sprintf('http://dev.virtualearth.net/REST/v1/Locations/%s,%s?key=%s', $coordinates[0], $coordinates[1], $this->apiKey);
+        $query = sprintf('http://dev.virtualearth.net/REST/v1/Locations/%F,%F?key=%s', $coordinates[0], $coordinates[1], $this->apiKey);
 
         return $this->executeQuery($query);
     }

--- a/src/Geocoder/Provider/CloudMadeProvider.php
+++ b/src/Geocoder/Provider/CloudMadeProvider.php
@@ -64,7 +64,7 @@ class CloudMadeProvider extends AbstractProvider implements ProviderInterface
             throw new \RuntimeException('No API Key provided');
         }
 
-        $query = sprintf('http://geocoding.cloudmade.com/%s/geocoding/v2/find.js?around=%s,%s&object_type=address&return_location=true&results=1', $this->apiKey, $coordinates[0], $coordinates[1]);
+        $query = sprintf('http://geocoding.cloudmade.com/%s/geocoding/v2/find.js?around=%F,%F&object_type=address&return_location=true&results=1', $this->apiKey, $coordinates[0], $coordinates[1]);
 
         return $this->executeQuery($query);
     }

--- a/src/Geocoder/Provider/GoogleMapsProvider.php
+++ b/src/Geocoder/Provider/GoogleMapsProvider.php
@@ -49,7 +49,7 @@ class GoogleMapsProvider extends AbstractProvider implements ProviderInterface
      */
     public function getReversedData(array $coordinates)
     {
-        return $this->getGeocodedData(sprintf('%s,%s', $coordinates[0], $coordinates[1]));
+        return $this->getGeocodedData(sprintf('%F,%F', $coordinates[0], $coordinates[1]));
     }
 
     /**

--- a/src/Geocoder/Provider/OpenStreetMapsProvider.php
+++ b/src/Geocoder/Provider/OpenStreetMapsProvider.php
@@ -78,7 +78,7 @@ class OpenStreetMapsProvider extends AbstractProvider implements ProviderInterfa
     public function getReversedData(array $coordinates)
     {
 
-        $query = sprintf('http://nominatim.openstreetmap.org/reverse?format=xml&lat=%s&lon=%s&addressdetails=1', $coordinates[0], $coordinates[1]);
+        $query = sprintf('http://nominatim.openstreetmap.org/reverse?format=xml&lat=%F&lon=%F&addressdetails=1', $coordinates[0], $coordinates[1]);
 
         $content = $this->executeQuery($query);
 

--- a/src/Geocoder/Provider/YahooProvider.php
+++ b/src/Geocoder/Provider/YahooProvider.php
@@ -65,7 +65,7 @@ class YahooProvider extends AbstractProvider implements ProviderInterface
             throw new \RuntimeException('No API Key provided');
         }
 
-        $query = sprintf('http://where.yahooapis.com/geocode?q=%s,+%s&gflags=R&flags=J&appid=%s', $coordinates[0], $coordinates[1], $this->apiKey);
+        $query = sprintf('http://where.yahooapis.com/geocode?q=%F,+%F&gflags=R&flags=J&appid=%s', $coordinates[0], $coordinates[1], $this->apiKey);
 
         return $this->executeQuery($query);
     }


### PR DESCRIPTION
Currently `%s` is used for coordinates when formatting urls in the providers. This will lead to wrong formatted coordinates when using a locale which uses a comma as decimal separator (eg. with `setlocale(LC_NUMERIC, 'de_DE');`
