### PR TITLE
Fix encoding for geoip provider

### DIFF
--- a/src/Geocoder/Provider/GeoipProvider.php
+++ b/src/Geocoder/Provider/GeoipProvider.php
@@ -58,7 +58,7 @@ class GeoipProvider extends AbstractProvider implements ProviderInterface
         $timezone = @geoip_time_zone_by_country_and_region($results['country_code'], $results['region']) ?: null;
         $region = @geoip_region_name_by_code($results['country_code'], $results['region']) ?: $results['region'];
 
-        return array_merge($this->getDefaults(), array(
+        $results = array_merge($this->getDefaults(), array(
             'latitude'    => $results['latitude'],
             'longitude'   => $results['longitude'],
             'city'        => $results['city'],
@@ -69,6 +69,12 @@ class GeoipProvider extends AbstractProvider implements ProviderInterface
             'countryCode' => $results['country_code'],
             'timezone'    => $timezone,
         ));
+
+        $results = array_map(function($value) {
+            return is_string($value) ? utf8_encode($value) : $value;
+        }, $results);
+
+        return $results;
     }
 
     /**


### PR DESCRIPTION
Geoip module return ISO-8859-1 encoded strings. Special characters are broken if they are not converted to utf8 before applying a transformation (like in https://github.com/willdurand/Geocoder/blob/master/src/Geocoder/Result/AbstractResult.php#L64)

You can try with this IP : 79.120.148.112 (Bogyoszló)
