### PR TITLE
Change wording from 'splitted' to 'split'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Geocoder
 ========
 
 **Geocoder** is a library which helps you build geo-aware applications. It provides an abstraction layer for geocoding manipulations.
-The library is splitted in two parts: `HttpAdapter` and `Provider` and is really extensible.
+The library is split in two parts: `HttpAdapter` and `Provider` and is really extensible.
 
 [![Build Status](https://secure.travis-ci.org/willdurand/Geocoder.png)](http://travis-ci.org/willdurand/Geocoder)
 


### PR DESCRIPTION
Splitted is not a real word, it's a common mistake that we add 'ed' on the end of every past-tense word. Split is the correct word here.
