### PR TITLE
Updating to Guzzle 2.0

### DIFF
--- a/bin/install_vendors.sh
+++ b/bin/install_vendors.sh
@@ -15,6 +15,7 @@ function installOrUpdate
 }
 
 installOrUpdate "vendor/Symfony/Component/ClassLoader" "http://github.com/symfony/ClassLoader.git" "origin/master"
+installOrUpdate "vendor/Symfony/Component/EventDispatcher" "http://github.com/symfony/EventDispatcher.git" "origin/master"
 installOrUpdate "vendor/Buzz" "http://github.com/kriswallsmith/Buzz.git" "origin/master"
 installOrUpdate "vendor/Guzzle" "http://github.com/guzzle/guzzle.git" "origin/master"
 

--- a/tests/Geocoder/Tests/HttpAdapter/GuzzleHttpAdapterTest.php
+++ b/tests/Geocoder/Tests/HttpAdapter/GuzzleHttpAdapterTest.php
@@ -6,7 +6,7 @@ use Geocoder\HttpAdapter\GuzzleHttpAdapter;
 
 use Guzzle\Http\Message\Response;
 use Guzzle\Http\Plugin\HistoryPlugin;
-use Guzzle\Service\Plugin\MockPlugin;
+use Guzzle\Http\Plugin\MockPlugin;
 use Guzzle\Service\Client;
 
 /**
@@ -40,8 +40,8 @@ class GuzzleHttpAdapterTest extends \Geocoder\Tests\TestCase
         $mockPlugin = new MockPlugin(array(new Response(200, null, 'body')));
 
         $client = new Client();
-        $client->getEventManager()->attach($mockPlugin);
-        $client->getEventManager()->attach($historyPlugin);
+        $client->getEventDispatcher()->addSubscriber($mockPlugin);
+        $client->getEventDispatcher()->addSubscriber($historyPlugin);
 
         $adapter = new GuzzleHttpAdapter($client);
         $this->assertEquals('body', $adapter->getContent('http://test.com/'));


### PR DESCRIPTION
Guzzle 2.0 requires the Symfony 2 Event Dispatcher
