### PR TITLE
Make Geocoder a Composer light-weight distribution package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/src
+CHANGELOG.md
+composer.json
+LICENCE
+README.md


### PR DESCRIPTION
Hi William,

A small update which make Geocoder a composer light-weight package (http://getcomposer.org/doc/02-libraries.md#light-weight-distribution-packages).

What do you think ?
