### PR TITLE
add failing test for mixed case array access

### DIFF
--- a/tests/Geocoder/Tests/Result/GeocodedTest.php
+++ b/tests/Geocoder/Tests/Result/GeocodedTest.php
@@ -149,7 +149,8 @@ class GeocodedTest extends TestCase
             'zipcode'   => '65943',
             'region'    => 'FOO region',
             'country'   => 'FOO Country',
-            'timezone'  => 'Foo/Timezone'
+            'timezone'  => 'Foo/Timezone',
+            'countryCode' => 'XX'
         );
 
         $this->geocoded->fromArray($array);
@@ -163,6 +164,8 @@ class GeocodedTest extends TestCase
         $this->assertEquals('Foo Region', $this->geocoded['region']);
         $this->assertEquals('Foo Country', $this->geocoded['country']);
         $this->assertEquals('Foo/Timezone', $this->geocoded['timezone']);
+        
+        $this->assertEquals('XX', $this->geocoded['countryCode']);
 
         // array access is case independant
         $this->assertEquals(0.001, $this->geocoded['LATITUDE']);


### PR DESCRIPTION
This test case fails - the properties of the Geocoded class are mixed case but for some reason the ArrayAccess methods lowercases the offsets so the properties can't be accessed.
