### PR TITLE
Fix for problem in GeoIpsProvider

### DIFF
--- a/src/Geocoder/Provider/GeoIPsProvider.php
+++ b/src/Geocoder/Provider/GeoIPsProvider.php
@@ -102,7 +102,7 @@ class GeoIPsProvider extends AbstractProvider implements ProviderInterface
             $response = $json['response'];
         } else {
             $response = $json;
-        }
+        } 
 
         if (!is_array($response) || !count($response)) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));


### PR DESCRIPTION
Accoring to api guide of GeoIPs (http://www.geoips.com/developer/api-guide) the response schema looks like this:
{
    "status" : "Success",
    "ip" : "66.147.244.214",
    "hostname" : "box714.bluehost.com",
    "owner" : "BLUEHOST INC.",
    "continent_name" : "NORTH AMERICA",
    "continent_code" : "NA",
    "country_name" : "UNITED STATES",
    "country_code" : "US",
    "region_name" : "UTAH",
    "region_code" : "UT",
    "county_name" : "UTAH",
    "city_name" : "PROVO",
    "latitude" : "40.3402",
    "longitude" : "-111.6073",
    "timezone" : "MST",
}

In this response there is no additional key 'response'. Because of this the current GeoIPs Provider generates an error.

This pull request should fix this. Solution is actually really simple.
