### PR TITLE
Removed not reliable place_rank and limit result to one + test - fix #12...

### DIFF
--- a/tests/Geocoder/Tests/Provider/OpenStreetMapsProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/OpenStreetMapsProviderTest.php
@@ -32,53 +32,64 @@ class OpenStreetMapsProviderTest extends TestCase
         $this->assertEquals(35, $result['streetNumber']);
         $this->assertEquals('Läntinen Pitkäkatu', $result['streetName']);
         $this->assertEquals('Turku', $result['city']);
+        $this->assertEquals('VII', $result['cityDistrict']);
         $this->assertEquals('Finland Proper', $result['county']);
-        $this->assertEquals(null, $result['region']);
+        $this->assertNull($result['region']);
+        $this->assertNull($result['regionCode']);
         $this->assertEquals('Finland', $result['country']);
         $this->assertEquals('FI', $result['countryCode']);
+    }
 
+    public function testGetGeocodedDataWithRealAddressWithLocale()
+    {
+        $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'fr_FR');
         $result   = $provider->getGeocodedData('10 allée Evariste Galois, Clermont ferrand');
 
-        $this->assertEquals(45.7587754693841, $result['latitude'], '', 0.01);
-        $this->assertEquals(3.13073228527092, $result['longitude'], '', 0.01);
+        $this->assertEquals(45.7586841, $result['latitude'], '', 0.0001);
+        $this->assertEquals(3.1354075, $result['longitude'], '', 0.0001);
         $this->assertArrayHasKey('south', $result['bounds']);
         $this->assertArrayHasKey('west', $result['bounds']);
         $this->assertArrayHasKey('north', $result['bounds']);
         $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(45.7595672607422, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(3.12900018692017, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(45.7605743408203, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(3.1324610710144, $result['bounds']['east'], '', 0.01);
-        $this->assertEquals(null, $result['streetNumber']);
+        $this->assertEquals(45.7576484680176, $result['bounds']['south'], '', 0.0001);
+        $this->assertEquals(3.13258004188538, $result['bounds']['west'], '', 0.0001);
+        $this->assertEquals(45.7595367431641, $result['bounds']['north'], '', 0.0001);
+        $this->assertEquals(3.13707232475281, $result['bounds']['east'], '', 0.0001);
+        $this->assertNull($result['streetNumber']);
         $this->assertEquals('Allée Évariste Galois', $result['streetName']);
         $this->assertEquals('63170', $result['zipcode']);
-        //$this->assertEquals('Clermont-Ferrand', $result['city']);
+        $this->assertEquals('Aubière', $result['city']);
+        $this->assertEquals('Cap Sud', $result['cityDistrict']);
         $this->assertEquals('Puy-de-Dôme', $result['county']);
         $this->assertEquals('Auvergne', $result['region']);
+        $this->assertNull($result['regionCode']);
         $this->assertEquals('France', $result['country']);
         $this->assertEquals('FR', $result['countryCode']);
     }
 
     public function testGetReversedDataWithRealCoordinates()
     {
-        $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'fi-FI');
+        $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getReversedData(array('60.4539471728726', '22.2567841926781'));
 
         $this->assertEquals(60.4539471768582, $result['latitude'], '', 0.0001);
         $this->assertEquals(22.2567842183875, $result['longitude'], '', 0.0001);
+        $this->assertNull($result['bounds']);
         $this->assertEquals(35, $result['streetNumber']);
         $this->assertEquals('Läntinen Pitkäkatu', $result['streetName']);
         $this->assertEquals(20100, $result['zipcode']);
         $this->assertEquals('Turku', $result['city']);
-        $this->assertEquals('Varsinais-Suomi', $result['county']);
-        $this->assertEquals(null, $result['region']);
-        $this->assertEquals('Suomi', $result['country']);
+        $this->assertEquals('VII', $result['cityDistrict']);
+        $this->assertEquals('Finland Proper', $result['county']);
+        $this->assertNull($result['region']);
+        $this->assertNull($result['regionCode']);
+        $this->assertEquals('Finland', $result['country']);
         $this->assertEquals('FI', $result['countryCode']);
     }
 
     /**
      * @expectedException Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=Hammm&format=xml&addressdetails=1
+     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=Hammm&format=xml&addressdetails=1&limit=1
      */
     public function testGetGeocodedDataWithUnknownCity()
     {
@@ -86,12 +97,31 @@ class OpenStreetMapsProviderTest extends TestCase
         $provider->getGeocodedData('Hammm');
     }
 
-    public function testGetGeocodedDataWithCityDistrict()
+    public function testGetReversedDataWithRealCoordinatesWithLocale()
     {
-        $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
+        $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'de_DE');
         $result   = $provider->getGeocodedData('Kalbacher Hauptstraße, 60437 Frankfurt, Germany');
 
-        $this->assertNotNull('Kalbach', $result['cityDistrict']);
+        $this->assertEquals(50.1856803, $result['latitude'], '', 0.0001);
+        $this->assertEquals(8.6506285, $result['longitude'], '', 0.0001);
+        $this->assertArrayHasKey('south', $result['bounds']);
+        $this->assertArrayHasKey('west', $result['bounds']);
+        $this->assertArrayHasKey('north', $result['bounds']);
+        $this->assertArrayHasKey('east', $result['bounds']);
+        $this->assertEquals(50.1851196289062, $result['bounds']['south'], '', 0.0001);
+        $this->assertEquals(8.64984607696533, $result['bounds']['west'], '', 0.0001);
+        $this->assertEquals(50.1860122680664, $result['bounds']['north'], '', 0.0001);
+        $this->assertEquals(8.65207576751709, $result['bounds']['east'], '', 0.0001);
+        $this->assertNull($result['streetNumber']);
+        $this->assertEquals('Kalbacher Hauptstraße', $result['streetName']);
+        $this->assertNull($result['zipcode']);
+        $this->assertEquals('Frankfurt am Main', $result['city']);
+        $this->assertEquals('Kalbach', $result['cityDistrict']);
+        $this->assertEquals('Frankfurt am Main', $result['county']);
+        $this->assertEquals('Hessen', $result['region']);
+        $this->assertNull($result['regionCode']);
+        $this->assertEquals('Deutschland', $result['country']);
+        $this->assertEquals('DE', $result['countryCode']);
     }
 
     public function testGetGeocodedDataWithLocalhostIPv4()
