### PR TITLE
Set a custom result factory via a setter

### DIFF
--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -44,7 +44,16 @@ class Geocoder implements GeocoderInterface
      */
     public function __construct(ProviderInterface $provider = null, ResultFactory $resultFactory = null)
     {
-        $this->provider      = $provider;
+        $this->provider = $provider;
+
+        $this->setResultFactory($resultFactory);
+    }
+
+    /**
+     * @param ResultFactory $resultFactory
+     */
+    public function setResultFactory(ResultFactory $resultFactory = null)
+    {
         $this->resultFactory = $resultFactory ?: new ResultFactory();
     }
 

--- a/tests/Geocoder/Tests/GeocoderTest.php
+++ b/tests/Geocoder/Tests/GeocoderTest.php
@@ -126,6 +126,19 @@ class GeocoderTest extends TestCase
         $this->assertInstanceOf('Geocoder\Tests\DummyResult', $geocoder->returnResult(array()));
     }
 
+    public function testSetAndUseCustomResultFactory()
+    {
+        $factoryMock = $this->getMock('Geocoder\Result\ResultFactory');
+        $factoryMock
+            ->expects($this->once())
+            ->method('newInstance')
+            ->will($this->returnValue(new DummyResult()));
+
+        $geocoder = new TestableGeocoder(null);
+        $geocoder->setResultFactory($factoryMock);
+        $this->assertInstanceOf('Geocoder\Tests\DummyResult', $geocoder->returnResult(array()));
+    }
+
     protected function assertEmptyResult($result)
     {
         $this->assertEquals(0, $result->getLatitude());


### PR DESCRIPTION
Hi William,

I think it can be usefull to have the possibility to set a custom result factory after a `Geocoder` object is created.

I'm trying to embed the provider name and its query string inside the result object. In my case, the geocoder object is created by the `Geotools` user so I need to inject my result object after its creation.
