### PR TITLE
offsetExists() on a Geocoded result returned true even for "unset-ed" offsets

### DIFF
--- a/src/Geocoder/Result/Geocoded.php
+++ b/src/Geocoder/Result/Geocoded.php
@@ -219,7 +219,7 @@ class Geocoded implements ResultInterface, \ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return property_exists($this, strtolower($offset));
+        return property_exists($this, strtolower($offset)) && null !== $this->$offset;
     }
 
     /**

--- a/tests/Geocoder/Tests/Result/GeocodedTest.php
+++ b/tests/Geocoder/Tests/Result/GeocodedTest.php
@@ -174,5 +174,9 @@ class GeocodedTest extends TestCase
         // set
         $this->geocoded['latitude'] = 0.123456;
         $this->assertEquals(0.123456, $this->geocoded['latitude']);
+
+        // unset
+        unset($this->geocoded['latitude']);
+        $this->assertEquals(false, isset($this->geocoded['latitude']));
     }
 }


### PR DESCRIPTION
See the "unset" part of the testArrayInterface() test.