@@ -125,8 +155,16 @@ class OpenStreetMapsProviderTest extends TestCase
         $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('88.188.221.14');
 
-        $this->assertEquals(43.6189, $result['latitude'], '', 0.0001);
-        $this->assertEquals(1.4564, $result['longitude'], '', 0.0001);
+        $this->assertEquals(43.6189768, $result['latitude'], '', 0.0001);
+        $this->assertEquals(1.4564493, $result['longitude'], '', 0.0001);
+        $this->assertArrayHasKey('south', $result['bounds']);
+        $this->assertArrayHasKey('west', $result['bounds']);
+        $this->assertArrayHasKey('north', $result['bounds']);
+        $this->assertArrayHasKey('east', $result['bounds']);
+        $this->assertEquals(43.6159553527832, $result['bounds']['south'], '', 0.0001);
+        $this->assertEquals(1.45302963256836, $result['bounds']['west'], '', 0.0001);
+        $this->assertEquals(43.623119354248, $result['bounds']['north'], '', 0.0001);
+        $this->assertEquals(1.45882403850555, $result['bounds']['east'], '', 0.0001);
         $this->assertNull($result['streetNumber']);
         $this->assertEquals('Rue du Faubourg Bonnefoy', $result['streetName']);
         $this->assertEquals(31506, $result['zipcode']);
@@ -134,7 +172,35 @@ class OpenStreetMapsProviderTest extends TestCase
         $this->assertEquals('Toulouse', $result['city']);
         $this->assertEquals('Haute-Garonne', $result['county']);
         $this->assertEquals('Midi-Pyrénées', $result['region']);
+        $this->assertNull($result['regionCode']);
         $this->assertEquals('France', $result['country']);
