### PR TITLE
Correct property reference.

### DIFF
--- a/src/Geocoder/Provider/GoogleMapsProvider.php
+++ b/src/Geocoder/Provider/GoogleMapsProvider.php
@@ -44,7 +44,7 @@ class GoogleMapsProvider extends AbstractProvider implements ProviderInterface
         parent::__construct($adapter, $locale);
 
         $this->region = $region;
-        $this->useSssl = $useSsl;
+        $this->useSsl = $useSsl;
     }
 
     /**


### PR DESCRIPTION
Embarrassing error has been fixed. Rogue 's' has been removed from property.

I'm so sorry.