+        $this->assertEquals('FR', $result['countryCode']);
+    }
+
+    public function testGetGeocodedDataWithRealIPv4WithLocale()
+    {
+        $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'da_DK');
+        $result   = $provider->getGeocodedData('88.188.221.14');
+
+        $this->assertEquals(43.6142209, $result['latitude'], '', 0.0001);
+        $this->assertEquals(1.4510706, $result['longitude'], '', 0.0001);
+        $this->assertArrayHasKey('south', $result['bounds']);
+        $this->assertArrayHasKey('west', $result['bounds']);
+        $this->assertArrayHasKey('north', $result['bounds']);
+        $this->assertArrayHasKey('east', $result['bounds']);
+        $this->assertEquals(43.6141357421875, $result['bounds']['south'], '', 0.0001);
+        $this->assertEquals(1.45088791847229, $result['bounds']['west'], '', 0.0001);
+        $this->assertEquals(43.6150016784668, $result['bounds']['north'], '', 0.0001);
+        $this->assertEquals(1.45196998119354, $result['bounds']['east'], '', 0.0001);
+        $this->assertNull($result['streetNumber']);
+        $this->assertEquals('Avenue de Lyon', $result['streetName']);
+        $this->assertEquals(31506, $result['zipcode']);
+        $this->assertEquals(4, $result['cityDistrict']);
+        $this->assertEquals('Toulouse', $result['city']);
+        $this->assertEquals('Haute-Garonne', $result['county']);
+        $this->assertEquals('Midi-Pyrénées', $result['region']);
+        $this->assertNull($result['regionCode']);
+        $this->assertEquals('Frankrig', $result['country']);
         $this->assertEquals('FR', $result['countryCode']);
     }
 
@@ -160,7 +226,7 @@ class OpenStreetMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=L%C3%A4ntinen+Pitk%C3%A4katu+35%2C+Turku&format=xml&addressdetails=1
+     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=L%C3%A4ntinen+Pitk%C3%A4katu+35%2C+Turku&format=xml&addressdetails=1&limit=1
      */
     public function testGetGeocodedDataWithAddressGetsEmptyContent()
     {
@@ -170,7 +236,7 @@ class OpenStreetMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=L%C3%A4ntinen+Pitk%C3%A4katu+35%2C+Turku&format=xml&addressdetails=1
+     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=L%C3%A4ntinen+Pitk%C3%A4katu+35%2C+Turku&format=xml&addressdetails=1&limit=1
      */
     public function testGetGeocodedDataWithAddressGetsEmptyXML()
     {


### PR DESCRIPTION
...9

Search for `paris`.

Before:

```
Geocoder\Result\Geocoded::__set_state(array(
   'latitude' => 36.1120019,
   'longitude' => -115.1726609,
   'bounds' => 
  array (
    'south' => 36.111999511719,
    'west' => -115.17266845703,
    'north' => 36.112003326416,
    'east' => -115.17266082764,
  ),
   'streetNumber' => NULL,
   'streetName' => 'Las Vegas Boulevard',
   'cityDistrict' => 'Hughes Center',
   'city' => 'Las Vegas',
   'zipcode' => '89169',
   'county' => 'Clark',
   'region' => 'Nevada',
   'regionCode' => NULL,
   'country' => 'United States Of America',
   'countryCode' => 'us',
   'timezone' => NULL,
))
```

After:

```
Geocoder\Result\Geocoded::__set_state(array(
   'latitude' => 48.8588408,
   'longitude' => 2.320034655299,
   'bounds' => 
  array (
    'south' => 48.815525054932,
    'west' => 2.2241218090057,
    'north' => 48.902156829834,
    'east' => 2.4697604179382,
  ),
   'streetNumber' => NULL,
   'streetName' => NULL,
   'cityDistrict' => NULL,
   'city' => NULL,
   'zipcode' => NULL,
   'county' => 'Paris',
   'region' => 'Île-De-France',
   'regionCode' => NULL,
   'country' => 'France',
   'countryCode' => 'FR',
   'timezone' => NULL,
))
```
