### PR TITLE
Refactor providers to leverage ResultFactories - fix #232

### DIFF
--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -25,6 +25,11 @@ class Geocoder implements GeocoderInterface
     const VERSION = '1.5.2-dev';
 
     /**
+     * @var integer
+     */
+    const MAX_RESULTS = 5;
+
+    /**
      * @var ProviderInterface[]
      */
     private $providers = array();
@@ -40,14 +45,22 @@ class Geocoder implements GeocoderInterface
     private $resultFactory;
 
     /**
+     * @var integer
+     */
+    private $maxResults;
+
+    /**
      * @param ProviderInterface      $provider
      * @param ResultFactoryInterface $resultFactory
+     * @param integer                $maxResults
      */
-    public function __construct(ProviderInterface $provider = null, ResultFactoryInterface $resultFactory = null)
+    public function __construct(ProviderInterface $provider = null, ResultFactoryInterface $resultFactory = null,
+        $maxResults = self::MAX_RESULTS)
     {
         $this->provider = $provider;
 
         $this->setResultFactory($resultFactory);
+        $this->setMaxResults($maxResults);
     }
 
     /**
@@ -56,6 +69,26 @@ class Geocoder implements GeocoderInterface
     public function setResultFactory(ResultFactoryInterface $resultFactory = null)
     {
         $this->resultFactory = $resultFactory ?: new DefaultResultFactory();
+    }
+
+    /**
+     * @param integer $maxResults
+     *
+     * @return GeocoderInterface
+     */
+    public function setMaxResults($maxResults)
+    {
+        $this->maxResults = $maxResults;
+
+        return $this;
+    }
+
+    /**
+     * @return integer $maxResults
+     */
+    public function getMaxResults()
+    {
+        return $this->maxResults;
     }
 
     /**
@@ -68,8 +101,9 @@ class Geocoder implements GeocoderInterface
             return $this->returnResult(array());
         }
 
-        $data   = $this->getProvider()->getGeocodedData(trim($value));
-        $result = $this->returnResult($data);
+        $provider = $this->getProvider()->setMaxResults($this->getMaxResults());
+        $data     = $provider->getGeocodedData(trim($value));
+        $result   = $this->returnResult($data);
 
         return $result;
     }
@@ -84,8 +118,9 @@ class Geocoder implements GeocoderInterface
             return $this->returnResult(array());
         }
 
-        $data   = $this->getProvider()->getReversedData(array($latitude, $longitude));
-        $result = $this->returnResult($data);
+        $provider = $this->getProvider()->setMaxResults($this->getMaxResults());
+        $data     = $provider->getReversedData(array($latitude, $longitude));
+        $result   = $this->returnResult($data);
 
         return $result;
     }

--- a/src/Geocoder/Provider/AbstractProvider.php
+++ b/src/Geocoder/Provider/AbstractProvider.php
@@ -10,6 +10,7 @@
 
 namespace Geocoder\Provider;
 
+use Geocoder\Geocoder;
 use Geocoder\HttpAdapter\HttpAdapterInterface;
 
 /**
@@ -26,6 +27,11 @@ abstract class AbstractProvider
      * @var string
      */
     protected $locale = null;
+
+    /**
+     * @var integer
+     */
+    protected $maxResults = Geocoder::MAX_RESULTS;
 
     /**
      * @param HttpAdapterInterface $adapter An HTTP adapter.
@@ -83,6 +89,30 @@ abstract class AbstractProvider
         $this->locale = $locale;
 
         return $this;
+    }
+
+    /**
+     * Sets the maximum of returned results.
+     *
+     * @param integer $maxResults
+     *
+     * @return AbstractProvider
+     */
+    public function setMaxResults($maxResults)
+    {
+        $this->maxResults = $maxResults;
+
+        return $this;
+    }
+
+    /**
+     * Returns the maximum of wished results.
+     *
+     * @return integer
+     */
+    public function getMaxResults()
+    {
+        return $this->maxResults;
     }
 
     /**

--- a/src/Geocoder/Provider/BaiduProvider.php
+++ b/src/Geocoder/Provider/BaiduProvider.php
@@ -110,7 +110,7 @@ class BaiduProvider extends AbstractProvider implements ProviderInterface
             throw new InvalidCredentialsException('API Key provided is not valid.');
         }
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'latitude'     => isset($data['result']['location']['lat']) ? $data['result']['location']['lat'] : null,
             'longitude'    => isset($data['result']['location']['lng']) ? $data['result']['location']['lng'] : null,
             'streetNumber' => isset($data['result']['addressComponent']['street_number']) ? $data['result']['addressComponent']['street_number'] : null,
@@ -119,6 +119,6 @@ class BaiduProvider extends AbstractProvider implements ProviderInterface
             'cityDistrict' => isset($data['result']['addressComponent']['district']) ? $data['result']['addressComponent']['district'] : null,
             'county'       => isset($data['result']['addressComponent']['province']) ? $data['result']['addressComponent']['province'] : null,
             'countyCode'   => isset($data['result']['cityCode']) ? $data['result']['cityCode'] : null,
-        ));
+        )));
     }
 }

--- a/src/Geocoder/Provider/BingMapsProvider.php
+++ b/src/Geocoder/Provider/BingMapsProvider.php
@@ -23,7 +23,7 @@ class BingMapsProvider extends AbstractProvider implements ProviderInterface
     /**
      * @var string
      */
-    const GEOCODE_ENDPOINT_URL = 'http://dev.virtualearth.net/REST/v1/Locations/?q=%s&key=%s';
+    const GEOCODE_ENDPOINT_URL = 'http://dev.virtualearth.net/REST/v1/Locations/?maxResults=%d&q=%s&key=%s';
 
     /**
      * @var string
@@ -61,7 +61,7 @@ class BingMapsProvider extends AbstractProvider implements ProviderInterface
             throw new UnsupportedException('The BingMapsProvider does not support IP addresses.');
         }
 
-        $query = sprintf(self::GEOCODE_ENDPOINT_URL, urlencode($address), $this->apiKey);
+        $query = sprintf(self::GEOCODE_ENDPOINT_URL, $this->getMaxResults(), urlencode($address), $this->apiKey);
 
         return $this->executeQuery($query);
     }
@@ -107,43 +107,49 @@ class BingMapsProvider extends AbstractProvider implements ProviderInterface
 
         $json = json_decode($content);
 
-        if (isset($json->resourceSets[0]) && isset($json->resourceSets[0]->resources[0])) {
-            $data = (array) $json->resourceSets[0]->resources[0];
-        } else {
+        if (!isset($json->resourceSets[0]) || !isset($json->resourceSets[0]->resources)) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        $coordinates = (array) $data['geocodePoints'][0]->coordinates;
+        $data = (array) $json->resourceSets[0]->resources;
 
-        $bounds = null;
-        if (isset($data['bbox']) && is_array($data['bbox']) && count($data['bbox']) > 0) {
-            $bounds = array(
-                'south' => $data['bbox'][0],
-                'west'  => $data['bbox'][1],
-                'north' => $data['bbox'][2],
-                'east'  => $data['bbox'][3]
-            );
+        $results = array();
+
+        foreach ($data as $item) {
+            $coordinates = (array) $item->geocodePoints[0]->coordinates;
+
+            $bounds = null;
+            if (isset($item->bbox) && is_array($item->bbox) && count($item->bbox) > 0) {
+                $bounds = array(
+                    'south' => $item->bbox[0],
+                    'west'  => $item->bbox[1],
+                    'north' => $item->bbox[2],
+                    'east'  => $item->bbox[3]
+                );
+            }
+
+            $streetNumber = null;
+            $streetName   = property_exists($item->address, 'addressLine') ? (string) $item->address->addressLine : '';
+            $zipcode      = property_exists($item->address, 'postalCode') ? (string) $item->address->postalCode : '';
+            $city         = property_exists($item->address, 'locality') ? (string) $item->address->locality: '';
+            $county       = property_exists($item->address, 'adminDistrict2') ? (string) $item->address->adminDistrict2 : '';
+            $region       = property_exists($item->address, 'adminDistrict') ? (string) $item->address->adminDistrict: '';
+            $country      = property_exists($item->address, 'countryRegion') ? (string) $item->address->countryRegion: '';
+
+            $results[] = array_merge($this->getDefaults(), array(
+                'latitude'     => $coordinates[0],
+                'longitude'    => $coordinates[1],
+                'bounds'       => $bounds,
+                'streetNumber' => $streetNumber,
+                'streetName'   => $streetName,
+                'city'         => empty($city) ? null : $city,
+                'zipcode'      => empty($zipcode) ? null : $zipcode,
+                'county'       => empty($county) ? null : $county,
+                'region'       => empty($region) ? null : $region,
+                'country'      => empty($country) ? null : $country,
+            ));
         }
 
-        $streetNumber = null;
-        $streetName   = property_exists($data['address'], 'addressLine') ? (string) $data['address']->addressLine : '';
-        $zipcode      = property_exists($data['address'], 'postalCode') ? (string) $data['address']->postalCode : '';
-        $city         = property_exists($data['address'], 'locality') ? (string) $data['address']->locality: '';
-        $county       = property_exists($data['address'], 'adminDistrict2') ? (string) $data['address']->adminDistrict2 : '';
-        $region       = property_exists($data['address'], 'adminDistrict') ? (string) $data['address']->adminDistrict: '';
-        $country      = property_exists($data['address'], 'countryRegion') ? (string) $data['address']->countryRegion: '';
-
-        return array_merge($this->getDefaults(), array(
-            'latitude'     => $coordinates[0],
-            'longitude'    => $coordinates[1],
-            'bounds'       => $bounds,
-            'streetNumber' => $streetNumber,
-            'streetName'   => $streetName,
-            'city'         => empty($city) ? null : $city,
-            'zipcode'      => empty($zipcode) ? null : $zipcode,
-            'county'       => empty($county) ? null : $county,
-            'region'       => empty($region) ? null : $region,
-            'country'      => empty($country) ? null : $country,
-        ));
+        return $results;
     }
 }

--- a/src/Geocoder/Provider/CloudMadeProvider.php
+++ b/src/Geocoder/Provider/CloudMadeProvider.php
@@ -23,12 +23,12 @@ class CloudMadeProvider extends AbstractProvider implements ProviderInterface
     /**
      * @var string
      */
-    const GEOCODE_ENDPOINT_URL = 'http://geocoding.cloudmade.com/%s/geocoding/v2/find.js?query=%s&distance=closest&return_location=true&results=1';
+    const GEOCODE_ENDPOINT_URL = 'http://geocoding.cloudmade.com/%s/geocoding/v2/find.js?query=%s&distance=closest&return_location=true&results=%d';
 
     /**
      * @var string
      */
-    const REVERSE_ENDPOINT_URL = 'http://geocoding.cloudmade.com/%s/geocoding/v2/find.js?around=%F,%F&object_type=address&return_location=true&results=1';
+    const REVERSE_ENDPOINT_URL = 'http://geocoding.cloudmade.com/%s/geocoding/v2/find.js?around=%F,%F&object_type=address&return_location=true&results=%d';
 
     /**
      * @var string
@@ -60,7 +60,7 @@ class CloudMadeProvider extends AbstractProvider implements ProviderInterface
             throw new UnsupportedException('The CloudMadeProvider does not support IP addresses.');
         }
 
-        $query = sprintf(self::GEOCODE_ENDPOINT_URL, $this->apiKey, urlencode($address));
+        $query = sprintf(self::GEOCODE_ENDPOINT_URL, $this->apiKey, urlencode($address), $this->getMaxResults());
 
         return $this->executeQuery($query);
     }
@@ -74,7 +74,7 @@ class CloudMadeProvider extends AbstractProvider implements ProviderInterface
             throw new InvalidCredentialsException('No API Key provided');
         }
 
-        $query = sprintf(self::REVERSE_ENDPOINT_URL, $this->apiKey, $coordinates[0], $coordinates[1]);
+        $query = sprintf(self::REVERSE_ENDPOINT_URL, $this->apiKey, $coordinates[0], $coordinates[1], $this->getMaxResults());
 
         return $this->executeQuery($query);
     }
@@ -104,52 +104,59 @@ class CloudMadeProvider extends AbstractProvider implements ProviderInterface
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        $json = json_decode($content);
-        if (isset($json->found) && $json->found > 0) {
-            $data = (array) $json->features[0];
+        $json = json_decode($content, true);
+
+        if (isset($json['found']) && $json['found'] > 0) {
+            $data = (array) $json['features'];
         } else {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        $coordinates = (array) $data['centroid']->coordinates;
+        $results = array();
 
-        $bounds = null;
-        if (isset($data['bounds']) && is_array($data['bounds']) && count($data['bounds']) > 0) {
-            $bounds = array(
-                'south' => $data['bounds'][0][0],
-                'west'  => $data['bounds'][0][1],
-                'north' => $data['bounds'][1][0],
-                'east'  => $data['bounds'][1][1]
-            );
+        foreach ($data as $item) {
+            $coordinates = (array) $item['centroid']['coordinates'];
+
+            $bounds = null;
+            if (isset($item['bounds']) && is_array($item['bounds']) && count($item['bounds']) > 0) {
+                $bounds = array(
+                    'south' => $item['bounds'][0][0],
+                    'west'  => $item['bounds'][0][1],
+                    'north' => $item['bounds'][1][0],
+                    'east'  => $item['bounds'][1][1]
+                );
+            }
+
+            $properties = (array) $item['properties'];
+
+            $streetNumber = null;
+            if (isset($properties['addr:housenumber'])) {
+                $streetNumber = $properties['addr:housenumber'];
+            }
+
+            $streetName = null;
+            if (isset($properties['addr:street'])) {
+                $streetName = $properties['addr:street'];
+            } elseif (isset($properties['name'])) {
+                $streetName = $properties['name'];
+            } elseif (isset($item['location']['road'])) {
+                $streetName = $item['location']['road'];
+            }
+
+            $results[] = array_merge($this->getDefaults(), array(
+                'latitude'     => $coordinates[0],
+                'longitude'    => $coordinates[1],
+                'bounds'       => $bounds,
+                'streetNumber' => $streetNumber,
+                'streetName'   => $streetName,
+                'city'         => isset($item['location']['city']) ? $item['location']['city'] : null,
+                'zipcode'      => isset($item['location']['zipcode']) ? $item['location']['zipcode'] : null,
+                'region'       => isset($item['location']['county']) ? $item['location']['county'] : null,
+                'county'       => isset($item['location']['county']) ? $item['location']['county'] : null,
+                'country'      => isset($item['location']['country']) ? $item['location']['country'] : null,
+            ));
         }
 
-        $properties = (array) $data['properties'];
-
-        $streetNumber = null;
-        if (isset($properties['addr:housenumber'])) {
-            $streetNumber = $properties['addr:housenumber'];
-        }
-
-        $streetName = null;
-        if (isset($properties['addr:street'])) {
-            $streetName = $properties['addr:street'];
-        } elseif (isset($properties['name'])) {
-            $streetName = $properties['name'];
-        } elseif (isset($data['location']->road)) {
-            $streetName = $data['location']->road;
-        }
-
-        return array_merge($this->getDefaults(), array(
-            'latitude'     => $coordinates[0],
-            'longitude'    => $coordinates[1],
-            'bounds'       => $bounds,
-            'streetNumber' => $streetNumber,
-            'streetName'   => $streetName,
-            'city'         => isset($data['location']->city) ? $data['location']->city : null,
-            'zipcode'      => isset($data['location']->zipcode) ? $data['location']->zipcode : null,
-            'region'       => isset($data['location']->county) ? $data['location']->county : null,
-            'county'       => isset($data['location']->county) ? $data['location']->county : null,
-            'country'      => isset($data['location']->country) ? $data['location']->country : null,
-        ));
+        return $results;
     }
 }

--- a/src/Geocoder/Provider/DataScienceToolkitProvider.php
+++ b/src/Geocoder/Provider/DataScienceToolkitProvider.php
@@ -41,14 +41,10 @@ class DataScienceToolkitProvider extends AbstractProvider implements ProviderInt
             throw new UnsupportedException('The DataScienceToolkitProvider does not support IPv6 addresses.');
         }
 
-        if (!filter_var($address, FILTER_VALIDATE_IP)) {
-            $endpoint = self::ENDPOINT_ADRESS_URL;
-        } else {
-            $endpoint = self::ENDPOINT_IP_URL;
-        }
+        $endpoint = filter_var($address, FILTER_VALIDATE_IP) ? self::ENDPOINT_IP_URL : self::ENDPOINT_ADRESS_URL;
 
         if ('127.0.0.1' === $address) {
-            return $this->getLocalhostDefaults();
+            return array($this->getLocalhostDefaults());
         }
 
         $query = sprintf($endpoint, urlencode($address));
@@ -88,7 +84,7 @@ class DataScienceToolkitProvider extends AbstractProvider implements ProviderInt
 
         $result = array_shift($result);
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'latitude'     => isset($result['latitude']) ? $result['latitude'] : null,
             'longitude'    => isset($result['longitude']) ? $result['longitude'] : null,
             'city'         => isset($result['locality']) ? $result['locality'] : null,
@@ -97,6 +93,6 @@ class DataScienceToolkitProvider extends AbstractProvider implements ProviderInt
             'zipcode'	   => isset($result['postal_code']) ? $result['postal_code'] : null,
             'streetName'   => isset($result['street_name']) ? $result['street_name'] : null,
             'streetNumber' => isset($result['street_number']) ? $result['street_number'] : null,
-        ));
+        )));
     }
 }

--- a/src/Geocoder/Provider/FreeGeoIpProvider.php
+++ b/src/Geocoder/Provider/FreeGeoIpProvider.php
@@ -33,7 +33,7 @@ class FreeGeoIpProvider extends AbstractProvider implements ProviderInterface
         }
 
         if (in_array($address, array('127.0.0.1', '::1'))) {
-            return $this->getLocalhostDefaults();
+            return array($this->getLocalhostDefaults());
         }
 
         $query = sprintf(self::ENDPOINT_URL, $address);
@@ -79,15 +79,10 @@ class FreeGeoIpProvider extends AbstractProvider implements ProviderInterface
         //it appears that for US states the region code is not returning the FIPS standard
         if ('US' === $data['country_code'] && isset($data['region_code']) && !is_numeric($data['region_code'])) {
             $newRegionCode = $this->stateToRegionCode($data['region_code']);
-
-            if (is_numeric($newRegionCode)) {
-                $data['region_code'] = $newRegionCode;
-            } else {
-                $data['region_code'] = null;
-            }
+            $data['region_code'] = is_numeric($newRegionCode) ? $newRegionCode : null;
         }
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'latitude'    => isset($data['latitude']) ? $data['latitude'] : null,
             'longitude'   => isset($data['longitude']) ? $data['longitude'] : null,
             'city'        => isset($data['city']) ? $data['city'] : null,
@@ -96,7 +91,7 @@ class FreeGeoIpProvider extends AbstractProvider implements ProviderInterface
             'regionCode'  => isset($data['region_code']) ? $data['region_code'] : null,
             'country'     => isset($data['country_name']) ? $data['country_name'] : null,
             'countryCode' => isset($data['country_code']) ? $data['country_code'] : null,
-        ));
+        )));
     }
 
     /**

--- a/src/Geocoder/Provider/GeoIPsProvider.php
+++ b/src/Geocoder/Provider/GeoIPsProvider.php
@@ -60,7 +60,7 @@ class GeoIPsProvider extends AbstractProvider implements ProviderInterface
         }
 
         if ('127.0.0.1' === $address) {
-            return $this->getLocalhostDefaults();
+            return array($this->getLocalhostDefaults());
         }
 
         $query = sprintf(self::GEOCODE_ENDPOINT_URL, $address, $this->apiKey);
@@ -98,11 +98,8 @@ class GeoIPsProvider extends AbstractProvider implements ProviderInterface
         }
 
         $json = json_decode($content, true);
-        if (array_key_exists('response', $json)) {
-            $response = $json['response'];
-        } else {
-            $response = $json;
-        }
+
+        $response = array_key_exists('response', $json) ? $json['response'] : $json;
 
         if (!is_array($response) || !count($response)) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
@@ -120,7 +117,7 @@ class GeoIPsProvider extends AbstractProvider implements ProviderInterface
             throw new InvalidCredentialsException('API Key provided is not valid.');
         }
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'country'     => '' === $response['country_name'] ? null : $response['country_name'],
             'countryCode' => '' === $response['country_code'] ? null : $response['country_code'],
             'region'      => '' === $response['region_name']  ? null : $response['region_name'],
@@ -130,6 +127,6 @@ class GeoIPsProvider extends AbstractProvider implements ProviderInterface
             'latitude'    => '' === $response['latitude']     ? null : $response['latitude'],
             'longitude'   => '' === $response['longitude']    ? null : $response['longitude'],
             'timezone'    => '' === $response['timezone']     ? null : $response['timezone'],
-        ));
+        )));
     }
 }

--- a/src/Geocoder/Provider/GeoPluginProvider.php
+++ b/src/Geocoder/Provider/GeoPluginProvider.php
@@ -33,7 +33,7 @@ class GeoPluginProvider extends AbstractProvider implements ProviderInterface
         }
 
         if (in_array($address, array('127.0.0.1', '::1'))) {
-            return $this->getLocalhostDefaults();
+            return array($this->getLocalhostDefaults());
         }
 
         $query = sprintf(self::GEOCODE_ENDPOINT_URL, $address);
@@ -82,7 +82,7 @@ class GeoPluginProvider extends AbstractProvider implements ProviderInterface
 
         $data = array_filter($json);
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'city'        => isset($data['geoplugin_city']) ? $data['geoplugin_city'] : null,
             'country'     => isset($data['geoplugin_countryName']) ? $data['geoplugin_countryName'] : null,
             'countryCode' => isset($data['geoplugin_countryCode']) ? $data['geoplugin_countryCode'] : null,
@@ -90,6 +90,6 @@ class GeoPluginProvider extends AbstractProvider implements ProviderInterface
             'regionCode'  => isset($data['geoplugin_regionCode']) ? $data['geoplugin_regionCode'] : null,
             'latitude'    => isset($data['geoplugin_latitude']) ? $data['geoplugin_latitude'] : null,
             'longitude'   => isset($data['geoplugin_longitude']) ? $data['geoplugin_longitude'] : null,
-        ));
+        )));
     }
 }

--- a/src/Geocoder/Provider/GeocoderCaProvider.php
+++ b/src/Geocoder/Provider/GeocoderCaProvider.php
@@ -46,10 +46,10 @@ class GeocoderCaProvider extends AbstractProvider implements ProviderInterface
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'latitude'  => $this->getNodeValue($doc->getElementsByTagName('latt')),
             'longitude' => $this->getNodeValue($doc->getElementsByTagName('longt'))
-        ));
+        )));
     }
 
     /**
@@ -65,7 +65,7 @@ class GeocoderCaProvider extends AbstractProvider implements ProviderInterface
             throw new NoResultException(sprintf('Could not resolve coordinates %s', implode(', ', $coordinates)));
         }
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'latitude'     => $this->getNodeValue($doc->getElementsByTagName('latt')),
             'longitude'    => $this->getNodeValue($doc->getElementsByTagName('longt')),
             'streetNumber' => $this->getNodeValue($doc->getElementsByTagName('stnumber')),
@@ -73,7 +73,7 @@ class GeocoderCaProvider extends AbstractProvider implements ProviderInterface
             'city'         => $this->getNodeValue($doc->getElementsByTagName('city')),
             'zipcode'      => $this->getNodeValue($doc->getElementsByTagName('postal')),
             'cityDistrict' => $this->getNodeValue($doc->getElementsByTagName('prov')),
-        ));
+        )));
     }
 
     /**
@@ -84,7 +84,12 @@ class GeocoderCaProvider extends AbstractProvider implements ProviderInterface
         return 'geocoder_ca';
     }
 
-    private function getNodeValue($element)
+    /**
+     * @param \DOMNodeList
+     *
+     * @return string
+     */
+    private function getNodeValue(\DOMNodeList $element)
     {
         return $element->length ? $element->item(0)->nodeValue : null;
     }

--- a/src/Geocoder/Provider/GeocoderUsProvider.php
+++ b/src/Geocoder/Provider/GeocoderUsProvider.php
@@ -73,9 +73,9 @@ class GeocoderUsProvider extends AbstractProvider implements ProviderInterface
         $lat  = $xpath->xpath('//geo:lat');
         $long = $xpath->xpath('//geo:long');
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'latitude'  => isset($lat[0]) ? (double) $lat[0] : null,
             'longitude' => isset($long[0]) ? (double) $long[0] : null,
-        ));
+        )));
     }
 }

--- a/src/Geocoder/Provider/GeoipProvider.php
+++ b/src/Geocoder/Provider/GeoipProvider.php
@@ -46,7 +46,7 @@ class GeoipProvider extends AbstractProvider implements ProviderInterface
         }
 
         if ('127.0.0.1' === $address) {
-            return $this->getLocalhostDefaults();
+            return array($this->getLocalhostDefaults());
         }
 
         $results = @geoip_record_by_name($address);
@@ -70,11 +70,9 @@ class GeoipProvider extends AbstractProvider implements ProviderInterface
             'timezone'    => $timezone,
         ));
 
-        $results = array_map(function($value) {
+        return array(array_map(function($value) {
             return is_string($value) ? utf8_encode($value) : $value;
-        }, $results);
-
-        return $results;
+        }, $results));
     }
 
     /**

--- a/src/Geocoder/Provider/GeonamesProvider.php
+++ b/src/Geocoder/Provider/GeonamesProvider.php
@@ -23,12 +23,12 @@ class GeonamesProvider extends AbstractProvider implements ProviderInterface
     /**
      * @var string
      */
-    const GEOCODE_ENDPOINT_URL = 'http://api.geonames.org/searchJSON?q=%s&maxRows=1&style=full&username=%s';
+    const GEOCODE_ENDPOINT_URL = 'http://api.geonames.org/searchJSON?q=%s&maxRows=%d&style=full&username=%s';
 
     /**
      * @var string
      */
-    const REVERSE_ENDPOINT_URL = 'http://api.geonames.org/findNearbyPlaceNameJSON?lat=%F&lng=%F&style=full&maxRows=1&username=%s';
+    const REVERSE_ENDPOINT_URL = 'http://api.geonames.org/findNearbyPlaceNameJSON?lat=%F&lng=%F&style=full&maxRows=%d&username=%s';
 
     /**
      * @var string
@@ -60,7 +60,7 @@ class GeonamesProvider extends AbstractProvider implements ProviderInterface
             throw new UnsupportedException('The GeonamesProvider does not support IP addresses.');
         }
 
-        $query = sprintf(self::GEOCODE_ENDPOINT_URL, urlencode($address), $this->username);
+        $query = sprintf(self::GEOCODE_ENDPOINT_URL, urlencode($address), $this->getMaxResults(), $this->username);
 
         return $this->executeQuery($query);
     }
@@ -74,7 +74,7 @@ class GeonamesProvider extends AbstractProvider implements ProviderInterface
             throw new InvalidCredentialsException('No Username provided');
         }
 
-        $query = sprintf(self::REVERSE_ENDPOINT_URL, $coordinates[0], $coordinates[1], $this->username);
+        $query = sprintf(self::REVERSE_ENDPOINT_URL, $coordinates[0], $coordinates[1], $this->getMaxResults(), $this->username);
 
         return $this->executeQuery($query);
     }
@@ -105,38 +105,46 @@ class GeonamesProvider extends AbstractProvider implements ProviderInterface
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        $json = json_decode($content);
-
-        if (isset($json->totalResultsCount) && ($json->totalResultsCount === 0)) {
-            throw new NoResultException(sprintf('No places found for query %s', $query));
-        }
-
-        if (isset($json->geonames) && !(empty($json->geonames))) {
-            $data = (array) $json->geonames[0];
-        } else {
+        if (null === $json = json_decode($content)) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        $bounds = null;
-        if (isset($data['bbox'])) {
-            $bounds = array(
-                'south' => $data['bbox']->south,
-                'west'  => $data['bbox']->west,
-                'north' => $data['bbox']->north,
-                'east'  => $data['bbox']->east
-            );
+        if (isset($json->totalResultsCount) && empty($json->totalResultsCount)) {
+            throw new NoResultException(sprintf('No places found for query %s', $query));
         }
 
-        return array_merge($this->getDefaults(), array(
-            'latitude'      => isset($data['lat']) ? $data['lat'] : null,
-            'longitude'     => isset($data['lng']) ? $data['lng'] : null,
-            'bounds'        => $bounds,
-            'city'          => isset($data['name']) ? $data['name'] : null,
-            'county'        => isset($data['adminName2']) ? $data['adminName2'] : null,
-            'region'        => isset($data['adminName1']) ? $data['adminName1'] : null,
-            'country'       => isset($data['countryName']) ? $data['countryName'] : null,
-            'countryCode'   => isset($data['countryCode']) ? $data['countryCode'] : null,
-            'timezone'      => isset($data['timezone']->timeZoneId)  ? $data['timezone']->timeZoneId : null,
-        ));
+        $data = $json->geonames;
+
+        if (empty($data)) {
+            throw new NoResultException(sprintf('Could not execute query %s', $query));
+        }
+
+        $results = array();
+
+        foreach ($data as $item) {
+            $bounds = null;
+            if (isset($item->bbox)) {
+                $bounds = array(
+                    'south' => $item->bbox->south,
+                    'west'  => $item->bbox->west,
+                    'north' => $item->bbox->north,
+                    'east'  => $item->bbox->east
+                );
+            }
+
+            $results[] = array_merge($this->getDefaults(), array(
+                'latitude'    => isset($item->lat) ? $item->lat : null,
+                'longitude'   => isset($item->lng) ? $item->lng : null,
+                'bounds'      => $bounds,
+                'city'        => isset($item->name) ? $item->name : null,
+                'county'      => isset($item->adminName2) ? $item->adminName2 : null,
+                'region'      => isset($item->adminName1) ? $item->adminName1 : null,
+                'country'     => isset($item->countryName) ? $item->countryName : null,
+                'countryCode' => isset($item->countryCode) ? $item->countryCode : null,
+                'timezone'    => isset($item->timezone->timeZoneId)  ? $item->timezone->timeZoneId : null,
+            ));
+        }
+
+        return $results;
     }
 }

--- a/src/Geocoder/Provider/GoogleMapsProvider.php
+++ b/src/Geocoder/Provider/GoogleMapsProvider.php
@@ -139,40 +139,45 @@ class GoogleMapsProvider extends AbstractProvider implements ProviderInterface
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        $result = $json->results[0];
-        $resultset = $this->getDefaults();
+        $results = array();
 
-        // update address components
-        foreach ($result->address_components as $component) {
-            foreach ($component->types as $type) {
-                $this->updateAddressComponent($resultset, $type, $component);
+        foreach ($json->results as $result) {
+            $resultset = $this->getDefaults();
+
+            // update address components
+            foreach ($result->address_components as $component) {
+                foreach ($component->types as $type) {
+                    $this->updateAddressComponent($resultset, $type, $component);
+                }
             }
+
+            // update coordinates
+            $coordinates = $result->geometry->location;
+            $resultset['latitude']  = $coordinates->lat;
+            $resultset['longitude'] = $coordinates->lng;
+
+            $resultset['bounds'] = null;
+            if (isset($result->geometry->bounds)) {
+                $resultset['bounds'] = array(
+                    'south' => $result->geometry->bounds->southwest->lat,
+                    'west'  => $result->geometry->bounds->southwest->lng,
+                    'north' => $result->geometry->bounds->northeast->lat,
+                    'east'  => $result->geometry->bounds->northeast->lng
+                );
+            } elseif ('ROOFTOP' === $result->geometry->location_type) {
+                // Fake bounds
+                $resultset['bounds'] = array(
+                    'south' => $coordinates->lat,
+                    'west'  => $coordinates->lng,
+                    'north' => $coordinates->lat,
+                    'east'  => $coordinates->lng
+                );
+            }
+
+            $results[] = array_merge($this->getDefaults(), $resultset);
         }
 
-        // update coordinates
-        $coordinates = $result->geometry->location;
-        $resultset['latitude']  = $coordinates->lat;
-        $resultset['longitude'] = $coordinates->lng;
-
-        $resultset['bounds'] = null;
-        if (isset($result->geometry->bounds)) {
-            $resultset['bounds'] = array(
-                'south' => $result->geometry->bounds->southwest->lat,
-                'west'  => $result->geometry->bounds->southwest->lng,
-                'north' => $result->geometry->bounds->northeast->lat,
-                'east'  => $result->geometry->bounds->northeast->lng
-            );
-        } elseif ('ROOFTOP' === $result->geometry->location_type) {
-            // Fake bounds
-            $resultset['bounds'] = array(
-                'south' => $coordinates->lat,
-                'west'  => $coordinates->lng,
-                'north' => $coordinates->lat,
-                'east'  => $coordinates->lng
-            );
-        }
-
-        return array_merge($this->getDefaults(), $resultset);
+        return $results;
     }
 
     /**

--- a/src/Geocoder/Provider/IpGeoBaseProvider.php
+++ b/src/Geocoder/Provider/IpGeoBaseProvider.php
@@ -38,7 +38,7 @@ class IpGeoBaseProvider extends AbstractProvider implements ProviderInterface
         }
 
         if ('127.0.0.1' === $address) {
-            return $this->getLocalhostDefaults();
+            return array($this->getLocalhostDefaults());
         }
 
         $query = sprintf(self::ENDPOINT_URL, $address);
@@ -53,14 +53,14 @@ class IpGeoBaseProvider extends AbstractProvider implements ProviderInterface
 
         $result = $xml->ip;
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'latitude'     => (double) $result->lat,
             'longitude'    => (double) $result->lng,
             'city'         => (string) $result->city,
             'cityDistrict' => (string) $result->district,
             'region'       => (string) $result->region,
             'countryCode'  => (string) $result->country,
-        ));
+        )));
     }
 
     /**

--- a/src/Geocoder/Provider/IpInfoDbProvider.php
+++ b/src/Geocoder/Provider/IpInfoDbProvider.php
@@ -60,7 +60,7 @@ class IpInfoDbProvider extends AbstractProvider implements ProviderInterface
         }
 
         if ('127.0.0.1' === $address) {
-            return $this->getLocalhostDefaults();
+            return array($this->getLocalhostDefaults());
         }
 
         $query = sprintf(self::ENDPOINT_URL, $this->apiKey, $address);
@@ -108,7 +108,7 @@ class IpInfoDbProvider extends AbstractProvider implements ProviderInterface
             $timezone = timezone_name_from_abbr("", (int) substr($data['timeZone'], 0, strpos($data['timeZone'], ':')) * 3600, 0);
         }
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'latitude'    => isset($data['latitude']) ? $data['latitude'] : null,
             'longitude'   => isset($data['longitude']) ? $data['longitude'] : null,
             'city'        => isset($data['cityName']) ? $data['cityName'] : null,
@@ -117,6 +117,6 @@ class IpInfoDbProvider extends AbstractProvider implements ProviderInterface
             'country'     => isset($data['countryName']) ? $data['countryName'] : null,
             'countryCode' => isset($data['countryName']) ? $data['countryCode'] : null,
             'timezone'    => $timezone,
-        ));
+        )));
     }
 }

--- a/src/Geocoder/Provider/MapQuestProvider.php
+++ b/src/Geocoder/Provider/MapQuestProvider.php
@@ -21,7 +21,7 @@ class MapQuestProvider extends AbstractProvider implements ProviderInterface
     /**
      * @var string
      */
-    const GEOCODE_ENDPOINT_URL = 'http://open.mapquestapi.com/geocoding/v1/address?location=%s&outFormat=json&maxResults=1&thumbMaps=false';
+    const GEOCODE_ENDPOINT_URL = 'http://open.mapquestapi.com/geocoding/v1/address?location=%s&outFormat=json&maxResults=%d&thumbMaps=false';
 
     /**
      * @var string
@@ -38,7 +38,7 @@ class MapQuestProvider extends AbstractProvider implements ProviderInterface
             throw new UnsupportedException('The MapQuestProvider does not support IP addresses.');
         }
 
-        $query = sprintf(self::GEOCODE_ENDPOINT_URL, urlencode($address));
+        $query = sprintf(self::GEOCODE_ENDPOINT_URL, urlencode($address), $this->getMaxResults());
 
         return $this->executeQuery($query);
     }
@@ -76,27 +76,31 @@ class MapQuestProvider extends AbstractProvider implements ProviderInterface
 
         $json = json_decode($content, true);
 
-        if (isset($json['results']) && !empty($json['results'])) {
-            $result = current($json['results']);
-
-            if (isset($result['locations']) && !empty($result['locations'])) {
-                $location = current($result['locations']);
-
-                // TODO: maybe add more information using the link below:
-                // http://open.mapquestapi.com/geocoding/
-                return array_merge($this->getDefaults(), array(
-                    'latitude'      => $location['latLng']['lat'],
-                    'longitude'     => $location['latLng']['lng'],
-                    'streetName'    => $location['street'] ?: null,
-                    'city'          => $location['adminArea5'] ?: null,
-                    'zipcode'       => $location['postalCode'] ?: null,
-                    'county'        => $location['adminArea4'] ?: null,
-                    'region'        => $location['adminArea3'] ?: null,
-                    'country'       => $location['adminArea1'] ?: null,
-                ));
-            }
+        if (!isset($json['results']) || empty($json['results'])) {
+            throw new NoResultException(sprintf('Could not find results for given query: %s', $query));
         }
 
-        throw new NoResultException(sprintf('Could not find results for given query: %s', $query));
+        $locations = $json['results'][0]['locations'];
+
+        if (empty($locations)) {
+            throw new NoResultException(sprintf('Could not find results for given query: %s', $query));
+        }
+
+        $results = array();
+
+        foreach ($locations as $location) {
+            $results[] = array_merge($this->getDefaults(), array(
+                'latitude'      => $location['latLng']['lat'],
+                'longitude'     => $location['latLng']['lng'],
+                'streetName'    => $location['street'] ?: null,
+                'city'          => $location['adminArea5'] ?: null,
+                'zipcode'       => $location['postalCode'] ?: null,
+                'county'        => $location['adminArea4'] ?: null,
+                'region'        => $location['adminArea3'] ?: null,
+                'country'       => $location['adminArea1'] ?: null,
+            ));
+        }
+
+        return $results;
     }
 }

--- a/src/Geocoder/Provider/MaxMindBinaryProvider.php
+++ b/src/Geocoder/Provider/MaxMindBinaryProvider.php
@@ -32,8 +32,8 @@ class MaxMindBinaryProvider extends AbstractProvider implements ProviderInterfac
      * @param string   $datFile
      * @param int|null $openFlag
      *
-     * @throws RuntimeException         if maxmind's lib not installed.
-     * @throws InvalidArgumentException if dat file is not correct.
+     * @throws RuntimeException         If maxmind's lib not installed.
+     * @throws InvalidArgumentException If dat file is not correct (optional).
      */
     public function __construct($datFile, $openFlag = null)
     {
@@ -75,14 +75,14 @@ class MaxMindBinaryProvider extends AbstractProvider implements ProviderInterfac
             throw new NoResultException(sprintf('No results found for IP address %s', $address));
         }
 
-        return array_merge($this->getDefaults(), array(
+        return array(array_merge($this->getDefaults(), array(
             'countryCode' => $geoIpRecord->country_code,
             'country'     => $geoIpRecord->country_name,
             'region'      => $geoIpRecord->region,
             'city'        => $geoIpRecord->city,
             'latitude'    => $geoIpRecord->latitude,
             'longitude'   => $geoIpRecord->longitude,
-        ));
+        )));
     }
 
     /**

--- a/src/Geocoder/Provider/MaxMindProvider.php
+++ b/src/Geocoder/Provider/MaxMindProvider.php
@@ -58,7 +58,7 @@ class MaxMindProvider extends AbstractProvider implements ProviderInterface
     /**
      * @param HttpAdapterInterface $adapter An HTTP adapter.
      * @param string               $apiKey  An API key.
-     * @param string               $service The specific Maxmind service to use.
+     * @param string               $service The specific Maxmind service to use (optional).
      * @param bool                 $useSsl  Whether to use an SSL connection (optional).
      */
     public function __construct(HttpAdapterInterface $adapter, $apiKey, $service = self::CITY_EXTENDED_SERVICE,
@@ -85,7 +85,7 @@ class MaxMindProvider extends AbstractProvider implements ProviderInterface
         }
 
         if (in_array($address, array('127.0.0.1', '::1'))) {
-            return $this->getLocalhostDefaults();
+            return array($this->getLocalhostDefaults());
         }
 
         $query = sprintf(
@@ -139,7 +139,7 @@ class MaxMindProvider extends AbstractProvider implements ProviderInterface
             $data['country'] = $this->countryCodeToCountryName($data['countryCode']);
         }
 
-        return array_merge($this->getDefaults(), $data);
+        return array(array_merge($this->getDefaults(), $data));
     }
 
     /**

--- a/src/Geocoder/Provider/OpenStreetMapsProvider.php
+++ b/src/Geocoder/Provider/OpenStreetMapsProvider.php
@@ -21,7 +21,7 @@ class OpenStreetMapsProvider extends AbstractProvider implements ProviderInterfa
     /**
      * @var string
      */
-    const GEOCODE_ENDPOINT_URL = 'http://nominatim.openstreetmap.org/search?q=%s&format=xml&addressdetails=1&limit=1';
+    const GEOCODE_ENDPOINT_URL = 'http://nominatim.openstreetmap.org/search?q=%s&format=xml&addressdetails=1&limit=%d';
 
     /**
      * @var string
@@ -39,10 +39,10 @@ class OpenStreetMapsProvider extends AbstractProvider implements ProviderInterfa
         }
 
         if ('127.0.0.1' === $address) {
-            return $this->getLocalhostDefaults();
+            return array($this->getLocalhostDefaults());
         }
 
-        $query   = sprintf(self::GEOCODE_ENDPOINT_URL, urlencode($address));
+        $query   = sprintf(self::GEOCODE_ENDPOINT_URL, urlencode($address), $this->getMaxResults());
         $content = $this->executeQuery($query);
 
         if (null === $content) {
@@ -55,31 +55,37 @@ class OpenStreetMapsProvider extends AbstractProvider implements ProviderInterfa
         }
 
         $searchResult = $doc->getElementsByTagName('searchresults')->item(0);
-        $place        = $searchResult->getElementsByTagName('place')->item(0);
+        $places = $searchResult->getElementsByTagName('place');
 
-        if (null === $place) {
+        if (null === $places || 0 === $places->length) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        $boundsAttr = $place->getAttribute('boundingbox');
-        list($bounds['south'], $bounds['north'], $bounds['west'], $bounds['east']) = $boundsAttr ? explode(',', $boundsAttr) : null;
+        $results = array();
 
-        $ret = $this->getDefaults();
+        foreach ($places as $place) {
+            $boundsAttr = $place->getAttribute('boundingbox');
+            list($bounds['south'], $bounds['north'], $bounds['west'], $bounds['east']) = $boundsAttr
+                ? explode(',', $boundsAttr)
+                : null;
 
-        $ret['latitude']     = $place->getAttribute('lat');
-        $ret['longitude']    = $place->getAttribute('lon');
-        $ret['bounds']       = $bounds;
-        $ret['zipcode']      = $this->getNodeValue($place->getElementsByTagName('postcode'));
-        $ret['county']       = $this->getNodeValue($place->getElementsByTagName('county'));
-        $ret['region']       = $this->getNodeValue($place->getElementsByTagName('state'));
-        $ret['streetNumber'] = $this->getNodeValue($place->getElementsByTagName('house_number'));
-        $ret['streetName']   = $this->getNodeValue($place->getElementsByTagName('road'));
-        $ret['city']         = $this->getNodeValue($place->getElementsByTagName('city'));
-        $ret['cityDistrict'] = $this->getNodeValue($place->getElementsByTagName('suburb'));
-        $ret['country']      = $this->getNodeValue($place->getElementsByTagName('country'));
-        $ret['countryCode']  = strtoupper($this->getNodeValue($place->getElementsByTagName('country_code')));
+            $results[] = array_merge($this->getDefaults(), array(
+                'latitude'     => $place->getAttribute('lat'),
+                'longitude'    => $place->getAttribute('lon'),
+                'bounds'       => $bounds,
+                'zipcode'      => $this->getNodeValue($place->getElementsByTagName('postcode')),
+                'county'       => $this->getNodeValue($place->getElementsByTagName('county')),
+                'region'       => $this->getNodeValue($place->getElementsByTagName('state')),
+                'streetNumber' => $this->getNodeValue($place->getElementsByTagName('house_number')),
+                'streetName'   => $this->getNodeValue($place->getElementsByTagName('road')),
+                'city'         => $this->getNodeValue($place->getElementsByTagName('city')),
+                'cityDistrict' => $this->getNodeValue($place->getElementsByTagName('suburb')),
+                'country'      => $this->getNodeValue($place->getElementsByTagName('country')),
+                'countryCode'  => strtoupper($this->getNodeValue($place->getElementsByTagName('country_code'))),
+            ));
+        }
 
-        return array_merge($this->getDefaults(), $ret);
+        return $results;
     }
 
     /**
@@ -102,21 +108,20 @@ class OpenStreetMapsProvider extends AbstractProvider implements ProviderInterfa
         $searchResult = $doc->getElementsByTagName('reversegeocode')->item(0);
         $addressParts = $searchResult->getElementsByTagName('addressparts')->item(0);
         $result       = $searchResult->getElementsByTagName('result')->item(0);
-        $ret          = $this->getDefaults();
 
-        $ret['latitude']     = $result->getAttribute('lat');
-        $ret['longitude']    = $result->getAttribute('lon');
-        $ret['zipcode']      = $this->getNodeValue($addressParts->getElementsByTagName('postcode'));
-        $ret['county']       = $this->getNodeValue($addressParts->getElementsByTagName('county'));
-        $ret['region']       = $this->getNodeValue($addressParts->getElementsByTagName('state'));
-        $ret['streetNumber'] = $this->getNodeValue($addressParts->getElementsByTagName('house_number'));
-        $ret['streetName']   = $this->getNodeValue($addressParts->getElementsByTagName('road'));
-        $ret['city']         = $this->getNodeValue($addressParts->getElementsByTagName('city'));
-        $ret['cityDistrict'] = $this->getNodeValue($addressParts->getElementsByTagName('suburb'));
-        $ret['country']      = $this->getNodeValue($addressParts->getElementsByTagName('country'));
-        $ret['countryCode']  = strtoupper($this->getNodeValue($addressParts->getElementsByTagName('country_code')));
-
-        return array_merge($this->getDefaults(), $ret);
+        return array(array_merge($this->getDefaults(), array(
+            'latitude'     => $result->getAttribute('lat'),
+            'longitude'    => $result->getAttribute('lon'),
+            'zipcode'      => $this->getNodeValue($addressParts->getElementsByTagName('postcode')),
+            'county'       => $this->getNodeValue($addressParts->getElementsByTagName('county')),
+            'region'       => $this->getNodeValue($addressParts->getElementsByTagName('state')),
+            'streetNumber' => $this->getNodeValue($addressParts->getElementsByTagName('house_number')),
+            'streetName'   => $this->getNodeValue($addressParts->getElementsByTagName('road')),
+            'city'         => $this->getNodeValue($addressParts->getElementsByTagName('city')),
+            'cityDistrict' => $this->getNodeValue($addressParts->getElementsByTagName('suburb')),
+            'country'      => $this->getNodeValue($addressParts->getElementsByTagName('country')),
+            'countryCode'  => strtoupper($this->getNodeValue($addressParts->getElementsByTagName('country_code'))),
+        )));
     }
 
     /**
@@ -141,7 +146,12 @@ class OpenStreetMapsProvider extends AbstractProvider implements ProviderInterfa
         return $this->getAdapter()->getContent($query);
     }
 
-    private function getNodeValue($element)
+    /**
+     * @param \DOMNodeList
+     *
+     * @return string
+     */
+    private function getNodeValue(\DOMNodeList $element)
     {
         return $element->length ? $element->item(0)->nodeValue : null;
     }

--- a/src/Geocoder/Provider/TomTomProvider.php
+++ b/src/Geocoder/Provider/TomTomProvider.php
@@ -23,7 +23,7 @@ class TomTomProvider extends AbstractProvider implements ProviderInterface
     /**
      * @var string
      */
-    const GEOCODE_ENDPOINT_URL = 'https://api.tomtom.com/lbs/geocoding/geocode?key=%s&maxResults=1&query=%s';
+    const GEOCODE_ENDPOINT_URL = 'https://api.tomtom.com/lbs/geocoding/geocode?key=%s&query=%s&maxResults=%d';
 
     /**
      * @var string
@@ -61,7 +61,7 @@ class TomTomProvider extends AbstractProvider implements ProviderInterface
             throw new UnsupportedException('The TomTomProvider does not support IP addresses.');
         }
 
-        $query = sprintf(self::GEOCODE_ENDPOINT_URL, $this->apiKey, rawurlencode($address));
+        $query = sprintf(self::GEOCODE_ENDPOINT_URL, $this->apiKey, rawurlencode($address), $this->getMaxResults());
 
         return $this->executeQuery($query);
     }
@@ -123,16 +123,37 @@ class TomTomProvider extends AbstractProvider implements ProviderInterface
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        $result = isset($xml->geoResult) ? $xml->geoResult : $xml->reverseGeoResult;
+        $data = isset($xml->geoResult) ? $xml->geoResult : $xml->reverseGeoResult;
 
+
+        if (0 === count($data)) {
+            return array($this->getResultArray($data));
+        }
+
+        $results = array();
+
+        foreach ($data as $item) {
+            $results[] = $this->getResultArray($item);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param \SimpleXmlElement $data
+     *
+     * @return array
+     */
+    protected function getResultArray(\SimpleXmlElement $data)
+    {
         return array_merge($this->getDefaults(), array(
-            'latitude'    => isset($result->latitude) ? (double) $result->latitude : null,
-            'longitude'   => isset($result->longitude) ? (double) $result->longitude : null,
-            'streetName'  => isset($result->street) ? (string) $result->street : null,
-            'city'        => isset($result->city) ? (string) $result->city : null,
-            'region'      => isset($result->state) ? (string) $result->state : null,
-            'country'     => isset($result->country) ? (string) $result->country : null,
-            'countryCode' => isset($result->countryISO3) ? (string) $result->countryISO3 : null,
+            'latitude'    => isset($data->latitude) ? (double) $data->latitude : null,
+            'longitude'   => isset($data->longitude) ? (double) $data->longitude : null,
+            'streetName'  => isset($data->street) ? (string) $data->street : null,
+            'city'        => isset($data->city) ? (string) $data->city : null,
+            'region'      => isset($data->state) ? (string) $data->state : null,
+            'country'     => isset($data->country) ? (string) $data->country : null,
+            'countryCode' => isset($data->countryISO3) ? (string) $data->countryISO3 : null,
         ));
     }
 }

--- a/src/Geocoder/Provider/YandexProvider.php
+++ b/src/Geocoder/Provider/YandexProvider.php
@@ -22,12 +22,12 @@ class YandexProvider extends AbstractProvider implements ProviderInterface
     /**
      * @var string
      */
-    const GEOCODE_ENDPOINT_URL = 'http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=%s';
+    const GEOCODE_ENDPOINT_URL = 'http://geocode-maps.yandex.ru/1.x/?format=json&geocode=%s';
 
     /**
      * @var string
      */
-    const REVERSE_ENDPOINT_URL = 'http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=%F,%F';
+    const REVERSE_ENDPOINT_URL = 'http://geocode-maps.yandex.ru/1.x/?format=json&geocode=%F,%F';
 
     /**
      * @var string
@@ -94,38 +94,47 @@ class YandexProvider extends AbstractProvider implements ProviderInterface
             $query = sprintf('%s&lang=%s', $query, str_replace('_', '-', $this->getLocale()));
         }
 
-        $content = $this->getAdapter()->getContent($query);
-        $result  = (array) json_decode($content, true);
+        $query = sprintf('%s&results=%d', $query, $this->getMaxResults());
 
-        if (empty($result) || '0' === $result['response']['GeoObjectCollection']['metaDataProperty']['GeocoderResponseMetaData']['found']) {
+        $content = $this->getAdapter()->getContent($query);
+        $json    = (array) json_decode($content, true);
+
+        if (empty($json) || '0' === $json['response']['GeoObjectCollection']['metaDataProperty']['GeocoderResponseMetaData']['found']) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        $result = $result['response']['GeoObjectCollection']['featureMember'][0]['GeoObject'];
+        $data = $json['response']['GeoObjectCollection']['featureMember'];
 
-        $country        = $result['metaDataProperty']['GeocoderMetaData']['AddressDetails']['Country'];
-        $addressDetails = isset($country['AdministrativeArea']) ? $country['AdministrativeArea'] : $country;
-        $locality       = isset($addressDetails['Locality']['Thoroughfare']) ? $addressDetails['Locality']['Thoroughfare'] : null;
-        $coordinates    = explode(' ', $result['Point']['pos']);
-        $bounds         = null;
-        $lowerCorner    = explode(' ', $result['boundedBy']['Envelope']['lowerCorner']);
-        $upperCorner    = explode(' ', $result['boundedBy']['Envelope']['upperCorner']);
-        $bounds         = array(
-            'south' => isset($lowerCorner[1]) ? $lowerCorner[1] : null,
-            'west'  => isset($lowerCorner[0]) ? $lowerCorner[0] : null,
-            'north' => isset($upperCorner[1]) ? $upperCorner[1] : null,
-            'east'  => isset($upperCorner[0]) ? $upperCorner[0] : null
-        );
+        $results = array();
 
-        return array_merge($this->getDefaults(), array(
-            'latitude'      => isset($coordinates[1]) ? $coordinates[1] : null,
-            'longitude'     => isset($coordinates[0]) ? $coordinates[0] : null,
-            'bounds'        => $bounds,
-            'streetNumber'  => isset($locality['Premise']['PremiseNumber']) ? $locality['Premise']['PremiseNumber'] : null,
-            'streetName'    => isset($locality['ThoroughfareName']) ? $locality['ThoroughfareName'] : null,
-            'cityDistrict'  => isset($addressDetails['AdministrativeAreaName']) ? $addressDetails['AdministrativeAreaName'] : null,
-            'country'       => isset($country['CountryName']) ? $country['CountryName'] : null,
-            'countryCode'   => isset($country['CountryNameCode']) ? $country['CountryNameCode'] : null,
-        ));
+        foreach ($data as $item) {
+            $item           = $item['GeoObject'];
+            $country        = $item['metaDataProperty']['GeocoderMetaData']['AddressDetails']['Country'];
+            $addressDetails = isset($country['AdministrativeArea']) ? $country['AdministrativeArea'] : $country;
+            $locality       = isset($addressDetails['Locality']['Thoroughfare']) ? $addressDetails['Locality']['Thoroughfare'] : null;
+            $coordinates    = explode(' ', $item['Point']['pos']);
+            $bounds         = null;
+            $lowerCorner    = explode(' ', $item['boundedBy']['Envelope']['lowerCorner']);
+            $upperCorner    = explode(' ', $item['boundedBy']['Envelope']['upperCorner']);
+            $bounds         = array(
+                'south' => isset($lowerCorner[1]) ? $lowerCorner[1] : null,
+                'west'  => isset($lowerCorner[0]) ? $lowerCorner[0] : null,
+                'north' => isset($upperCorner[1]) ? $upperCorner[1] : null,
+                'east'  => isset($upperCorner[0]) ? $upperCorner[0] : null
+            );
+
+            $results[] = array_merge($this->getDefaults(), array(
+                'latitude'      => isset($coordinates[1]) ? $coordinates[1] : null,
+                'longitude'     => isset($coordinates[0]) ? $coordinates[0] : null,
+                'bounds'        => $bounds,
+                'streetNumber'  => isset($locality['Premise']['PremiseNumber']) ? $locality['Premise']['PremiseNumber'] : null,
+                'streetName'    => isset($locality['ThoroughfareName']) ? $locality['ThoroughfareName'] : null,
+                'cityDistrict'  => isset($addressDetails['AdministrativeAreaName']) ? $addressDetails['AdministrativeAreaName'] : null,
+                'country'       => isset($country['CountryName']) ? $country['CountryName'] : null,
+                'countryCode'   => isset($country['CountryNameCode']) ? $country['CountryNameCode'] : null,
+            ));
+        }
+
+        return $results;
     }
 }

--- a/src/Geocoder/Result/DefaultResultFactory.php
+++ b/src/Geocoder/Result/DefaultResultFactory.php
@@ -21,7 +21,7 @@ class DefaultResultFactory implements ResultFactoryInterface
     final public function createFromArray(array $data)
     {
         $result = $this->newInstance();
-        $result->fromArray($data);
+        $result->fromArray(isset($data[0]) ? $data[0] : $data);
 
         return $result;
     }

--- a/tests/Geocoder/Tests/GeocoderTest.php
+++ b/tests/Geocoder/Tests/GeocoderTest.php
@@ -200,6 +200,17 @@ class GeocoderTest extends TestCase
         }
     }
 
+    public function testSetMaxResults()
+    {
+        $this->geocoder->setMaxResults(3);
+        $this->assertSame(3, $this->geocoder->getMaxResults());
+    }
+
+    public function testDefaultMaxResults()
+    {
+        $this->assertSame(Geocoder::MAX_RESULTS, $this->geocoder->getMaxResults());
+    }
+
     protected function assertEmptyResult($result)
     {
         $this->assertEquals(0, $result->getLatitude());
@@ -233,6 +244,11 @@ class MockProvider implements ProviderInterface
     public function getName()
     {
         return $this->name;
+    }
+
+    public function setMaxResults($maxResults)
+    {
+        return $this;
     }
 }
 

--- a/tests/Geocoder/Tests/Provider/ArcGISOnlineProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/ArcGISOnlineProviderTest.php
@@ -64,6 +64,7 @@ class ArcGISOnlineProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedExceptionMessage Could not execute query http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?text=10+avenue+Gambetta%2C+Paris%2C+France&maxLocations=5&f=json&outFields=*
      */
     public function testGetGeocodedDataWithAddressGetsNullContent()
     {
@@ -74,8 +75,13 @@ class ArcGISOnlineProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddress()
     {
         $provider = new ArcGISOnlineProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
+        $results  = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(48.863279997000461, $result['latitude'], '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result['longitude'], '', 0.0001);
         $this->assertEquals('10 Avenue Gambetta, 75020, 20e Arrondissement, Paris', $result['streetName']);
@@ -97,8 +103,13 @@ class ArcGISOnlineProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddressAndHttps()
     {
         $provider = new ArcGISOnlineProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), null, true);
-        $result   = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
+        $results  = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(48.863279997000461, $result['latitude'], '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result['longitude'], '', 0.0001);
         $this->assertEquals('10 Avenue Gambetta, 75020, 20e Arrondissement, Paris', $result['streetName']);
@@ -119,6 +130,7 @@ class ArcGISOnlineProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedExceptionMessage No results found for query http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?text=10+avenue+Gambetta%2C+Paris%2C+France
      */
     public function testGetGeocodedDataWithInvalidAddressForSourceCountry()
     {
@@ -128,6 +140,7 @@ class ArcGISOnlineProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedExceptionMessage No results found for query https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?text=10+avenue+Gambetta%2C+Paris%2C+France
      */
     public function testGetGeocodedDataWithInvalidAddressWithHttpsForSourceCountry()
     {
@@ -137,6 +150,7 @@ class ArcGISOnlineProviderTest extends TestCase
 
     /**
      * @expectedException Geocoder\Exception\NoResultException
+     * @expectedExceptionMessage Could not execute query http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?location=2.000000,1.000000&maxLocations=5&f=json&outFields=*
      */
     public function testGetReversedDataWithInvalid()
     {
@@ -146,6 +160,7 @@ class ArcGISOnlineProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedExceptionMessage Could not execute query http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?location=2.389020,48.863280&maxLocations=5&f=json&outFields=*
      */
     public function testGetReversedDataWithCoordinatesContentReturnNull()
     {
@@ -156,8 +171,12 @@ class ArcGISOnlineProviderTest extends TestCase
     public function testGetReversedDataWithRealCoordinates()
     {
         $provider = new ArcGISOnlineProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getReversedData(array(48.863279997000461, 2.3890199980004354));
+        $result   = $provider->getReversedData(array(48.863279997000461, 2.3890199980004354));
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
         $this->assertEquals(48.863279997000461, $result['latitude'], '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result['longitude'], '', 0.0001);
         $this->assertEquals('10 Avenue Gambetta', $result['streetName']);
@@ -179,8 +198,12 @@ class ArcGISOnlineProviderTest extends TestCase
     public function testGetReversedDataWithRealCoordinatesWithHttps()
     {
         $provider = new ArcGISOnlineProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), null, true);
-        $result = $provider->getReversedData(array(48.863279997000461, 2.3890199980004354));
+        $result   = $provider->getReversedData(array(48.863279997000461, 2.3890199980004354));
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
         $this->assertEquals(48.863279997000461, $result['latitude'], '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result['longitude'], '', 0.0001);
         $this->assertEquals('10 Avenue Gambetta', $result['streetName']);
@@ -202,24 +225,60 @@ class ArcGISOnlineProviderTest extends TestCase
     public function testGetGeocodedDataWithCity()
     {
         $provider = new ArcGISOnlineProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('Hannover');
+        $results  = $provider->getGeocodedData('Hannover');
 
-        $this->assertEquals(52.370518568000477, $result['latitude'], '', 0.0001);
-        $this->assertEquals(9.7332166860004463, $result['longitude'], '', 0.0001);
-        $this->assertEquals('Hannover, Lower Saxony, Germany', $result['streetName']);
-        $this->assertEquals('Lower Saxony', $result['region']);
-        $this->assertEquals('DEU', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
 
-        $this->assertNull($result['city']);
-        $this->assertNull($result['county']);
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['streetNumber']);
-        $this->assertNull($result['country']);
-        $this->assertNull($result['timezone']);
-        $this->assertNull($result['regionCode']);
-        $this->assertNull($result['bounds']);
-        $this->assertNull($result['cityDistrict']);
-        $this->assertNull($result['countyCode']);
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(52.370518568000477, $results[0]['latitude'], '', 0.0001);
+        $this->assertEquals(9.7332166860004463, $results[0]['longitude'], '', 0.0001);
+        $this->assertEquals('Hannover, Lower Saxony, Germany', $results[0]['streetName']);
+        $this->assertEquals('Lower Saxony', $results[0]['region']);
+        $this->assertEquals('DEU', $results[0]['countryCode']);
+
+        $this->assertNull($results[0]['city']);
+        $this->assertNull($results[0]['county']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertNull($results[0]['country']);
+        $this->assertNull($results[0]['timezone']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertNull($results[0]['bounds']);
+        $this->assertNull($results[0]['cityDistrict']);
+        $this->assertNull($results[0]['countyCode']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(52.370518568, $results[1]['latitude'], '', 0.0001);
+        $this->assertEquals(9.7332166860004, $results[1]['longitude'], '', 0.0001);
+        $this->assertEquals('Hannover, Lower Saxony, Germany', $results[1]['streetName']);
+        $this->assertEquals('Hannover', $results[1]['city']);
+        $this->assertEquals('Lower Saxony', $results[1]['region']);
+        $this->assertEquals('DEU', $results[1]['countryCode']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(52.860295779, $results[2]['latitude'], '', 0.0001);
+        $this->assertEquals(9.5946585670005, $results[2]['longitude'], '', 0.0001);
+        $this->assertEquals('Hannover', $results[2]['streetName']);
+        $this->assertEquals('Walsrode', $results[2]['city']);
+        $this->assertEquals('Niedersachsen', $results[2]['region']);
+        $this->assertEquals('DEU', $results[2]['countryCode']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(52.461059225, $results[3]['latitude'], '', 0.0001);
+        $this->assertEquals(9.6850777290005, $results[3]['longitude'], '', 0.0001);
+        $this->assertEquals('Hannover', $results[3]['streetName']);
+        $this->assertEquals('Lower Saxony', $results[3]['region']);
+        $this->assertEquals('DEU', $results[3]['countryCode']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(53.285176744, $results[4]['latitude'], '', 0.0001);
+        $this->assertEquals(10.929027428, $results[4]['longitude'], '', 0.0001);
+        $this->assertEquals('Hannover', $results[4]['streetName']);
+        $this->assertEquals('Neuhaus (Elbe)', $results[4]['city']);
+        $this->assertEquals('Niedersachsen', $results[4]['region']);
+        $this->assertEquals('Amt Neuhaus', $results[4]['county']);
+        $this->assertEquals('DEU', $results[4]['countryCode']);
     }
 
     /**
@@ -229,7 +288,7 @@ class ArcGISOnlineProviderTest extends TestCase
     public function testGetGeocodedDataWithRealIPv4()
     {
         $provider = new ArcGISOnlineProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('88.188.221.14');
+        $provider->getGeocodedData('88.188.221.14');
     }
 
     /**
@@ -239,6 +298,6 @@ class ArcGISOnlineProviderTest extends TestCase
     public function testGetGeocodedDataWithRealIPv6()
     {
         $provider = new ArcGISOnlineProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('::ffff:88.188.221.14');
+        $provider->getGeocodedData('::ffff:88.188.221.14');
     }
 }

--- a/tests/Geocoder/Tests/Provider/BaiduProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/BaiduProviderTest.php
@@ -94,6 +94,10 @@ class BaiduProviderTest extends TestCase
         $provider = new BaiduProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BAIDU_API_KEY'], 'fr-FR');
         $result   = $provider->getGeocodedData('上地十街10号 北京市'); // Beijing
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
         $this->assertEquals(40.056885, $result['latitude'], '', 0.01);
         $this->assertEquals(116.30815, $result['longitude'], '', 0.01);
         $this->assertNull($result['bounds']);
@@ -148,8 +152,12 @@ class BaiduProviderTest extends TestCase
         }
 
         $provider = new BaiduProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BAIDU_API_KEY']);
-        $result = $provider->getReversedData(array(39.983424, 116.322987));
+        $result   = $provider->getReversedData(array(39.983424, 116.322987));
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
         $this->assertEquals(39.983424, $result['latitude'], '', 0.01);
         $this->assertEquals(116.322987, $result['longitude'], '', 0.01);
         $this->assertNull($result['bounds']);
@@ -178,7 +186,7 @@ class BaiduProviderTest extends TestCase
         }
 
         $provider = new BaiduProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BAIDU_API_KEY']);
-        $result = $provider->getGeocodedData('88.188.221.14');
+        $provider->getGeocodedData('88.188.221.14');
     }
 
     /**
@@ -192,7 +200,7 @@ class BaiduProviderTest extends TestCase
         }
 
         $provider = new BaiduProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BAIDU_API_KEY']);
-        $result = $provider->getGeocodedData('::ffff:88.188.221.14');
+        $provider->getGeocodedData('::ffff:88.188.221.14');
     }
 
     /**

--- a/tests/Geocoder/Tests/Provider/BingMapsProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/BingMapsProviderTest.php
@@ -24,7 +24,7 @@ class BingMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/?q=foobar&key=api_key
+     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=foobar&key=api_key
      */
     public function testGetGeocodedDataWithInvalidData()
     {
@@ -34,7 +34,7 @@ class BingMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/?q=&key=api_key
+     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=&key=api_key
      */
     public function testGetGeocodedDataWithNull()
     {
@@ -44,7 +44,7 @@ class BingMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/?q=&key=api_key
+     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=&key=api_key
      */
     public function testGetGeocodedDataWithEmpty()
     {
@@ -74,7 +74,7 @@ class BingMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/?q=10+avenue+Gambetta%2C+Paris%2C+France&key=api_key
+     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=10+avenue+Gambetta%2C+Paris%2C+France&key=api_key
      */
     public function testGetGeocodedDataWithAddressGetsNullContent()
     {
@@ -82,66 +82,93 @@ class BingMapsProviderTest extends TestCase
         $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
     }
 
-    public function testGetGeocodedDataWithRealAddress()
+    public function testGetGeocodedDataReturnsMultipleResults()
     {
-        if (!isset($_SERVER['BINGMAPS_API_KEY'])) {
-            $this->markTestSkipped('You need to configure the BINGMAPS_API_KEY value in phpunit.xml');
-        }
+        $json = <<<JSON
+{"authenticationResultCode":"ValidCredentials","brandLogoUri":"http:\/\/dev.virtualearth.net\/Branding\/logo_powered_by.png","copyright":"Copyright © 2013 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.","resourceSets":[{"estimatedTotal":3,"resources":[{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.859354042429317,2.3809438666389395,48.86707947757067,2.3966003933610596],"name":"10 Avenue Gambetta, 75020 Paris","point":{"type":"Point","coordinates":[48.863216759999993,2.3887721299999995]},"address":{"addressLine":"10 Avenue Gambetta","adminDistrict":"IdF","adminDistrict2":"Paris","countryRegion":"France","formattedAddress":"10 Avenue Gambetta, 75020 Paris","locality":"Paris","postalCode":"75020"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.863216759999993,2.3887721299999995],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Ambiguous","Good"]},{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.809565092429317,2.3172171827738461,48.81729052757067,2.3328581572261538],"name":"10 Avenue Léon Gambetta, 92120 Montrouge","point":{"type":"Point","coordinates":[48.813427809999993,2.32503767]},"address":{"addressLine":"10 Avenue Léon Gambetta","adminDistrict":"IdF","adminDistrict2":"Hauts-de-Seine","countryRegion":"France","formattedAddress":"10 Avenue Léon Gambetta, 92120 Montrouge","locality":"Montrouge","postalCode":"92120"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.813427809999993,2.32503767],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Ambiguous","Good"]},{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.806278752429328,2.4278605052896745,48.814004187570681,2.4435004547103261],"name":"10 Avenue Gambetta, 94700 Maisons-Alfort","point":{"type":"Point","coordinates":[48.810141470000005,2.4356804800000003]},"address":{"addressLine":"10 Avenue Gambetta","adminDistrict":"IdF","adminDistrict2":"Val-De-Marne","countryRegion":"France","formattedAddress":"10 Avenue Gambetta, 94700 Maisons-Alfort","locality":"Maisons-Alfort","postalCode":"94700"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.810141470000005,2.4356804800000003],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Ambiguous","Good"]}]}],"statusCode":200,"statusDescription":"OK","traceId":"fd9b0b8fe1a34ad384923b5d0937bfb2|AMSM001404|02.00.139.700|AMSMSNVM002409, AMSMSNVM001862, AMSMSNVM001322, AMSMSNVM000044"}
+JSON;
 
-        $provider = new BingMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BINGMAPS_API_KEY'], 'fr-FR');
-        $result   = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
+        $provider = new BingMapsProvider($this->getMockAdapterReturns($json), 'api_key', 'fr_FR');
+        $results  = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
 
-        $this->assertEquals(48.86321675999999, $result['latitude'], '', 0.0001);
-        $this->assertEquals(2.3887721299999995, $result['longitude'], '', 0.0001);
-        $this->assertArrayHasKey('south', $result['bounds']);
-        $this->assertArrayHasKey('west', $result['bounds']);
-        $this->assertArrayHasKey('north', $result['bounds']);
-        $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(48.859354042429, $result['bounds']['south'], '', 0.0001);
-        $this->assertEquals(2.3809438666389, $result['bounds']['west'], '', 0.0001);
-        $this->assertEquals(48.867079477571, $result['bounds']['north'], '', 0.0001);
-        $this->assertEquals(2.3966003933611, $result['bounds']['east'], '', 0.0001);
-        $this->assertNull($result['streetNumber']);
-        $this->assertEquals('10 Avenue Gambetta', $result['streetName']);
-        $this->assertEquals(75020, $result['zipcode']);
-        $this->assertEquals('Paris', $result['city']);
-        $this->assertEquals('Paris', $result['county']);
-        $this->assertEquals('IdF', $result['region']);
-        $this->assertEquals('France', $result['country']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(3, $results);
 
-        $this->assertNull($result['countryCode']);
-        $this->assertNull($result['timezone']);
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.86321675999999, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(2.3887721299999995, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(48.859354042429, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.3809438666389, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.867079477571, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.3966003933611, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('10 Avenue Gambetta', $results[0]['streetName']);
+        $this->assertEquals(75020, $results[0]['zipcode']);
+        $this->assertEquals('Paris', $results[0]['city']);
+        $this->assertEquals('Paris', $results[0]['county']);
+        $this->assertEquals('IdF', $results[0]['region']);
+        $this->assertEquals('France', $results[0]['country']);
+
+        $this->assertNull($results[0]['countryCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(48.81342781, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(2.32503767, $results[1]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertEquals(48.809565092429, $results[1]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.3172171827738, $results[1]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.817290527571, $results[1]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.3328581572262, $results[1]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[1]['streetNumber']);
+        $this->assertEquals('10 Avenue Léon Gambetta', $results[1]['streetName']);
+        $this->assertEquals(92120, $results[1]['zipcode']);
+        $this->assertEquals('Montrouge', $results[1]['city']);
+        $this->assertEquals('Hauts-de-Seine', $results[1]['county']);
+        $this->assertEquals('IdF', $results[1]['region']);
+        $this->assertEquals('France', $results[1]['country']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(48.81014147, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(2.43568048, $results[2]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[2]['bounds']);
+        $this->assertArrayHasKey('west', $results[2]['bounds']);
+        $this->assertArrayHasKey('north', $results[2]['bounds']);
+        $this->assertArrayHasKey('east', $results[2]['bounds']);
+        $this->assertEquals(48.806278752429, $results[2]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.4278605052897, $results[2]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.814004187571, $results[2]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.4435004547103, $results[2]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[2]['streetNumber']);
+        $this->assertEquals('10 Avenue Gambetta', $results[2]['streetName']);
+        $this->assertEquals(94700, $results[2]['zipcode']);
+        $this->assertEquals('Maisons-Alfort', $results[2]['city']);
+        $this->assertEquals('Val-De-Marne', $results[2]['county']);
+        $this->assertEquals('IdF', $results[2]['region']);
+        $this->assertEquals('France', $results[2]['country']);
     }
 
-    /**
-     * @expectedException Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/1.000000,2.000000?key=api_key
-     */
-    public function testGetReversedData()
+    public function testGetReversedDataReturnsSingleResult()
     {
-        $provider = new BingMapsProvider($this->getMockAdapter(), 'api_key');
-        $provider->getReversedData(array(1, 2));
-    }
+        $json = <<<JSON
+{"authenticationResultCode":"ValidCredentials","brandLogoUri":"http:\/\/dev.virtualearth.net\/Branding\/logo_powered_by.png","copyright":"Copyright © 2013 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.","resourceSets":[{"estimatedTotal":1,"resources":[{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.859353771982775,2.3809437325832983,48.867079207124128,2.3966002592208246],"name":"10 Avenue Gambetta, 75020 20e Arrondissement","point":{"type":"Point","coordinates":[48.863216489553452,2.3887719959020615]},"address":{"addressLine":"10 Avenue Gambetta","adminDistrict":"IdF","adminDistrict2":"Paris","countryRegion":"France","formattedAddress":"10 Avenue Gambetta, 75020 20e Arrondissement","locality":"20e Arrondissement","postalCode":"75020"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.863216489553452,2.3887719959020615],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Good"]}]}],"statusCode":200,"statusDescription":"OK","traceId":"0691dabd257043b381b678fbfaf799dd|AMSM001401|02.00.139.700|AMSMSNVM001951, AMSMSNVM002152"}
+JSON;
 
-    /**
-     * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/48.863216,2.388772?key=api_key
-     */
-    public function testGetReversedDataWithCoordinatesContentReturnNull()
-    {
-        $provider = new BingMapsProvider($this->getMockAdapterReturns(null), 'api_key');
-        $provider->getReversedData(array(48.86321648955345, 2.3887719959020615));
-    }
+        $provider = new BingMapsProvider($this->getMockAdapterReturns($json), 'api_key');
+        $results  = $provider->getReversedData(array(48.86321648955345, 2.3887719959020615));
 
-    public function testGetReversedDataWithRealCoordinates()
-    {
-        if (!isset($_SERVER['BINGMAPS_API_KEY'])) {
-            $this->markTestSkipped('You need to configure the BINGMAPS_API_KEY value in phpunit.xml');
-        }
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
 
-        $provider = new BingMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BINGMAPS_API_KEY']);
-        $result = $provider->getReversedData(array(48.86321648955345, 2.3887719959020615));
-
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(48.86321648955345, $result['latitude'], '', 0.0001);
         $this->assertEquals(2.3887719959020615, $result['longitude'], '', 0.0001);
         $this->assertArrayHasKey('south', $result['bounds']);
@@ -165,29 +192,134 @@ class BingMapsProviderTest extends TestCase
         $this->assertNull($result['timezone']);
     }
 
-    public function testGetGeocodedDataWithCity()
+    public function testGetGeocodedDataWithRealAddressReturnsMultipleResults()
     {
         if (!isset($_SERVER['BINGMAPS_API_KEY'])) {
             $this->markTestSkipped('You need to configure the BINGMAPS_API_KEY value in phpunit.xml');
         }
 
-        $provider = new BingMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BINGMAPS_API_KEY']);
-        $result = $provider->getGeocodedData('Hannover');
+        $provider = new BingMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BINGMAPS_API_KEY'], 'fr-FR');
+        $results  = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
 
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['timezone']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(3, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.86321675999999, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(2.3887721299999995, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(48.859354042429, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.3809438666389, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.867079477571, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.3966003933611, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('10 Avenue Gambetta', $results[0]['streetName']);
+        $this->assertEquals(75020, $results[0]['zipcode']);
+        $this->assertEquals('Paris', $results[0]['city']);
+        $this->assertEquals('Paris', $results[0]['county']);
+        $this->assertEquals('IdF', $results[0]['region']);
+        $this->assertEquals('France', $results[0]['country']);
+
+        $this->assertNull($results[0]['countryCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(48.81342781, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(2.32503767, $results[1]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertEquals(48.809565092429, $results[1]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.3172171827738, $results[1]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.817290527571, $results[1]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.3328581572262, $results[1]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[1]['streetNumber']);
+        $this->assertEquals('10 Avenue Léon Gambetta', $results[1]['streetName']);
+        $this->assertEquals(92120, $results[1]['zipcode']);
+        $this->assertEquals('Montrouge', $results[1]['city']);
+        $this->assertEquals('Hauts-de-Seine', $results[1]['county']);
+        $this->assertEquals('IdF', $results[1]['region']);
+        $this->assertEquals('France', $results[1]['country']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(48.81014147, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(2.43568048, $results[2]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[2]['bounds']);
+        $this->assertArrayHasKey('west', $results[2]['bounds']);
+        $this->assertArrayHasKey('north', $results[2]['bounds']);
+        $this->assertArrayHasKey('east', $results[2]['bounds']);
+        $this->assertEquals(48.806278752429, $results[2]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.4278605052897, $results[2]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.814004187571, $results[2]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.4435004547103, $results[2]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[2]['streetNumber']);
+        $this->assertEquals('10 Avenue Gambetta', $results[2]['streetName']);
+        $this->assertEquals(94700, $results[2]['zipcode']);
+        $this->assertEquals('Maisons-Alfort', $results[2]['city']);
+        $this->assertEquals('Val-De-Marne', $results[2]['county']);
+        $this->assertEquals('IdF', $results[2]['region']);
+        $this->assertEquals('France', $results[2]['country']);
     }
 
-    public function testGetGeocodedDataWithCityDistrict()
+    /**
+     * @expectedException Geocoder\Exception\NoResultException
+     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/1.000000,2.000000?key=api_key
+     */
+    public function testGetReversedData()
+    {
+        $provider = new BingMapsProvider($this->getMockAdapter(), 'api_key');
+        $provider->getReversedData(array(1, 2));
+    }
+
+    /**
+     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedExceptionMessage Could not execute query http://dev.virtualearth.net/REST/v1/Locations/48.863216,2.388772?key=api_key
+     */
+    public function testGetReversedDataWithCoordinatesContentReturnNull()
+    {
+        $provider = new BingMapsProvider($this->getMockAdapterReturns(null), 'api_key');
+        $provider->getReversedData(array(48.86321648955345, 2.3887719959020615));
+    }
+
+    public function testGetReversedDataWithRealCoordinatesReturnsSingleResult()
     {
         if (!isset($_SERVER['BINGMAPS_API_KEY'])) {
             $this->markTestSkipped('You need to configure the BINGMAPS_API_KEY value in phpunit.xml');
         }
 
         $provider = new BingMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BINGMAPS_API_KEY']);
-        $result = $provider->getGeocodedData('Kalbacher Hauptstraße 10, 60437 Frankfurt, Germany');
+        $results  = $provider->getReversedData(array(48.86321648955345, 2.3887719959020615));
 
-        $this->assertNull($result['cityDistrict']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
+        $this->assertEquals(48.86321648955345, $result['latitude'], '', 0.0001);
+        $this->assertEquals(2.3887719959020615, $result['longitude'], '', 0.0001);
+        $this->assertArrayHasKey('south', $result['bounds']);
+        $this->assertArrayHasKey('west', $result['bounds']);
+        $this->assertArrayHasKey('north', $result['bounds']);
+        $this->assertArrayHasKey('east', $result['bounds']);
+        $this->assertEquals(48.859353771983, $result['bounds']['south'], '', 0.0001);
+        $this->assertEquals(2.3809437325833, $result['bounds']['west'], '', 0.0001);
+        $this->assertEquals(48.867079207124, $result['bounds']['north'], '', 0.0001);
+        $this->assertEquals(2.3966002592208, $result['bounds']['east'], '', 0.0001);
+        $this->assertNull($result['streetNumber']);
+        $this->assertEquals('10 Avenue Gambetta', $result['streetName']);
+        $this->assertEquals(75020, $result['zipcode']);
+        // $this->assertEquals('Paris', $result['city']);
+        $this->assertEquals('20e Arrondissement', $result['city']);
+        $this->assertEquals('Paris', $result['county']);
+        $this->assertEquals('IdF', $result['region']);
+        $this->assertEquals('France', $result['country']);
+
+        $this->assertNull($result['countryCode']);
+        $this->assertNull($result['timezone']);
     }
 
     /**
@@ -201,7 +333,7 @@ class BingMapsProviderTest extends TestCase
         }
 
         $provider = new BingMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BINGMAPS_API_KEY']);
-        $result = $provider->getGeocodedData('88.188.221.14');
+        $provider->getGeocodedData('88.188.221.14');
     }
 
     /**
@@ -215,6 +347,6 @@ class BingMapsProviderTest extends TestCase
         }
 
         $provider = new BingMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['BINGMAPS_API_KEY']);
-        $result = $provider->getGeocodedData('::ffff:88.188.221.14');
+        $provider->getGeocodedData('::ffff:88.188.221.14');
     }
 }

--- a/tests/Geocoder/Tests/Provider/CloudMadeProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/CloudMadeProviderTest.php
@@ -24,7 +24,7 @@ class CloudMadeProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?query=foobar&distance=closest&return_location=true&results=1
+     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?query=foobar&distance=closest&return_location=true&results=5
      */
     public function testGetGeocodedData()
     {
@@ -34,7 +34,7 @@ class CloudMadeProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?query=&distance=closest&return_location=true&results=1
+     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?query=&distance=closest&return_location=true&results=5
      */
     public function testGetGeocodedDataWithNull()
     {
@@ -44,7 +44,7 @@ class CloudMadeProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?query=&distance=closest&return_location=true&results=1
+     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?query=&distance=closest&return_location=true&results=5
      */
     public function testGetGeocodedDataWithEmpty()
     {
@@ -74,7 +74,7 @@ class CloudMadeProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?query=36+Quai+des+Orf%C3%A8vres%2C+Paris%2C+France&distance=closest&return_location=true&results=1
+     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?query=36+Quai+des+Orf%C3%A8vres%2C+Paris%2C+France&distance=closest&return_location=true&results=5
      */
     public function testGetGeocodedDataWithAddressGetsNullContent()
     {
@@ -109,8 +109,13 @@ class CloudMadeProviderTest extends TestCase
         }
 
         $provider = new CloudMadeProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['CLOUDMADE_API_KEY']);
-        $result = $provider->getGeocodedData('36 Quai des Orfèvres, Paris, France');
+        $result   = $provider->getGeocodedData('36 Quai des Orfèvres, Paris, France');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(48.85645, $result['latitude'], '', 0.0001);
         $this->assertEquals(2.35243, $result['longitude'], '', 0.0001);
         $this->assertArrayHasKey('south', $result['bounds']);
@@ -136,7 +141,7 @@ class CloudMadeProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?around=1.000000,2.000000&object_type=address&return_location=true&results=1
+     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?around=1.000000,2.000000&object_type=address&return_location=true&results=5
      */
     public function testGetReversedData()
     {
@@ -146,7 +151,7 @@ class CloudMadeProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?around=48.856570,2.353250&object_type=address&return_location=true&results=1
+     * @expectedExceptionMessage Could not execute query http://geocoding.cloudmade.com/api_key/geocoding/v2/find.js?around=48.856570,2.353250&object_type=address&return_location=true&results=5
      */
     public function testGetReversedDataWithCoordinatesGetsNullContent()
     {
@@ -161,62 +166,166 @@ class CloudMadeProviderTest extends TestCase
         }
 
         $provider = new CloudMadeProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['CLOUDMADE_API_KEY']);
-        $result = $provider->getReversedData(array(48.85657, 2.35325));
+        $results  = $provider->getReversedData(array(48.85657, 2.35325));
 
-        $this->assertEquals(48.85657, $result['latitude'], '', 0.0001);
-        $this->assertEquals(2.35325, $result['longitude'], '', 0.0001);
-        $this->assertArrayHasKey('south', $result['bounds']);
-        $this->assertArrayHasKey('west', $result['bounds']);
-        $this->assertArrayHasKey('north', $result['bounds']);
-        $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(48.85657, $result['bounds']['south'], '', 0.0001);
-        $this->assertEquals(2.35325, $result['bounds']['west'], '', 0.0001);
-        $this->assertEquals(48.85657, $result['bounds']['north'], '', 0.0001);
-        $this->assertEquals(2.35325, $result['bounds']['east'], '', 0.0001);
-        $this->assertEquals(5, $result['streetNumber']);
-        $this->assertEquals('Rue Lobau', $result['streetName']);
-        $this->assertNull($result['zipcode']);
-        $this->assertEquals('Paris', $result['city']);
-        $this->assertEquals('Ile-del-france', $result['region']);
-        $this->assertEquals('Ile-del-france', $result['county']);
-        $this->assertEquals('France', $result['country']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(4, $results); // 4 results are returned by the provider
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.85657, $results[0]['latitude'], '', 0.0001);
+        $this->assertEquals(2.35325, $results[0]['longitude'], '', 0.0001);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(48.85657, $results[0]['bounds']['south'], '', 0.0001);
+        $this->assertEquals(2.35325, $results[0]['bounds']['west'], '', 0.0001);
+        $this->assertEquals(48.85657, $results[0]['bounds']['north'], '', 0.0001);
+        $this->assertEquals(2.35325, $results[0]['bounds']['east'], '', 0.0001);
+        $this->assertEquals(5, $results[0]['streetNumber']);
+        $this->assertEquals('Rue Lobau', $results[0]['streetName']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertEquals('Paris', $results[0]['city']);
+        $this->assertEquals('Ile-del-france', $results[0]['region']);
+        $this->assertEquals('Ile-del-france', $results[0]['county']);
+        $this->assertEquals('France', $results[0]['country']);
 
         // not provided
-        $this->assertNull($result['countryCode']);
-        $this->assertNull($result['timezone']);
+        $this->assertNull($results[0]['countryCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(48.85658, $results[1]['latitude'], '', 0.0001);
+        $this->assertEquals(2.35381, $results[1]['longitude'], '', 0.0001);
+        $this->assertEquals('Rue Lobau', $results[1]['streetName']);
+        $this->assertEquals('Paris', $results[1]['city']);
+        $this->assertEquals('France', $results[1]['country']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(48.85714, $results[2]['latitude'], '', 0.0001);
+        $this->assertEquals(2.35348, $results[2]['longitude'], '', 0.0001);
+        $this->assertEquals('Rue de Rivoli', $results[2]['streetName']);
+        $this->assertEquals('Paris', $results[2]['city']);
+        $this->assertEquals('France', $results[2]['country']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(48.8571, $results[3]['latitude'], '', 0.0001);
+        $this->assertEquals(2.35362, $results[3]['longitude'], '', 0.0001);
+        $this->assertEquals('Rue de Rivoli', $results[3]['streetName']);
+        $this->assertEquals('Paris', $results[3]['city']);
+        $this->assertEquals('France', $results[3]['country']);
     }
 
-    public function testGetGeocodedDataWithRealAddress2()
+    public function testGetGeocodedDataWithRealAddressReturnsMultilpleResults()
     {
         if (!isset($_SERVER['CLOUDMADE_API_KEY'])) {
             $this->markTestSkipped('You need to configure the CLOUDMADE_API_KEY value in phpunit.xml');
         }
 
         $provider = new CloudMadeProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['CLOUDMADE_API_KEY']);
-        $result = $provider->getGeocodedData('73 Boulevard Schuman, Clermont-Ferrand');
+        $results  = $provider->getGeocodedData('73 Boulevard Schuman');
 
-        $this->assertNull($result['streetNumber']);
-        $this->assertEquals('Boulevard Robert Schuman', $result['streetName']);
-        $this->assertEquals('Clermont Ferrand', $result['city']);
-        $this->assertEquals('Auvergne', $result['region']);
-        $this->assertEquals('Auvergne', $result['county']);
-        $this->assertEquals('France', $result['country']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.92846, $results[0]['latitude'], '', 0.001);
+        $this->assertEquals(2.55019, $results[0]['longitude'], '', 0.001);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(48.92633, $results[0]['bounds']['south'], '', 0.001);
+        $this->assertEquals(2.54513, $results[0]['bounds']['west'], '', 0.001);
+        $this->assertEquals(48.93074, $results[0]['bounds']['north'], '', 0.001);
+        $this->assertEquals(2.5552, $results[0]['bounds']['east'], '', 0.001);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('Boulevard Robert Schuman', $results[0]['streetName']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertEquals('Montreuil', $results[0]['city']);
+        $this->assertEquals('Ile-del-france', $results[0]['region']);
+        $this->assertEquals('Ile-del-france', $results[0]['county']);
+        $this->assertEquals('France', $results[0]['country']);
 
         // not provided
-        $this->assertNull($result['countryCode']);
-        $this->assertNull($result['timezone']);
-    }
+        $this->assertNull($results[0]['countryCode']);
+        $this->assertNull($results[0]['timezone']);
 
-    public function testGetGeocodedDataWithCityDistrict()
-    {
-        if (!isset($_SERVER['CLOUDMADE_API_KEY'])) {
-            $this->markTestSkipped('You need to configure the CLOUDMADE_API_KEY value in phpunit.xml');
-        }
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(49.64693, $results[1]['latitude'], '', 0.001);
+        $this->assertEquals(5.99272, $results[1]['longitude'], '', 0.001);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertEquals(49.64676, $results[1]['bounds']['south'], '', 0.001);
+        $this->assertEquals(5.98893, $results[1]['bounds']['west'], '', 0.001);
+        $this->assertEquals(49.65023, $results[1]['bounds']['north'], '', 0.001);
+        $this->assertEquals(5.99711, $results[1]['bounds']['east'], '', 0.001);
+        $this->assertNull($results[1]['streetNumber']);
+        $this->assertEquals('Boulevard Robert Schuman', $results[1]['streetName']);
+        $this->assertNull($results[1]['zipcode']);
+        $this->assertEquals('Luxembourg', $results[1]['city']);
+        $this->assertEquals('Luxembourg', $results[1]['region']);
+        $this->assertEquals('Luxembourg', $results[1]['county']);
+        $this->assertEquals('Luxembourg', $results[1]['country']);
 
-        $provider = new CloudMadeProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['CLOUDMADE_API_KEY']);
-        $result = $provider->getGeocodedData('Kalbacher Hauptstraße 10, 60437 Frankfurt, Germany');
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(44.96087, $results[2]['latitude'], '', 0.001);
+        $this->assertEquals(4.90654, $results[2]['longitude'], '', 0.001);
+        $this->assertArrayHasKey('south', $results[2]['bounds']);
+        $this->assertArrayHasKey('west', $results[2]['bounds']);
+        $this->assertArrayHasKey('north', $results[2]['bounds']);
+        $this->assertArrayHasKey('east', $results[2]['bounds']);
+        $this->assertEquals(44.96025, $results[2]['bounds']['south'], '', 0.001);
+        $this->assertEquals(4.90413, $results[2]['bounds']['west'], '', 0.001);
+        $this->assertEquals(44.96109, $results[2]['bounds']['north'], '', 0.001);
+        $this->assertEquals(4.90946, $results[2]['bounds']['east'], '', 0.001);
+        $this->assertNull($results[2]['streetNumber']);
+        $this->assertEquals('Boulevard Robert Schuman', $results[2]['streetName']);
+        $this->assertNull($results[2]['zipcode']);
+        $this->assertEquals('Bourg lès Valence', $results[2]['city']);
+        $this->assertEquals('Rhone-alpes', $results[2]['region']);
+        $this->assertEquals('Rhone-alpes', $results[2]['county']);
+        $this->assertEquals('France', $results[2]['country']);
 
-        $this->assertNull($result['cityDistrict']);
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(44.96098, $results[3]['latitude'], '', 0.001);
+        $this->assertEquals(4.90574, $results[3]['longitude'], '', 0.001);
+        $this->assertArrayHasKey('south', $results[3]['bounds']);
+        $this->assertArrayHasKey('west', $results[3]['bounds']);
+        $this->assertArrayHasKey('north', $results[3]['bounds']);
+        $this->assertArrayHasKey('east', $results[3]['bounds']);
+        $this->assertEquals(44.96098, $results[3]['bounds']['south'], '', 0.001);
+        $this->assertEquals(4.90563, $results[3]['bounds']['west'], '', 0.001);
+        $this->assertEquals(44.96098, $results[3]['bounds']['north'], '', 0.001);
+        $this->assertEquals(4.90585, $results[3]['bounds']['east'], '', 0.001);
+        $this->assertNull($results[3]['streetNumber']);
+        $this->assertEquals('Boulevard Robert Schuman', $results[3]['streetName']);
+        $this->assertNull($results[3]['zipcode']);
+        $this->assertEquals('Bourg lès Valence', $results[3]['city']);
+        $this->assertEquals('Rhone-alpes', $results[3]['region']);
+        $this->assertEquals('Rhone-alpes', $results[3]['county']);
+        $this->assertEquals('France', $results[3]['country']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(50.29716, $results[4]['latitude'], '', 0.001);
+        $this->assertEquals(2.77608, $results[4]['longitude'], '', 0.001);
+        $this->assertArrayHasKey('south', $results[4]['bounds']);
+        $this->assertArrayHasKey('west', $results[4]['bounds']);
+        $this->assertArrayHasKey('north', $results[4]['bounds']);
+        $this->assertArrayHasKey('east', $results[4]['bounds']);
+        $this->assertEquals(50.29633, $results[4]['bounds']['south'], '', 0.001);
+        $this->assertEquals(2.76961, $results[4]['bounds']['west'], '', 0.001);
+        $this->assertEquals(50.29735, $results[4]['bounds']['north'], '', 0.001);
+        $this->assertEquals(2.78268, $results[4]['bounds']['east'], '', 0.001);
+        $this->assertNull($results[4]['streetNumber']);
+        $this->assertEquals('Boulevard Robert Schuman', $results[4]['streetName']);
+        $this->assertNull($results[4]['zipcode']);
+        $this->assertEquals('Arras', $results[4]['city']);
+        $this->assertEquals('Nord-pas-de-calais', $results[4]['region']);
+        $this->assertEquals('Nord-pas-de-calais', $results[4]['county']);
+        $this->assertEquals('France', $results[4]['country']);
     }
 
     /**
@@ -230,7 +339,7 @@ class CloudMadeProviderTest extends TestCase
         }
 
         $provider = new CloudMadeProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['CLOUDMADE_API_KEY']);
-        $result = $provider->getGeocodedData('88.188.221.14');
+        $provider->getGeocodedData('88.188.221.14');
     }
 
     /**
@@ -244,6 +353,6 @@ class CloudMadeProviderTest extends TestCase
         }
 
         $provider = new CloudMadeProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['CLOUDMADE_API_KEY']);
-        $result = $provider->getGeocodedData('::ffff:88.188.221.14');
+        $provider->getGeocodedData('::ffff:88.188.221.14');
     }
 }

--- a/tests/Geocoder/Tests/Provider/DataScienceToolkitProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/DataScienceToolkitProviderTest.php
@@ -46,8 +46,13 @@ class DataScienceToolkitProviderTest extends TestCase
     public function testGetGeocodedDataWithLocalhostIPv4()
     {
         $provider = new DataScienceToolkitProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('127.0.0.1');
+        $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -94,8 +99,13 @@ class DataScienceToolkitProviderTest extends TestCase
         $provider = new DataScienceToolkitProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('81.220.239.218');
 
-        $this->assertEquals(45.75 , $result['latitude'], '', 0.0001);
-        $this->assertEquals(4.8499999046326, $result['longitude'], '', 0.0001);
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
+        $this->assertEquals(45.75, $result['latitude'], '', 0.01);
+        $this->assertEquals(4.8499999046326, $result['longitude'], '', 0.01);
         $this->assertEquals('Lyon', $result['city']);
         $this->assertEquals('France', $result['country']);
         $this->assertEquals('FR', $result['countryCode']);
@@ -106,8 +116,13 @@ class DataScienceToolkitProviderTest extends TestCase
         $provider = new DataScienceToolkitProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('2543 Graystone Place, Simi Valley, CA 93065');
 
-        $this->assertEquals(34.281016 , $result['latitude'], '', 0.0001);
-        $this->assertEquals(-118.766282, $result['longitude'], '', 0.0001);
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
+        $this->assertEquals(34.280874, $result['latitude'], '', 0.01);
+        $this->assertEquals(-118.766282, $result['longitude'], '', 0.01);
         $this->assertEquals('Simi Valley', $result['city']);
         $this->assertEquals('United States', $result['country']);
         $this->assertEquals('US', $result['countryCode']);

--- a/tests/Geocoder/Tests/Provider/FreeGeoIpProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/FreeGeoIpProviderTest.php
@@ -46,8 +46,13 @@ class FreeGeoIpProviderTest extends TestCase
     public function testGetGeocodedDataWithLocalhostIPv4()
     {
         $provider = new FreeGeoIpProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('127.0.0.1');
+        $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -62,8 +67,13 @@ class FreeGeoIpProviderTest extends TestCase
     public function testGetGeocodedDataWithLocalhostIPv6()
     {
         $provider = new FreeGeoIpProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('::1');
+        $result   = $provider->getGeocodedData('::1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -98,8 +108,13 @@ class FreeGeoIpProviderTest extends TestCase
     public function testGetGeocodedDataWithRealIPv4()
     {
         $provider = new FreeGeoIpProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('74.200.247.59');
+        $result   = $provider->getGeocodedData('74.200.247.59');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(37.7484, $result['latitude'], '', 0.01);
         $this->assertEquals(-122.4156, $result['longitude'], '', 0.01);
         $this->assertEquals(94110, $result['zipcode']);
@@ -112,8 +127,13 @@ class FreeGeoIpProviderTest extends TestCase
     public function testGetGeocodedDataWithRealIPv6()
     {
         $provider = new FreeGeoIpProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('::ffff:74.200.247.59');
+        $result   = $provider->getGeocodedData('::ffff:74.200.247.59');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(37.7484, $result['latitude'], '', 0.01);
         $this->assertEquals(-122.4156, $result['longitude'], '', 0.01);
         $this->assertEquals(94110, $result['zipcode']);
@@ -138,30 +158,50 @@ class FreeGeoIpProviderTest extends TestCase
         $provider = new FreeGeoIpProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('74.200.247.59');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('6', $result['regionCode']);
     }
 
     public function testGetGeocodedDataWithUSIPv6()
     {
         $provider = new FreeGeoIpProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('::ffff:74.200.247.59');
+        $result   = $provider->getGeocodedData('::ffff:74.200.247.59');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('6', $result['regionCode']);
     }
 
     public function testGetGeocodedDataWithUKIPv4()
     {
         $provider = new FreeGeoIpProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('132.185.255.60');
+        $result   = $provider->getGeocodedData('132.185.255.60');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('H9', $result['regionCode']);
     }
 
     public function testGetGeocodedDataWithUKIPv6()
     {
         $provider = new FreeGeoIpProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('::ffff:132.185.255.60');
+        $result   = $provider->getGeocodedData('::ffff:132.185.255.60');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('H9', $result['regionCode']);
     }
 

--- a/tests/Geocoder/Tests/Provider/GeoIPsProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoIPsProviderTest.php
@@ -57,6 +57,11 @@ class GeoIPsProviderTest extends TestCase
         $provider = new GeoIPsProvider($this->getMockAdapter($this->never()), 'api_key');
         $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -121,6 +126,11 @@ class GeoIPsProviderTest extends TestCase
         $provider = new GeoIPsProvider($this->getMockAdapterReturns($json), 'api_key');
         $result   = $provider->getGeocodedData('66.147.244.214');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertNull($result['country']);
         $this->assertNull($result['countryCode']);
         $this->assertNull($result['regionCode']);
@@ -154,6 +164,11 @@ class GeoIPsProviderTest extends TestCase
         $provider = new GeoIPsProvider($this->getMockAdapterReturns($json), 'api_key');
         $result   = $provider->getGeocodedData('66.147.244.214');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('UNITED STATES', $result['country']);
         $this->assertEquals('US', $result['countryCode']);
         $this->assertEquals('UTAH', $result['region']);
@@ -206,13 +221,18 @@ class GeoIPsProviderTest extends TestCase
         $provider = new GeoIPsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['GEOIPS_API_KEY']);
         $result   = $provider->getGeocodedData('66.147.244.214');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('UNITED STATES', $result['country']);
         $this->assertEquals('US', $result['countryCode']);
         $this->assertEquals('UTAH', $result['region']);
         $this->assertEquals('UT', $result['regionCode']);
         $this->assertEquals('UTAH', $result['county']);
         $this->assertEquals('PROVO', $result['city']);
-        $this->assertEquals(75093, $result['zipcode']);
+        $this->assertNull($result['zipcode']);
         $this->assertEquals(40.3402, $result['latitude'], '', 0.0001);
         $this->assertEquals(-111.6073, $result['longitude'], '', 0.0001);
         $this->assertEquals('MST', $result['timezone']);

--- a/tests/Geocoder/Tests/Provider/GeoPluginProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoPluginProviderTest.php
@@ -48,6 +48,11 @@ class GeoPluginProviderTest extends TestCase
         $provider = new GeoPluginProvider($this->getMockAdapter($this->never()));
         $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -64,6 +69,11 @@ class GeoPluginProviderTest extends TestCase
         $provider = new GeoPluginProvider($this->getMockAdapter($this->never()));
         $result   = $provider->getGeocodedData('::1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -100,6 +110,11 @@ class GeoPluginProviderTest extends TestCase
         $provider = new GeoPluginProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('66.147.244.214');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('Provo', $result['city']);
         $this->assertEquals(40.218102, $result['latitude'], '', 0.0001);
         $this->assertEquals(-111.613297, $result['longitude'], '', 0.0001);

--- a/tests/Geocoder/Tests/Provider/GeocoderCaProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GeocoderCaProviderTest.php
@@ -41,6 +41,11 @@ class GeocoderCaProviderTest extends TestCase
         $provider = new GeocoderCaProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('1600 Pennsylvania Ave, Washington, DC');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(38.898748, $result['latitude'], '', 0.0001);
         $this->assertEquals(-77.037684, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -61,6 +66,11 @@ class GeocoderCaProviderTest extends TestCase
         $provider = new GeocoderCaProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('4208 Gallaghers, Kelowna, BC');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(49.831515, $result['latitude'], '', 0.0001);
         $this->assertEquals(-119.381857, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -131,6 +141,11 @@ class GeocoderCaProviderTest extends TestCase
         $provider = new GeocoderCaProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getReversedData(array('40.707507', '-74.011255'));
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(40.707507, $result['latitude'], '', 0.0001);
         $this->assertEquals(-74.011255, $result['longitude'], '', 0.0001);
         $this->assertEquals(2, $result['streetNumber']);

--- a/tests/Geocoder/Tests/Provider/GeocoderUsProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GeocoderUsProviderTest.php
@@ -43,6 +43,11 @@ class GeocoderUsProviderTest extends TestCase
         $provider = new GeocoderUsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('1600 Pennsylvania Ave, Washington, DC');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(38.898748, $result['latitude'], '', 0.0001);
         $this->assertEquals(-77.037684, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);

--- a/tests/Geocoder/Tests/Provider/GeoipProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoipProviderTest.php
@@ -57,6 +57,11 @@ class GeoipProviderTest extends TestCase
         $provider = new GeoipProvider();
         $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -83,6 +88,11 @@ class GeoipProviderTest extends TestCase
         $provider = new GeoipProvider();
         $result   = $provider->getGeocodedData('74.200.247.59');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertNotNull($result['latitude']);
         $this->assertNotNull($result['longitude']);
         $this->assertNotNull($result['zipcode']);

--- a/tests/Geocoder/Tests/Provider/GeonamesProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GeonamesProviderTest.php
@@ -55,7 +55,7 @@ class GeonamesProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://api.geonames.org/searchJSON?q=&maxRows=1&style=full&username=username
+     * @expectedExceptionMessage Could not execute query http://api.geonames.org/searchJSON?q=&maxRows=5&style=full&username=username
      */
     public function testGetGeocodedDataWithNull()
     {
@@ -65,7 +65,7 @@ class GeonamesProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage No places found for query http://api.geonames.org/searchJSON?q=BlaBlaBla&maxRows=1&style=full&username=username
+     * @expectedExceptionMessage No places found for query http://api.geonames.org/searchJSON?q=BlaBlaBla&maxRows=5&style=full&username=username
      * @
      */
     public function testGetGeocodedDataWithUnknownCity()
@@ -87,24 +87,100 @@ JSON;
         }
 
         $provider = new GeonamesProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['GEONAMES_USERNAME']);
-        $result   = $provider->getGeocodedData('London');
+        $results  = $provider->getGeocodedData('London');
 
-        $this->assertEquals(51.50853, $result['latitude'], '', 0.01);
-        $this->assertEquals(-0.12574, $result['longitude'], '', 0.01);
-        $this->assertArrayHasKey('south', $result['bounds']);
-        $this->assertArrayHasKey('west', $result['bounds']);
-        $this->assertArrayHasKey('north', $result['bounds']);
-        $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(51.15169, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(-0.70361, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(51.86537, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(0.45212, $result['bounds']['east'], '', 0.01);
-        $this->assertEquals('London', $result['city']);
-        $this->assertEquals('Greater London', $result['county']);
-        $this->assertEquals('England', $result['region']);
-        $this->assertEquals('United Kingdom', $result['country']);
-        $this->assertEquals('GB', $result['countryCode']);
-        $this->assertEquals('Europe/London', $result['timezone']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(51.508528775863, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(-0.12574195861816, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(51.151689398345, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-0.70360885396019, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(51.865368153381, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(0.45212493672386, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertEquals('London', $results[0]['city']);
+        $this->assertEquals('Greater London', $results[0]['county']);
+        $this->assertEquals('England', $results[0]['region']);
+        $this->assertEquals('United Kingdom', $results[0]['country']);
+        $this->assertEquals('GB', $results[0]['countryCode']);
+        $this->assertEquals('Europe/London', $results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(51.512788890295, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(-0.091838836669922, $results[1]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertEquals(51.155949512764, $results[1]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-0.66976046752962, $results[1]['bounds']['west'], '', 0.01);
+        $this->assertEquals(51.869628267826, $results[1]['bounds']['north'], '', 0.01);
+        $this->assertEquals(0.48608279418978, $results[1]['bounds']['east'], '', 0.01);
+        $this->assertEquals('City of London', $results[1]['city']);
+        $this->assertEquals('Greater London', $results[1]['county']);
+        $this->assertEquals('England', $results[1]['region']);
+        $this->assertEquals('United Kingdom', $results[1]['country']);
+        $this->assertEquals('GB', $results[1]['countryCode']);
+        $this->assertEquals('Europe/London', $results[1]['timezone']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(42.983389283, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(-81.233042387, $results[2]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[2]['bounds']);
+        $this->assertArrayHasKey('west', $results[2]['bounds']);
+        $this->assertArrayHasKey('north', $results[2]['bounds']);
+        $this->assertArrayHasKey('east', $results[2]['bounds']);
+        $this->assertEquals(42.907075642763, $results[2]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-81.337489676463, $results[2]['bounds']['west'], '', 0.01);
+        $this->assertEquals(43.059702923237, $results[2]['bounds']['north'], '', 0.01);
+        $this->assertEquals(-81.128595097537, $results[2]['bounds']['east'], '', 0.01);
+        $this->assertEquals('London', $results[2]['city']);
+        $this->assertEquals('', $results[2]['county']);
+        $this->assertEquals('Ontario', $results[2]['region']);
+        $this->assertEquals('Canada', $results[2]['country']);
+        $this->assertEquals('CA', $results[2]['countryCode']);
+        $this->assertEquals('America/Toronto', $results[2]['timezone']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(-33.015285093464, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(27.911624908447, $results[3]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[3]['bounds']);
+        $this->assertArrayHasKey('west', $results[3]['bounds']);
+        $this->assertArrayHasKey('north', $results[3]['bounds']);
+        $this->assertArrayHasKey('east', $results[3]['bounds']);
+        $this->assertEquals(-33.104996458003, $results[3]['bounds']['south'], '', 0.01);
+        $this->assertEquals(27.804746435655, $results[3]['bounds']['west'], '', 0.01);
+        $this->assertEquals(-32.925573728925, $results[3]['bounds']['north'], '', 0.01);
+        $this->assertEquals(28.018503381239, $results[3]['bounds']['east'], '', 0.01);
+        $this->assertEquals('East London', $results[3]['city']);
+        $this->assertEquals('Buffalo City Metropolitan Municipality', $results[3]['county']);
+        $this->assertEquals('Eastern Cape', $results[3]['region']);
+        $this->assertEquals('South Africa', $results[3]['country']);
+        $this->assertEquals('ZA', $results[3]['countryCode']);
+        $this->assertEquals('Africa/Johannesburg', $results[3]['timezone']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(41.3556539, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(-72.0995209, $results[4]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[4]['bounds']);
+        $this->assertArrayHasKey('west', $results[4]['bounds']);
+        $this->assertArrayHasKey('north', $results[4]['bounds']);
+        $this->assertArrayHasKey('east', $results[4]['bounds']);
+        $this->assertEquals(41.334087887904, $results[4]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-72.128261254846, $results[4]['bounds']['west'], '', 0.01);
+        $this->assertEquals(41.377219912096, $results[4]['bounds']['north'], '', 0.01);
+        $this->assertEquals(-72.070780545154, $results[4]['bounds']['east'], '', 0.01);
+        $this->assertEquals('New London', $results[4]['city']);
+        $this->assertEquals('New London County', $results[4]['county']);
+        $this->assertEquals('Connecticut', $results[4]['region']);
+        $this->assertEquals('United States', $results[4]['country']);
+        $this->assertEquals('US', $results[4]['countryCode']);
+        $this->assertEquals('America/New_York', $results[4]['timezone']);
     }
 
     public function testGetGeocodedDataWithRealPlaceWithLocale()
@@ -114,24 +190,100 @@ JSON;
         }
 
         $provider = new GeonamesProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['GEONAMES_USERNAME'], 'it_IT');
-        $result   = $provider->getGeocodedData('London');
+        $results  = $provider->getGeocodedData('London');
 
-        $this->assertEquals(51.50853, $result['latitude'], '', 0.01);
-        $this->assertEquals(-0.12574, $result['longitude'], '', 0.01);
-        $this->assertArrayHasKey('south', $result['bounds']);
-        $this->assertArrayHasKey('west', $result['bounds']);
-        $this->assertArrayHasKey('north', $result['bounds']);
-        $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(51.15169, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(-0.70361, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(51.86537, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(0.45212, $result['bounds']['east'], '', 0.01);
-        $this->assertEquals('Londra', $result['city']);
-        $this->assertEquals('Greater London', $result['county']);   // the webservice returns the same as default
-        $this->assertEquals('Inghilterra', $result['region']);
-        $this->assertEquals('Regno Unito', $result['country']);
-        $this->assertEquals('GB', $result['countryCode']);
-        $this->assertEquals('Europe/London', $result['timezone']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(51.50853, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(-0.12574, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(51.15169, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-0.70361, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(51.86537, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(0.45212, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertEquals('Londra', $results[0]['city']);
+        $this->assertEquals('Greater London', $results[0]['county']);
+        $this->assertEquals('Inghilterra', $results[0]['region']);
+        $this->assertEquals('Regno Unito', $results[0]['country']);
+        $this->assertEquals('GB', $results[0]['countryCode']);
+        $this->assertEquals('Europe/London', $results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(51.512788890295, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(-0.091838836669922, $results[1]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertEquals(51.155949512764, $results[1]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-0.66976046752962, $results[1]['bounds']['west'], '', 0.01);
+        $this->assertEquals(51.869628267826, $results[1]['bounds']['north'], '', 0.01);
+        $this->assertEquals(0.48608279418978, $results[1]['bounds']['east'], '', 0.01);
+        $this->assertEquals('City of London', $results[1]['city']);
+        $this->assertEquals('Greater London', $results[1]['county']);
+        $this->assertEquals('Inghilterra', $results[1]['region']);
+        $this->assertEquals('Regno Unito', $results[1]['country']);
+        $this->assertEquals('GB', $results[1]['countryCode']);
+        $this->assertEquals('Europe/London', $results[1]['timezone']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(42.983389283, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(-81.233042387, $results[2]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[2]['bounds']);
+        $this->assertArrayHasKey('west', $results[2]['bounds']);
+        $this->assertArrayHasKey('north', $results[2]['bounds']);
+        $this->assertArrayHasKey('east', $results[2]['bounds']);
+        $this->assertEquals(42.907075642763, $results[2]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-81.337489676463, $results[2]['bounds']['west'], '', 0.01);
+        $this->assertEquals(43.059702923237, $results[2]['bounds']['north'], '', 0.01);
+        $this->assertEquals(-81.128595097537, $results[2]['bounds']['east'], '', 0.01);
+        $this->assertEquals('London', $results[2]['city']);
+        $this->assertEquals('', $results[2]['county']);
+        $this->assertEquals('Ontario', $results[2]['region']);
+        $this->assertEquals('Canada', $results[2]['country']);
+        $this->assertEquals('CA', $results[2]['countryCode']);
+        $this->assertEquals('America/Toronto', $results[2]['timezone']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(-33.015285093464, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(27.911624908447, $results[3]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[3]['bounds']);
+        $this->assertArrayHasKey('west', $results[3]['bounds']);
+        $this->assertArrayHasKey('north', $results[3]['bounds']);
+        $this->assertArrayHasKey('east', $results[3]['bounds']);
+        $this->assertEquals(-33.104996458003, $results[3]['bounds']['south'], '', 0.01);
+        $this->assertEquals(27.804746435655, $results[3]['bounds']['west'], '', 0.01);
+        $this->assertEquals(-32.925573728925, $results[3]['bounds']['north'], '', 0.01);
+        $this->assertEquals(28.018503381239, $results[3]['bounds']['east'], '', 0.01);
+        $this->assertEquals('East London', $results[3]['city']);
+        $this->assertEquals('Buffalo City Metropolitan Municipality', $results[3]['county']);
+        $this->assertEquals('Eastern Cape', $results[3]['region']);
+        $this->assertEquals('Sudafrica', $results[3]['country']);
+        $this->assertEquals('ZA', $results[3]['countryCode']);
+        $this->assertEquals('Africa/Johannesburg', $results[3]['timezone']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(41.3556539, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(-72.0995209, $results[4]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[4]['bounds']);
+        $this->assertArrayHasKey('west', $results[4]['bounds']);
+        $this->assertArrayHasKey('north', $results[4]['bounds']);
+        $this->assertArrayHasKey('east', $results[4]['bounds']);
+        $this->assertEquals(41.334087887904, $results[4]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-72.128261254846, $results[4]['bounds']['west'], '', 0.01);
+        $this->assertEquals(41.377219912096, $results[4]['bounds']['north'], '', 0.01);
+        $this->assertEquals(-72.070780545154, $results[4]['bounds']['east'], '', 0.01);
+        $this->assertEquals('New London', $results[4]['city']);
+        $this->assertEquals('New London County', $results[4]['county']);
+        $this->assertEquals('Connecticut', $results[4]['region']);
+        $this->assertEquals('Stati Uniti', $results[4]['country']);
+        $this->assertEquals('US', $results[4]['countryCode']);
+        $this->assertEquals('America/New_York', $results[4]['timezone']);
     }
 
     public function testGetReversedDataWithRealCoordinates()
@@ -141,8 +293,13 @@ JSON;
         }
 
         $provider = new GeonamesProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['GEONAMES_USERNAME']);
-        $result   = $provider->getReversedData(array(51.50853, -0.12574));
+        $results  = $provider->getReversedData(array(51.50853, -0.12574));
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(51.50853, $result['latitude'], '', 0.01);
         $this->assertEquals(-0.12574, $result['longitude'], '', 0.01);
         $this->assertEquals('London', $result['city']);
@@ -159,9 +316,14 @@ JSON;
             $this->markTestSkipped('You need to configure the GEONAMES_USERNAME value in phpunit.xml');
         }
 
-        $provider = new GeonamesProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['GEONAMES_USERNAME'], "it_IT");
-        $result   = $provider->getReversedData(array(51.50853, -0.12574));
+        $provider = new GeonamesProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['GEONAMES_USERNAME'], 'it_IT');
+        $results  = $provider->getReversedData(array(51.50853, -0.12574));
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(51.50853, $result['latitude'], '', 0.01);
         $this->assertEquals(-0.12574, $result['longitude'], '', 0.01);
         $this->assertEquals('Londra', $result['city']);
@@ -174,7 +336,7 @@ JSON;
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://api.geonames.org/findNearbyPlaceNameJSON?lat=-80.000000&lng=-170.000000&style=full&maxRows=1&username=username
+     * @expectedExceptionMessage Could not execute query http://api.geonames.org/findNearbyPlaceNameJSON?lat=-80.000000&lng=-170.000000&style=full&maxRows=5&username=username
      */
     public function testGetReversedDataWithBadCoordinates()
     {

--- a/tests/Geocoder/Tests/Provider/GoogleMapsProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GoogleMapsProviderTest.php
@@ -106,8 +106,13 @@ class GoogleMapsProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddress()
     {
         $provider = new GoogleMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'fr-FR', 'Île-de-France');
-        $result   = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
+        $results  = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(48.8630462, $result['latitude'], '', 0.001);
         $this->assertEquals(2.3882487, $result['longitude'], '', 0.001);
         $this->assertArrayHasKey('south', $result['bounds']);
@@ -134,8 +139,13 @@ class GoogleMapsProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddressWithSsl()
     {
         $provider = new GoogleMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), null, null, true);
-        $result   = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
+        $results  = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(48.8630462, $result['latitude'], '', 0.001);
         $this->assertEquals(2.3882487, $result['longitude'], '', 0.001);
         $this->assertArrayHasKey('south', $result['bounds']);
@@ -162,8 +172,13 @@ class GoogleMapsProviderTest extends TestCase
     public function testGetGeocodedDataBoundsWithRealAddressForNonRooftopLocation()
     {
         $provider = new GoogleMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('Paris, France');
+        $results  = $provider->getGeocodedData('Paris, France');
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertNotNull($result['bounds']);
         $this->assertArrayHasKey('south', $result['bounds']);
         $this->assertArrayHasKey('west', $result['bounds']);
@@ -173,6 +188,50 @@ class GoogleMapsProviderTest extends TestCase
         $this->assertEquals(2.224199, $result['bounds']['west'], '', 0.0001);
         $this->assertEquals(48.902145, $result['bounds']['north'], '', 0.0001);
         $this->assertEquals(2.4699209, $result['bounds']['east'], '', 0.0001);
+    }
+
+    public function testGetGeocodedDataWithRealAddressReturnsMultipleResults()
+    {
+        $provider = new GoogleMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
+        $results  = $provider->getGeocodedData('Paris');
+
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.856614, $results[0]['latitude'], '', 0.001);
+        $this->assertEquals(2.3522219, $results[0]['longitude'], '', 0.001);
+        $this->assertEquals('Paris', $results[0]['city']);
+        $this->assertEquals('France', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(33.6609389, $results[1]['latitude'], '', 0.001);
+        $this->assertEquals(-95.555513, $results[1]['longitude'], '', 0.001);
+        $this->assertEquals('Paris', $results[1]['city']);
+        $this->assertEquals('United States', $results[1]['country']);
+        $this->assertEquals('US', $results[1]['countryCode']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(36.3020023, $results[2]['latitude'], '', 0.001);
+        $this->assertEquals(-88.3267107, $results[2]['longitude'], '', 0.001);
+        $this->assertEquals('Paris', $results[2]['city']);
+        $this->assertEquals('United States', $results[2]['country']);
+        $this->assertEquals('US', $results[2]['countryCode']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(39.611146, $results[3]['latitude'], '', 0.001);
+        $this->assertEquals(-87.6961374, $results[3]['longitude'], '', 0.001);
+        $this->assertEquals('Paris', $results[3]['city']);
+        $this->assertEquals('United States', $results[3]['country']);
+        $this->assertEquals('US', $results[3]['countryCode']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(38.2097987, $results[4]['latitude'], '', 0.001);
+        $this->assertEquals(-84.2529869, $results[4]['longitude'], '', 0.001);
+        $this->assertEquals('Paris', $results[4]['city']);
+        $this->assertEquals('United States', $results[4]['country']);
+        $this->assertEquals('US', $results[4]['countryCode']);
     }
 
     /**
@@ -190,6 +249,11 @@ class GoogleMapsProviderTest extends TestCase
         $provider = new GoogleMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getReversedData(array(48.8631507, 2.388911));
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(10, $result['streetNumber']);
         $this->assertEquals('Avenue Gambetta', $result['streetName']);
         $this->assertEquals(75020, $result['zipcode']);
@@ -213,8 +277,13 @@ class GoogleMapsProviderTest extends TestCase
     public function testGetGeocodedDataWithCityDistrict()
     {
         $provider = new GoogleMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('Kalbacher Hauptstraße 10, 60437 Frankfurt, Germany');
+        $results  = $provider->getGeocodedData('Kalbacher Hauptstraße 10, 60437 Frankfurt, Germany');
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('Kalbach-Riedberg', $result['cityDistrict']);
     }
 }

--- a/tests/Geocoder/Tests/Provider/HostIpProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/HostIpProviderTest.php
@@ -46,8 +46,13 @@ class HostIpProviderTest extends TestCase
     public function testGetGeocodedDataWithLocalhostIPv4()
     {
         $provider = new HostIpProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('127.0.0.1');
+        $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -66,12 +71,12 @@ class HostIpProviderTest extends TestCase
     public function testGetGeocodedDataWithLocalhostIPv6()
     {
         $provider = new HostIpProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('::1');
+        $provider->getGeocodedData('::1');
     }
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://api.hostip.info/get_xml.php?ip=88.188.221.14&position=true
+     * @expectedExceptionMessage Could not execute query http://api.hostip.info/get_json.php?ip=88.188.221.14&position=true
      */
     public function testGetGeocodedDataWithRealIPv4GetsNullContent()
     {
@@ -81,7 +86,7 @@ class HostIpProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://api.hostip.info/get_xml.php?ip=88.188.221.14&position=true
+     * @expectedExceptionMessage Could not execute query http://api.hostip.info/get_json.php?ip=88.188.221.14&position=true
      */
     public function testGetGeocodedDataWithRealIPv4GetsEmptyContent()
     {
@@ -94,6 +99,11 @@ class HostIpProviderTest extends TestCase
         $provider = new HostIpProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('88.188.221.14');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(45.5333, $result['latitude'], '', 0.0001);
         $this->assertEquals(2.6167, $result['longitude'], '', 0.0001);
         $this->assertNull($result['zipcode']);
@@ -110,7 +120,7 @@ class HostIpProviderTest extends TestCase
     public function testGetGeocodedDataWithRealIPv6()
     {
         $provider = new HostIpProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('::ffff:88.188.221.14');
+        $provider->getGeocodedData('::ffff:88.188.221.14');
     }
 
     /**
@@ -126,8 +136,13 @@ class HostIpProviderTest extends TestCase
     public function testGetGeocodedDataWithAnotherIp()
     {
         $provider = new HostIpProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('33.33.33.22');
+        $result   = $provider->getGeocodedData('33.33.33.22');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertNull($result['latitude']);
         $this->assertNull($result['longitude']);
     }

--- a/tests/Geocoder/Tests/Provider/IGNOpenLSProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/IGNOpenLSProviderTest.php
@@ -24,7 +24,7 @@ class IGNOpenLSProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=json&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%221%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3Efoobar%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
+     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3Efoobar%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
     public function testGetGeocodedData()
     {
@@ -34,7 +34,7 @@ class IGNOpenLSProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=json&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%221%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
+     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
     public function testGetGeocodedDataWithNull()
     {
@@ -44,7 +44,7 @@ class IGNOpenLSProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=json&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%221%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
+     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
     public function testGetGeocodedDataWithEmpty()
     {
@@ -54,7 +54,7 @@ class IGNOpenLSProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=json&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%221%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E36+Quai+des+Orf%C3%A8vres%2C+Paris%2C+France%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
+     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E36+Quai+des+Orf%C3%A8vres%2C+Paris%2C+France%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
     public function testGetGeocodedDataWithAddressGetsNullContent()
     {
@@ -64,75 +64,269 @@ class IGNOpenLSProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=json&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%221%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E36+Quai+des+Orf%C3%A8vres%2C+Paris%2C+France%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
-     */
-    public function testGetGeocodedDataWithAddressGetsEmptyContent()
-    {
-        $emptyContent = '{"http":{"status":200,"error":null}, "xml":null}';
-        $provider = new IGNOpenLSProvider($this->getMockAdapterReturns($emptyContent), 'api_key');
-        $provider->getGeocodedData('36 Quai des Orfèvres, Paris, France');
-    }
-
-    /**
-     * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=json&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%221%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E36+Quai+des+Orf%C3%A8vres%2C+Paris%2C+France%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
-     */
-    public function testGetGeocodedDataWithAddressGetsStatus403Content()
-    {
-        $status403Content = '{"http":{"status":403,"error":null}, "xml":"<EmptyContent></EmptyContent>"}';
-        $provider = new IGNOpenLSProvider($this->getMockAdapterReturns($status403Content), 'api_key');
-        $provider->getGeocodedData('36 Quai des Orfèvres, Paris, France');
-    }
-
-    /**
-     * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=json&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%221%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E36+Quai+des+Orf%C3%A8vres%2C+Paris%2C+France%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
+     * @expectedMessage Could not execute query http://gpp3-wxs.ign.fr/jqljhusfrcl0c3w1int0dzhd/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3Efoobar%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
     public function testGetGeocodedDataWithAddressGetsErrorContent()
     {
-        $errorContent = '{"http":{"status":200,"error":"<ErrorContent></ErrorContent>"}, "xml":"<EmptyContent></EmptyContent>"}';
-        $provider = new IGNOpenLSProvider($this->getMockAdapterReturns($errorContent), 'api_key');
-        $provider->getGeocodedData('36 Quai des Orfèvres, Paris, France');
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<XLS version="1.2" xsi:schemaLocation="http://gpp3-wxs.ign.fr/schemas/olsAll.xsd" xmlns:xls="http://www.opengis.net/xls" xmlns="http://www.opengis.net/xls" xmlns:xlsext="http://www.opengis.net/xlsext" xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <ResponseHeader/>
+    <Response version="1.2">
+        <GeocodeResponse>
+            <GeocodeResponseList numberOfGeocodedAddresses="0"/>
+        </GeocodeResponse>
+    </Response>
+</XLS>
+XML;
+
+        $provider = new IGNOpenLSProvider($this->getMockAdapterReturns($xml), 'api_key');
+        $provider->getGeocodedData('foobar');
     }
 
-    public function testGetGeocodedDataWithRealAddressOne()
+    public function testGetGeocodedDataReturnsMultipleResults()
     {
-        if (!isset($_SERVER['IGN_WEB_API_KEY'])) {
-            $this->markTestSkipped('You need to configure the IGN_WEB_API_KEY value in phpunit.xml');
-        }
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<XLS version="1.2" xsi:schemaLocation="http://gpp3-wxs.ign.fr/schemas/olsAll.xsd" xmlns:xls="http://www.opengis.net/xls" xmlns="http://www.opengis.net/xls" xmlns:xlsext="http://www.opengis.net/xlsext" xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <ResponseHeader/>
+    <Response version="1.2">
+        <GeocodeResponse>
+            <GeocodeResponseList numberOfGeocodedAddresses="5">
+                <GeocodedAddress>
+                    <gml:Point>
+                        <gml:pos>48.855471 2.343021</gml:pos>
+                    </gml:Point>
+                    <Address countryCode="StreetAddress">
+                        <StreetAddress>
+                            <Building number="36"/>
+                            <Street>qu des orfevres</Street>
+                        </StreetAddress>
+                        <Place type="Municipality">Paris</Place>
+                        <Place type="Qualite">Plaque adresse</Place>
+                        <Place type="Departement">75</Place>
+                        <Place type="Commune">Paris</Place>
+                        <Place type="Territoire">FXX</Place>
+                        <PostalCode>75001</PostalCode>
+                    </Address>
+                    <GeocodeMatchCode matchType="Street number" accuracy="0.8039562614314194"/>
+                </GeocodedAddress>
+                <GeocodedAddress>
+                    <gml:Point>
+                        <gml:pos>48.858515 2.345263</gml:pos>
+                    </gml:Point>
+                    <Address countryCode="StreetAddress">
+                        <StreetAddress>
+                            <Street>r des orfevres</Street>
+                        </StreetAddress>
+                        <Place type="Municipality">Paris</Place>
+                        <Place type="Qualite">2.5</Place>
+                        <Place type="Departement">75</Place>
+                        <Place type="Bbox">2.345118;48.858219;2.345409;48.858812</Place>
+                        <Place type="Commune">Paris</Place>
+                        <Place type="Territoire">FXX</Place>
+                        <PostalCode>75001</PostalCode>
+                    </Address>
+                    <GeocodeMatchCode matchType="Street" accuracy="0.6479110861835901"/>
+                </GeocodedAddress>
+                <GeocodedAddress>
+                    <gml:Point>
+                        <gml:pos>48.856667 2.349042</gml:pos>
+                    </gml:Point>
+                    <Address countryCode="StreetAddress">
+                        <StreetAddress>
+                            <Street>qu de gesvres</Street>
+                        </StreetAddress>
+                        <Place type="Municipality">Paris</Place>
+                        <Place type="Qualite">2.5</Place>
+                        <Place type="Departement">75</Place>
+                        <Place type="Bbox">2.348926;48.856494;2.349495;48.856712</Place>
+                        <Place type="Commune">Paris</Place>
+                        <Place type="Territoire">FXX</Place>
+                        <PostalCode>75004</PostalCode>
+                    </Address>
+                    <GeocodeMatchCode matchType="Street" accuracy="0.5286360630901586"/>
+                </GeocodedAddress>
+                <GeocodedAddress>
+                    <gml:Point>
+                        <gml:pos>48.835584 2.278107</gml:pos>
+                    </gml:Point>
+                    <Address countryCode="StreetAddress">
+                        <StreetAddress>
+                            <Street>av de la porte de sevres</Street>
+                        </StreetAddress>
+                        <Place type="Municipality">Paris</Place>
+                        <Place type="Qualite">1.5</Place>
+                        <Place type="Departement">75</Place>
+                        <Place type="Bbox">2.277803;48.834961;2.278267;48.836012</Place>
+                        <Place type="Commune">Paris</Place>
+                        <Place type="Territoire">FXX</Place>
+                        <PostalCode>75015</PostalCode>
+                    </Address>
+                    <GeocodeMatchCode matchType="Street" accuracy="0.41724411983729437"/>
+                </GeocodedAddress>
+                <GeocodedAddress>
+                    <gml:Point>
+                        <gml:pos>48.849953 2.323454</gml:pos>
+                    </gml:Point>
+                    <Address countryCode="StreetAddress">
+                        <StreetAddress>
+                            <Building number="36"/>
+                            <Street>r de sevres</Street>
+                        </StreetAddress>
+                        <Place type="Municipality">Paris</Place>
+                        <Place type="Qualite">Tronçon</Place>
+                        <Place type="Departement">75</Place>
+                        <Place type="Commune">Paris</Place>
+                        <Place type="Territoire">FXX</Place>
+                        <PostalCode>75007</PostalCode>
+                    </Address>
+                    <GeocodeMatchCode matchType="Street number" accuracy="0.4161277782207547"/>
+                </GeocodedAddress>
+            </GeocodeResponseList>
+        </GeocodeResponse>
+    </Response>
+</XLS>
+XML;
 
-        $provider = new IGNOpenLSProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['IGN_WEB_API_KEY']);
-        $result = $provider->getGeocodedData('36 Quai des Orfèvres, 75001 Paris, France');
+        $provider = new IGNOpenLSProvider($this->getMockAdapterReturns($xml), 'api_key');
+        $results  = $provider->getGeocodedData('36 Quai des Orfèvres, 75001 Paris, France');
 
-        $this->assertEquals(48.855471, $result['latitude'], '', 0.0001);
-        $this->assertEquals(2.343021, $result['longitude'], '', 0.0001);
-        $this->assertEquals(36, $result['streetNumber']);
-        $this->assertEquals('qu des orfevres', $result['streetName']);
-        $this->assertEquals(75001, $result['zipcode']);
-        $this->assertEquals('Paris', $result['city']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.855471, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(2.343021, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertEquals(48.858812, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.345409, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertEquals(48.858219, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.345118, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(36, $results[0]['streetNumber']);
+        $this->assertEquals('qu des orfevres', $results[0]['streetName']);
+        $this->assertEquals('qu des orfevres', $results[0]['cityDistrict']);
+        $this->assertEquals(75001, $results[0]['zipcode']);
+        $this->assertEquals('Paris', $results[0]['city']);
 
         // hard-coded
-        $this->assertEquals('France', $result['country']);
-        $this->assertEquals('FR', $result['countryCode']);
-        $this->assertEquals('Europe/Paris', $result['timezone']);
+        $this->assertEquals('France', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
+        $this->assertEquals('Europe/Paris', $results[0]['timezone']);
 
         // not provided
-        $this->assertNull($result['bounds']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
+        $this->assertNull($results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(48.858515, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(2.345263, $results[1]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertEquals(48.856712, $results[1]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.349495, $results[1]['bounds']['east'], '', 0.01);
+        $this->assertEquals(48.856494, $results[1]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.348926, $results[1]['bounds']['west'], '', 0.01);
+        $this->assertEquals(36, $results[1]['streetNumber']);
+        $this->assertEquals('r des orfevres', $results[1]['streetName']);
+        $this->assertEquals('r des orfevres', $results[1]['cityDistrict']);
+        $this->assertEquals(75001, $results[1]['zipcode']);
+        $this->assertEquals('Paris', $results[1]['city']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(48.856667, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(2.349042, $results[2]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('north', $results[2]['bounds']);
+        $this->assertArrayHasKey('east', $results[2]['bounds']);
+        $this->assertArrayHasKey('south', $results[2]['bounds']);
+        $this->assertArrayHasKey('west', $results[2]['bounds']);
+        $this->assertEquals(48.836012, $results[2]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.278267, $results[2]['bounds']['east'], '', 0.01);
+        $this->assertEquals(48.834961, $results[2]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.277803, $results[2]['bounds']['west'], '', 0.01);
+        $this->assertnull($results[2]['streetNumber']);
+        $this->assertEquals('qu de gesvres', $results[2]['streetName']);
+        $this->assertEquals('qu de gesvres', $results[2]['cityDistrict']);
+        $this->assertEquals(75004, $results[2]['zipcode']);
+        $this->assertEquals('Paris', $results[2]['city']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(48.835584, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(2.278107, $results[3]['longitude'], '', 0.01);
+        $this->assertNull($results[3]['bounds']);
+        $this->assertnull($results[3]['streetNumber']);
+        $this->assertEquals('av de la porte de sevres', $results[3]['streetName']);
+        $this->assertEquals('av de la porte de sevres', $results[3]['cityDistrict']);
+        $this->assertEquals(75015, $results[3]['zipcode']);
+        $this->assertEquals('Paris', $results[3]['city']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(48.849953, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(2.323454, $results[4]['longitude'], '', 0.01);
+        $this->assertNull($results[4]['bounds']);
+        $this->assertnull($results[4]['streetNumber']);
+        $this->assertEquals('r de sevres', $results[4]['streetName']);
+        $this->assertEquals('r de sevres', $results[4]['cityDistrict']);
+        $this->assertEquals(75007, $results[4]['zipcode']);
+        $this->assertEquals('Paris', $results[4]['city']);
     }
 
-    public function testGetGeocodedDataWithRealAddressTwo()
+    public function testGetGeocodedDataReturnsSingleResult()
     {
-        if (!isset($_SERVER['IGN_WEB_API_KEY'])) {
-            $this->markTestSkipped('You need to configure the IGN_WEB_API_KEY value in phpunit.xml');
-        }
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<XLS version="1.2" xsi:schemaLocation="http://gpp3-wxs.ign.fr/schemas/olsAll.xsd" xmlns:xls="http://www.opengis.net/xls" xmlns="http://www.opengis.net/xls" xmlns:xlsext="http://www.opengis.net/xlsext" xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <ResponseHeader/>
+    <Response version="1.2">
+        <GeocodeResponse>
+            <GeocodeResponseList numberOfGeocodedAddresses="1">
+                <GeocodedAddress>
+                    <gml:Point>
+                        <gml:pos>49.100976 6.216957</gml:pos>
+                    </gml:Point>
+                    <Address countryCode="StreetAddress">
+                        <StreetAddress>
+                            <Street>r marconi</Street>
+                        </StreetAddress>
+                        <Place type="Municipality">Metz</Place>
+                        <Place type="Qualite">2.5</Place>
+                        <Place type="Departement">57</Place>
+                        <Place type="Bbox">6.215960;49.100595;6.217397;49.102511</Place>
+                        <Place type="Commune">Metz</Place>
+                        <Place type="Territoire">FXX</Place>
+                        <PostalCode>57000</PostalCode>
+                    </Address>
+                    <GeocodeMatchCode matchType="Street" accuracy="1.0"/>
+                </GeocodedAddress>
+            </GeocodeResponseList>
+        </GeocodeResponse>
+    </Response>
+</XLS>
+XML;
 
-        $provider = new IGNOpenLSProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['IGN_WEB_API_KEY']);
-        $result = $provider->getGeocodedData('Rue Marconi 57000 Metz');
+        $provider = new IGNOpenLSProvider($this->getMockAdapterReturns($xml), 'api_key');
+        $results  = $provider->getGeocodedData('Rue Marconi 57000 Metz');
 
-        $this->assertEquals(49.100976, $result['latitude'], '', 0.0001);
-        $this->assertEquals(6.216957, $result['longitude'], '', 0.0001);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
+        $this->assertEquals(49.100976, $result['latitude'], '', 0.01);
+        $this->assertEquals(6.216957, $result['longitude'], '', 0.01);
+        $this->assertArrayHasKey('north', $result['bounds']);
+        $this->assertArrayHasKey('east', $result['bounds']);
+        $this->assertArrayHasKey('south', $result['bounds']);
+        $this->assertArrayHasKey('west', $result['bounds']);
+        $this->assertEquals(49.102511, $result['bounds']['north'], '', 0.01);
+        $this->assertEquals(6.217397, $result['bounds']['east'], '', 0.01);
+        $this->assertEquals(49.100595, $result['bounds']['south'], '', 0.01);
+        $this->assertEquals(6.215960, $result['bounds']['west'], '', 0.01);
         $this->assertNull($result['streetNumber']);
         $this->assertEquals('r marconi', $result['streetName']);
         $this->assertEquals(57000, $result['zipcode']);
@@ -144,7 +338,138 @@ class IGNOpenLSProviderTest extends TestCase
         $this->assertEquals('Europe/Paris', $result['timezone']);
 
         // not provided
-        $this->assertNull($result['bounds']);
+        $this->assertNull($result['region']);
+        $this->assertNull($result['regionCode']);
+    }
+
+    public function testGetGeocodedDataWithRealAddressReturnsMultipleResults()
+    {
+        if (!isset($_SERVER['IGN_WEB_API_KEY'])) {
+            $this->markTestSkipped('You need to configure the IGN_WEB_API_KEY value in phpunit.xml');
+        }
+
+        $provider = new IGNOpenLSProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['IGN_WEB_API_KEY']);
+        $results  = $provider->getGeocodedData('36 Quai des Orfèvres, 75001 Paris, France');
+
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.855471, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(2.343021, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertEquals(48.858812, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.345409, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertEquals(48.858219, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.345118, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(36, $results[0]['streetNumber']);
+        $this->assertEquals('qu des orfevres', $results[0]['streetName']);
+        $this->assertEquals('qu des orfevres', $results[0]['cityDistrict']);
+        $this->assertEquals(75001, $results[0]['zipcode']);
+        $this->assertEquals('Paris', $results[0]['city']);
+
+        // hard-coded
+        $this->assertEquals('France', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
+        $this->assertEquals('Europe/Paris', $results[0]['timezone']);
+
+        // not provided
+        $this->assertNull($results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(48.858515, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(2.345263, $results[1]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertEquals(48.856712, $results[1]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.349495, $results[1]['bounds']['east'], '', 0.01);
+        $this->assertEquals(48.856494, $results[1]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.348926, $results[1]['bounds']['west'], '', 0.01);
+        $this->assertEquals(36, $results[1]['streetNumber']);
+        $this->assertEquals('r des orfevres', $results[1]['streetName']);
+        $this->assertEquals('r des orfevres', $results[1]['cityDistrict']);
+        $this->assertEquals(75001, $results[1]['zipcode']);
+        $this->assertEquals('Paris', $results[1]['city']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(48.856667, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(2.349042, $results[2]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('north', $results[2]['bounds']);
+        $this->assertArrayHasKey('east', $results[2]['bounds']);
+        $this->assertArrayHasKey('south', $results[2]['bounds']);
+        $this->assertArrayHasKey('west', $results[2]['bounds']);
+        $this->assertEquals(48.836012, $results[2]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.278267, $results[2]['bounds']['east'], '', 0.01);
+        $this->assertEquals(48.834961, $results[2]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.277803, $results[2]['bounds']['west'], '', 0.01);
+        $this->assertnull($results[2]['streetNumber']);
+        $this->assertEquals('qu de gesvres', $results[2]['streetName']);
+        $this->assertEquals('qu de gesvres', $results[2]['cityDistrict']);
+        $this->assertEquals(75004, $results[2]['zipcode']);
+        $this->assertEquals('Paris', $results[2]['city']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(48.835584, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(2.278107, $results[3]['longitude'], '', 0.01);
+        $this->assertNull($results[3]['bounds']);
+        $this->assertnull($results[3]['streetNumber']);
+        $this->assertEquals('av de la porte de sevres', $results[3]['streetName']);
+        $this->assertEquals('av de la porte de sevres', $results[3]['cityDistrict']);
+        $this->assertEquals(75015, $results[3]['zipcode']);
+        $this->assertEquals('Paris', $results[3]['city']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(48.849953, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(2.323454, $results[4]['longitude'], '', 0.01);
+        $this->assertNull($results[4]['bounds']);
+        $this->assertnull($results[4]['streetNumber']);
+        $this->assertEquals('r de sevres', $results[4]['streetName']);
+        $this->assertEquals('r de sevres', $results[4]['cityDistrict']);
+        $this->assertEquals(75007, $results[4]['zipcode']);
+        $this->assertEquals('Paris', $results[4]['city']);
+    }
+
+    public function testGetGeocodedDataWithRealAddressReturnsSingleResult()
+    {
+        if (!isset($_SERVER['IGN_WEB_API_KEY'])) {
+            $this->markTestSkipped('You need to configure the IGN_WEB_API_KEY value in phpunit.xml');
+        }
+
+        $provider = new IGNOpenLSProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['IGN_WEB_API_KEY']);
+        $results  = $provider->getGeocodedData('Rue Marconi 57000 Metz');
+
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
+        $this->assertEquals(49.100976, $result['latitude'], '', 0.01);
+        $this->assertEquals(6.216957, $result['longitude'], '', 0.01);
+        $this->assertArrayHasKey('north', $result['bounds']);
+        $this->assertArrayHasKey('east', $result['bounds']);
+        $this->assertArrayHasKey('south', $result['bounds']);
+        $this->assertArrayHasKey('west', $result['bounds']);
+        $this->assertEquals(49.102511, $result['bounds']['north'], '', 0.01);
+        $this->assertEquals(6.217397, $result['bounds']['east'], '', 0.01);
+        $this->assertEquals(49.100595, $result['bounds']['south'], '', 0.01);
+        $this->assertEquals(6.215960, $result['bounds']['west'], '', 0.01);
+        $this->assertNull($result['streetNumber']);
+        $this->assertEquals('r marconi', $result['streetName']);
+        $this->assertEquals(57000, $result['zipcode']);
+        $this->assertEquals('Metz', $result['city']);
+
+        // hard-coded
+        $this->assertEquals('France', $result['country']);
+        $this->assertEquals('FR', $result['countryCode']);
+        $this->assertEquals('Europe/Paris', $result['timezone']);
+
+        // not provided
         $this->assertNull($result['region']);
         $this->assertNull($result['regionCode']);
     }

--- a/tests/Geocoder/Tests/Provider/IpGeoBaseProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/IpGeoBaseProviderTest.php
@@ -49,8 +49,13 @@ class IpGeoBaseProviderTest extends TestCase
     public function testGetGeocodedDataWithLocalhostIPv4()
     {
         $provider = new IpGeoBaseProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('127.0.0.1');
+        $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -97,6 +102,11 @@ class IpGeoBaseProviderTest extends TestCase
         $provider = new IpGeoBaseProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('144.206.192.6');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(55.755787, $result['latitude'], '', 0.001);
         $this->assertEquals(37.617634, $result['longitude'], '', 0.001);
         $this->assertNull($result['streetNumber']);
@@ -116,6 +126,11 @@ class IpGeoBaseProviderTest extends TestCase
         $provider = new IpGeoBaseProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getGeocodedData('2.56.176.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(50.450001, $result['latitude'], '', 0.001);
         $this->assertEquals(30.523333, $result['longitude'], '', 0.001);
         $this->assertNull($result['streetNumber']);
@@ -137,7 +152,7 @@ class IpGeoBaseProviderTest extends TestCase
     public function testGetGeocodedDataWithRealIPv6()
     {
         $provider = new IpGeoBaseProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('::ffff:88.188.221.14');
+        $provider->getGeocodedData('::ffff:88.188.221.14');
     }
 
     /**

--- a/tests/Geocoder/Tests/Provider/IpInfoDbProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/IpInfoDbProviderTest.php
@@ -67,6 +67,11 @@ class IpInfoDbProviderTest extends TestCase
         $provider = new IpInfoDbProvider($this->getMockAdapter($this->never()), 'api_key');
         $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -117,6 +122,11 @@ class IpInfoDbProviderTest extends TestCase
         $provider = new IpInfoDbProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['IPINFODB_API_KEY']);
         $result   = $provider->getGeocodedData('74.125.45.100');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(37.406, $result['latitude'], '', 0.001);
         $this->assertEquals(-122.079, $result['longitude'], '', 0.001);
         $this->assertEquals(94043, $result['zipcode']);

--- a/tests/Geocoder/Tests/Provider/MapQuestProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/MapQuestProviderTest.php
@@ -18,7 +18,7 @@ class MapQuestProviderTest extends TestCase
 
     /**
      * @expectedException Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not find results for given query: http://open.mapquestapi.com/geocoding/v1/address?location=foobar&outFormat=json&maxResults=1&thumbMaps=fals
+     * @expectedExceptionMessage Could not find results for given query: http://open.mapquestapi.com/geocoding/v1/address?location=foobar&outFormat=json&maxResults=5&thumbMaps=fals
      */
     public function testGetGeocodedData()
     {
@@ -28,7 +28,7 @@ class MapQuestProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://open.mapquestapi.com/geocoding/v1/address?location=10+avenue+Gambetta%2C+Paris%2C+France&outFormat=json&maxResults=1&thumbMaps=false
+     * @expectedExceptionMessage Could not execute query http://open.mapquestapi.com/geocoding/v1/address?location=10+avenue+Gambetta%2C+Paris%2C+France&outFormat=json&maxResults=5&thumbMaps=false
      */
     public function testGetGeocodedDataWithAddressGetsNullContent()
     {
@@ -39,8 +39,13 @@ class MapQuestProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddress()
     {
         $provider = new MapQuestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
+        $results  = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(48.866205, $result['latitude'], '', 0.01);
         $this->assertEquals(2.389089, $result['longitude'], '', 0.01);
         $this->assertNull($result['bounds']);
@@ -63,20 +68,7 @@ class MapQuestProviderTest extends TestCase
     public function testGetReversedData()
     {
         $provider = new MapQuestProvider($this->getMockAdapter());
-        $result   = $provider->getReversedData(array(1, 2));
-
-        $this->assertNull($result['latitude']);
-        $this->assertNull($result['longitude']);
-        $this->assertNull($result['bounds']);
-        $this->assertNull($result['streetNumber']);
-        $this->assertNull($result['streetName']);
-        $this->assertNull($result['city']);
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['county']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['country']);
-        $this->assertNull($result['countryCode']);
-        $this->assertNull($result['timezone']);
+        $provider->getReversedData(array(1, 2));
     }
 
     public function testGetReversedDataWithRealCoordinates()
@@ -84,6 +76,11 @@ class MapQuestProviderTest extends TestCase
         $provider = new MapQuestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result   = $provider->getReversedData(array(54.0484068, -2.7990345));
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(54.0484068, $result['latitude'], '', 0.001);
         $this->assertEquals(-2.7990345, $result['longitude'], '', 0.001);
         $this->assertNull($result['bounds']);
@@ -102,17 +99,62 @@ class MapQuestProviderTest extends TestCase
     public function testGetGeocodedDataWithCity()
     {
         $provider = new MapQuestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('Hannover');
+        $results  = $provider->getGeocodedData('Hanover');
 
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['timezone']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(52.374478, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(9.738553, $results[0]['longitude'], '', 0.01);
+        $this->assertEquals('Hanover', $results[0]['city']);
+        $this->assertEquals('Region Hannover', $results[0]['county']);
+        $this->assertEquals('Niedersachsen (Landmasse)', $results[0]['region']);
+        $this->assertEquals('DE', $results[0]['country']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(37.744783, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(-77.446416, $results[1]['longitude'], '', 0.01);
+        $this->assertNull($results[1]['city']);
+        $this->assertEquals('Hanover', $results[1]['county']);
+        $this->assertEquals('Virginia', $results[1]['region']);
+        $this->assertEquals('US', $results[1]['country']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(18.383715, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(-78.131484, $results[2]['longitude'], '', 0.01);
+        $this->assertNull($results[2]['city']);
+        $this->assertEquals('Hanover', $results[2]['county']);
+        $this->assertNull($results[2]['region']);
+        $this->assertEquals('JM', $results[2]['country']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(43.703307, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(-72.288566, $results[3]['longitude'], '', 0.01);
+        $this->assertEquals('Hanover', $results[3]['city']);
+        $this->assertEquals('Grafton County', $results[3]['county']);
+        $this->assertEquals('New Hampshire', $results[3]['region']);
+        $this->assertEquals('US', $results[3]['country']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(39.806325, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(-76.984274, $results[4]['longitude'], '', 0.01);
+        $this->assertEquals('Hanover', $results[4]['city']);
+        $this->assertEquals('York County', $results[4]['county']);
+        $this->assertEquals('Pennsylvania', $results[4]['region']);
+        $this->assertEquals('US', $results[4]['country']);
     }
 
     public function testGetGeocodedDataWithCityDistrict()
     {
         $provider = new MapQuestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getGeocodedData('Kalbacher Hauptstraße 10, 60437 Frankfurt, Germany');
+        $result   = $provider->getGeocodedData('Kalbacher Hauptstraße 10, 60437 Frankfurt, Germany');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(50.189062, $result['latitude'], '', 0.01);
         $this->assertEquals(8.636567, $result['longitude'], '', 0.01);
         $this->assertNull($result['bounds']);

--- a/tests/Geocoder/Tests/Provider/MaxMindBinaryProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/MaxMindBinaryProviderTest.php
@@ -50,6 +50,10 @@ class MaxMindBinaryProviderTest extends TestCase
         $result   = $provider->getGeocodedData($ip);
 
         $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
 
         $this->assertArrayHasKey('country', $result);
         $this->assertArrayHasKey('countryCode', $result);
@@ -77,10 +81,13 @@ class MaxMindBinaryProviderTest extends TestCase
         $result   = $provider->getGeocodedData($ip);
 
         $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
 
         $this->assertArrayHasKey('city', $result);
         $this->assertEquals($expectedCity, $result['city']);
-
         $this->assertArrayHasKey('country', $result);
         $this->assertEquals($expectedCountry, $result['country']);
     }

--- a/tests/Geocoder/Tests/Provider/MaxMindProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/MaxMindProviderTest.php
@@ -55,8 +55,13 @@ class MaxMindProviderTest extends TestCase
     public function testGetGeocodedDataWithLocalhostIPv4()
     {
         $provider = new MaxMindProvider($this->getMockAdapter($this->never()), 'api_key');
-        $result = $provider->getGeocodedData('127.0.0.1');
+        $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -71,8 +76,13 @@ class MaxMindProviderTest extends TestCase
     public function testGetGeocodedDataWithLocalhostIPv6()
     {
         $provider = new MaxMindProvider($this->getMockAdapter($this->never()), 'api_key');
-        $result = $provider->getGeocodedData('::1');
+        $result   = $provider->getGeocodedData('::1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -127,8 +137,13 @@ class MaxMindProviderTest extends TestCase
     public function testGetGeocodedDataWithRealIPv4GetsFakeContentFormattedEmpty()
     {
         $provider = new MaxMindProvider($this->getMockAdapterReturns(',,,,,,,,,'), 'api_key');
-        $result = $provider->getGeocodedData('74.200.247.59');
+        $result   = $provider->getGeocodedData('74.200.247.59');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertNull($result['country']);
         $this->assertNull($result['countryCode']);
         $this->assertNull($result['regionCode']);
@@ -150,8 +165,13 @@ class MaxMindProviderTest extends TestCase
     {
         $provider = new MaxMindProvider($this->getMockAdapterReturns(
             'US,TX,Plano,75093,33.034698486328,-96.813400268555,,,,'), 'api_key');
-        $result = $provider->getGeocodedData('74.200.247.59');
+        $result   = $provider->getGeocodedData('74.200.247.59');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('United States', $result['country']);
         $this->assertEquals('US', $result['countryCode']);
         $this->assertEquals('TX', $result['regionCode']);
@@ -170,17 +190,22 @@ class MaxMindProviderTest extends TestCase
         $this->assertNull($result['timezone']);
 
         $provider2 = new MaxMindProvider($this->getMockAdapterReturns('FR,,,,,,,,,'), 'api_key');
-        $result2 = $provider2->getGeocodedData('74.200.247.59');
-        $this->assertEquals('France', $result2['country']);
+        $result2   = $provider2->getGeocodedData('74.200.247.59');
+        $this->assertEquals('France', $result2[0]['country']);
 
         $provider3 = new MaxMindProvider($this->getMockAdapterReturns('GB,,,,,,,,,'), 'api_key');
-        $result3 = $provider3->getGeocodedData('74.200.247.59');
-        $this->assertEquals('United Kingdom', $result3['country']);
+        $result3   = $provider3->getGeocodedData('74.200.247.59');
+        $this->assertEquals('United Kingdom', $result3[0]['country']);
 
         $provider4 = new MaxMindProvider($this->getMockAdapterReturns(
             'US,CA,San Francisco,94110,37.748402,-122.415604,807,415,"Layered Technologies","Automattic"'), 'api_key');
-        $result = $provider4->getGeocodedData('74.200.247.59');
+        $result    = $provider4->getGeocodedData('74.200.247.59');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals('United States', $result['country']);
         $this->assertEquals('US', $result['countryCode']);
         $this->assertEquals('CA', $result['regionCode']);
@@ -288,8 +313,13 @@ class MaxMindProviderTest extends TestCase
         }
 
         $provider = new MaxMindProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['MAXMIND_API_KEY']);
-        $result = $provider->getGeocodedData('74.200.247.159');
+        $result   = $provider->getGeocodedData('74.200.247.159');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(37.748402, $result['latitude'], '', 0.001);
         $this->assertEquals(-122.415604, $result['longitude'], '', 0.001);
         $this->assertEquals('San Francisco', $result['city']);
@@ -315,8 +345,13 @@ class MaxMindProviderTest extends TestCase
 
         $provider = new MaxMindProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['MAXMIND_API_KEY'],
             MaxMindProvider::OMNI_SERVICE);
-        $result = $provider->getGeocodedData('74.200.247.159');
+        $result   = $provider->getGeocodedData('74.200.247.159');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(37.748402, $result['latitude'], '', 0.001);
         $this->assertEquals(-122.415604, $result['longitude'], '', 0.001);
         $this->assertEquals('San Francisco', $result['city']);
@@ -341,8 +376,13 @@ class MaxMindProviderTest extends TestCase
         }
 
         $provider = new MaxMindProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['MAXMIND_API_KEY']);
-        $result = $provider->getGeocodedData('66.147.244.214');
+        $result   = $provider->getGeocodedData('66.147.244.214');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(40.2181, $result['latitude'], '', 0.001);
         $this->assertEquals(-111.6133, $result['longitude'], '', 0.001);
         $this->assertEquals('Provo', $result['city']);
@@ -368,8 +408,13 @@ class MaxMindProviderTest extends TestCase
 
         $provider = new MaxMindProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['MAXMIND_API_KEY'],
             MaxMindProvider::OMNI_SERVICE, true);
-        $result = $provider->getGeocodedData('::ffff:66.147.244.214');
+        $result   = $provider->getGeocodedData('::ffff:66.147.244.214');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(40.2181, $result['latitude'], '', 0.001);
         $this->assertEquals(-111.6133, $result['longitude'], '', 0.001);
         $this->assertEquals('Provo', $result['city']);

--- a/tests/Geocoder/Tests/Provider/OIORestProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/OIORestProviderTest.php
@@ -18,7 +18,7 @@ class OIORestProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser/.json
+     * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser.json?q=
      */
     public function testGetGeocodedDataWithNull()
     {
@@ -28,7 +28,7 @@ class OIORestProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser/.json
+     * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser.json?q=
      */
     public function testGetGeocodedDataWithEmpty()
     {
@@ -38,7 +38,7 @@ class OIORestProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser/Tagensvej%2C47%2C2200.json
+     * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser.json?q=Tagensvej%2047%2C%202200%20K%C3%B8benhavn%20N
      */
     public function testGetGeocodedDataWithAddressContentReturnNull()
     {
@@ -48,7 +48,7 @@ class OIORestProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser/Tagensvej%2C47%2C2200.json
+     * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser.json?q=Tagensvej%2047%2C%202200%20K%C3%B8benhavn%20N
      */
     public function testGetGeocodedDataWithAddress()
     {
@@ -59,8 +59,13 @@ class OIORestProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddress()
     {
         $provider = new OIORestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('Tagensvej 47, 2200 København N');
+        $result   = $provider->getGeocodedData('Tagensvej 47 2200 København');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(55.6999, $result['latitude'], '', 0.0001);
         $this->assertEquals(12.5527, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -79,8 +84,13 @@ class OIORestProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddressAalborg()
     {
         $provider = new OIORestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('Lauritzens Plads 1, 9000 Aalborg');
+        $result   = $provider->getGeocodedData('Lauritzens Plads 1 9000 Aalborg');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(57.0489, $result['latitude'], '', 0.0001);
         $this->assertEquals(9.94566, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -99,8 +109,13 @@ class OIORestProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddressAarhus()
     {
         $provider = new OIORestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('St.Blichers Vej 74, 8210 Århus V');
+        $result   = $provider->getGeocodedData('St.Blichers Vej 74 8210 AArhus');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(56.1623, $result['latitude'], '', 0.0001);
         $this->assertEquals(10.1501, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -119,8 +134,13 @@ class OIORestProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddressCopenhagen()
     {
         $provider = new OIORestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('Århusgade 80, 2100 København Ø');
+        $result   = $provider->getGeocodedData('Århusgade 80 2100 København');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(55.7063, $result['latitude'], '', 0.0001);
         $this->assertEquals(12.5837, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -139,8 +159,13 @@ class OIORestProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddressOdense()
     {
         $provider = new OIORestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('Hvenekildeløkken 255, 5240 Odense');
+        $result   = $provider->getGeocodedData('Hvenekildeløkken 255 5240 Odense');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(55.4221, $result['latitude'], '', 0.0001);
         $this->assertEquals(10.4588, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -154,6 +179,111 @@ class OIORestProviderTest extends TestCase
         $this->assertEquals('Denmark', $result['country']);
         $this->assertEquals('DK', $result['countryCode']);
         $this->assertEquals('Europe/Copenhagen', $result['timezone']);
+    }
+
+    public function testGetGeocodedDataWithRealAddressReturnsMultipleResults()
+    {
+        $provider = new OIORestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
+        $results  = $provider->getGeocodedData('Tagensvej 47');
+
+        $this->assertInternalType('array', $results);
+        $this->assertCount(10, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(55.6999504950464, $results[0]['latitude'], '', 0.0001);
+        $this->assertEquals(12.552780016775, $results[0]['longitude'], '', 0.0001);
+        $this->assertNull($results[0]['bounds']);
+        $this->assertEquals(47, $results[0]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[0]['streetName']);
+        $this->assertEquals(2200, $results[0]['zipcode']);
+        $this->assertEquals('København N', $results[0]['city']);
+        $this->assertEquals('København', $results[0]['cityDistrict']);
+        $this->assertEquals('Region Hovedstaden', $results[0]['region']);
+        $this->assertEquals('1084', $results[0]['regionCode']);
+        $this->assertEquals('Denmark', $results[0]['country']);
+        $this->assertEquals('DK', $results[0]['countryCode']);
+        $this->assertEquals('Europe/Copenhagen', $results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(55.2272287041871, $results[1]['latitude'], '', 0.000001);
+        $this->assertEquals(11.7695695592728, $results[1]['longitude'], '', 0.000001);
+        $this->assertEquals(1, $results[1]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[1]['streetName']);
+        $this->assertEquals(4700, $results[1]['zipcode']);
+        $this->assertEquals('Næstved', $results[1]['city']);
+        $this->assertEquals('Region Sjælland', $results[1]['region']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(55.2271757871039, $results[2]['latitude'], '', 0.000001);
+        $this->assertEquals(11.7691129123425, $results[2]['longitude'], '', 0.000001);
+        $this->assertEquals(2, $results[2]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[2]['streetName']);
+        $this->assertEquals(4700, $results[2]['zipcode']);
+        $this->assertEquals('Næstved', $results[2]['city']);
+        $this->assertEquals('Region Sjælland', $results[2]['region']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(55.2271205312374, $results[3]['latitude'], '', 0.000001);
+        $this->assertEquals(11.7695192586423, $results[3]['longitude'], '', 0.000001);
+        $this->assertEquals(3, $results[3]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[3]['streetName']);
+        $this->assertEquals(4700, $results[3]['zipcode']);
+        $this->assertEquals('Næstved', $results[3]['city']);
+        $this->assertEquals('Region Sjælland', $results[3]['region']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(55.2270592164468, $results[4]['latitude'], '', 0.000001);
+        $this->assertEquals(11.7691790457091, $results[4]['longitude'], '', 0.000001);
+        $this->assertEquals(4, $results[4]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[4]['streetName']);
+        $this->assertEquals(4700, $results[4]['zipcode']);
+        $this->assertEquals('Næstved', $results[4]['city']);
+        $this->assertEquals('Region Sjælland', $results[4]['region']);
+
+        $this->assertInternalType('array', $results[5]);
+        $this->assertEquals(55.2269838646556, $results[5]['latitude'], '', 0.000001);
+        $this->assertEquals(11.7694569115436, $results[5]['longitude'], '', 0.000001);
+        $this->assertEquals(5, $results[5]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[5]['streetName']);
+        $this->assertEquals(4700, $results[5]['zipcode']);
+        $this->assertEquals('Næstved', $results[5]['city']);
+        $this->assertEquals('Region Sjælland', $results[5]['region']);
+
+        $this->assertInternalType('array', $results[6]);
+        $this->assertEquals(55.2269514141865, $results[6]['latitude'], '', 0.000001);
+        $this->assertEquals(11.7691124150561, $results[6]['longitude'], '', 0.000001);
+        $this->assertEquals(6, $results[6]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[6]['streetName']);
+        $this->assertEquals(4700, $results[6]['zipcode']);
+        $this->assertEquals('Næstved', $results[6]['city']);
+        $this->assertEquals('Region Sjælland', $results[6]['region']);
+
+        $this->assertInternalType('array', $results[7]);
+        $this->assertEquals(55.2268810365838, $results[7]['latitude'], '', 0.000001);
+        $this->assertEquals(11.7694245984061, $results[7]['longitude'], '', 0.000001);
+        $this->assertEquals(7, $results[7]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[7]['streetName']);
+        $this->assertEquals(4700, $results[7]['zipcode']);
+        $this->assertEquals('Næstved', $results[7]['city']);
+        $this->assertEquals('Region Sjælland', $results[7]['region']);
+
+        $this->assertInternalType('array', $results[8]);
+        $this->assertEquals(55.2268597609547, $results[8]['latitude'], '', 0.000001);
+        $this->assertEquals(11.7690947201688, $results[8]['longitude'], '', 0.000001);
+        $this->assertEquals(8, $results[8]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[8]['streetName']);
+        $this->assertEquals(4700, $results[8]['zipcode']);
+        $this->assertEquals('Næstved', $results[8]['city']);
+        $this->assertEquals('Region Sjælland', $results[8]['region']);
+
+        $this->assertInternalType('array', $results[9]);
+        $this->assertEquals(55.2267671191869, $results[9]['latitude'], '', 0.000001);
+        $this->assertEquals(11.7693738993126, $results[9]['longitude'], '', 0.000001);
+        $this->assertEquals(9, $results[9]['streetNumber']);
+        $this->assertEquals('Tagensvej', $results[9]['streetName']);
+        $this->assertEquals(4700, $results[9]['zipcode']);
+        $this->assertEquals('Næstved', $results[9]['city']);
+        $this->assertEquals('Region Sjælland', $results[9]['region']);
     }
 
     /**
@@ -231,6 +361,11 @@ class OIORestProviderTest extends TestCase
         $provider = new OIORestProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
         $result = $provider->getReversedData(array(56.5231, 10.0659));
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(56.521542795662, $result['latitude'], '', 0.0001);
         $this->assertEquals(10.0668558607917, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);

--- a/tests/Geocoder/Tests/Provider/OpenStreetMapsProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/OpenStreetMapsProviderTest.php
@@ -16,62 +16,185 @@ class OpenStreetMapsProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddress()
     {
         $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('Läntinen Pitkäkatu 35, Turku');
+        $results  = $provider->getGeocodedData('Paris');
 
-        $this->assertEquals(60.4539, $result['latitude'], '', 0.001);
-        $this->assertEquals(22.2568, $result['longitude'], '', 0.001);
-        $this->assertArrayHasKey('south', $result['bounds']);
-        $this->assertArrayHasKey('west', $result['bounds']);
-        $this->assertArrayHasKey('north', $result['bounds']);
-        $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(60.4537, $result['bounds']['south'], '', 0.001);
-        $this->assertEquals(22.2563, $result['bounds']['west'], '', 0.001);
-        $this->assertEquals(60.4541, $result['bounds']['north'], '', 0.001);
-        $this->assertEquals(22.2572, $result['bounds']['east'], '', 0.001);
-        $this->assertEquals('20100', $result['zipcode']);
-        $this->assertEquals(35, $result['streetNumber']);
-        $this->assertEquals('Läntinen Pitkäkatu', $result['streetName']);
-        $this->assertEquals('Turku', $result['city']);
-        $this->assertEquals('VII', $result['cityDistrict']);
-        //$this->assertEquals('Finland Proper', $result['county']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
-        //$this->assertEquals('Finland', $result['country']);
-        $this->assertEquals('FI', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.8565056, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(2.3521334, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(48.8155250549316, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.22412180900574, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.902156829834, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.46976041793823, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertEquals(75000, $results[0]['zipcode']);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertNull($results[0]['streetName']);
+        $this->assertEquals('Paris', $results[0]['city']);
+        $this->assertNull($results[0]['cityDistrict']);
+        $this->assertEquals('Paris', $results[0]['county']);
+        $this->assertEquals('Île-de-France', $results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertEquals('France métropolitaine', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(48.8588408, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(2.32003465529896, $results[1]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertEquals(48.8155250549316, $results[1]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.22412180900574, $results[1]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.902156829834, $results[1]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.46976041793823, $results[1]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[1]['zipcode']);
+        $this->assertNull($results[1]['streetNumber']);
+        $this->assertNull($results[1]['streetName']);
+        $this->assertNull($results[1]['city']);
+        $this->assertNull($results[1]['cityDistrict']);
+        $this->assertEquals('Paris', $results[1]['county']);
+        $this->assertEquals('Île-de-France', $results[1]['region']);
+        $this->assertNull($results[1]['regionCode']);
+        $this->assertEquals('France métropolitaine', $results[1]['country']);
+        $this->assertEquals('FR', $results[1]['countryCode']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(35.28687645, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(-93.7354879210082, $results[2]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[2]['bounds']);
+        $this->assertArrayHasKey('west', $results[2]['bounds']);
+        $this->assertArrayHasKey('north', $results[2]['bounds']);
+        $this->assertArrayHasKey('east', $results[2]['bounds']);
+        $this->assertEquals(35.2672462463379, $results[2]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-93.7618103027344, $results[2]['bounds']['west'], '', 0.01);
+        $this->assertEquals(35.3065032958984, $results[2]['bounds']['north'], '', 0.01);
+        $this->assertEquals(-93.6750793457031, $results[2]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[2]['zipcode']);
+        $this->assertNull($results[2]['streetNumber']);
+        $this->assertNull($results[2]['streetName']);
+        $this->assertEquals('Paris', $results[2]['city']);
+        $this->assertNull($results[2]['cityDistrict']);
+        $this->assertEquals('Logan County', $results[2]['county']);
+        $this->assertEquals('Arkansas', $results[2]['region']);
+        $this->assertNull($results[2]['regionCode']);
+        $this->assertEquals('United States of America', $results[2]['country']);
+        $this->assertEquals('US', $results[2]['countryCode']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(33.6751155, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(-95.5502662477703, $results[3]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[3]['bounds']);
+        $this->assertArrayHasKey('west', $results[3]['bounds']);
+        $this->assertArrayHasKey('north', $results[3]['bounds']);
+        $this->assertArrayHasKey('east', $results[3]['bounds']);
+        $this->assertEquals(33.6118507385254, $results[3]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-95.6279296875, $results[3]['bounds']['west'], '', 0.01);
+        $this->assertEquals(33.7383804321289, $results[3]['bounds']['north'], '', 0.01);
+        $this->assertEquals(-95.4354476928711, $results[3]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[3]['zipcode']);
+        $this->assertNull($results[3]['streetNumber']);
+        $this->assertNull($results[3]['streetName']);
+        $this->assertEquals('Paris', $results[3]['city']);
+        $this->assertNull($results[3]['cityDistrict']);
+        $this->assertEquals('Lamar County', $results[3]['county']);
+        $this->assertEquals('Texas', $results[3]['region']);
+        $this->assertNull($results[3]['regionCode']);
+        $this->assertEquals('United States of America', $results[3]['country']);
+        $this->assertEquals('US', $results[3]['countryCode']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(38.2097987, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(-84.2529869, $results[4]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[4]['bounds']);
+        $this->assertArrayHasKey('west', $results[4]['bounds']);
+        $this->assertArrayHasKey('north', $results[4]['bounds']);
+        $this->assertArrayHasKey('east', $results[4]['bounds']);
+        $this->assertEquals(38.1649208068848, $results[4]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-84.3073272705078, $results[4]['bounds']['west'], '', 0.01);
+        $this->assertEquals(38.2382736206055, $results[4]['bounds']['north'], '', 0.01);
+        $this->assertEquals(-84.2320861816406, $results[4]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[4]['zipcode']);
+        $this->assertNull($results[4]['streetNumber']);
+        $this->assertNull($results[4]['streetName']);
+        $this->assertEquals('Paris', $results[4]['city']);
+        $this->assertNull($results[4]['cityDistrict']);
+        $this->assertEquals('Bourbon County', $results[4]['county']);
+        $this->assertEquals('Kentucky', $results[4]['region']);
+        $this->assertNull($results[4]['regionCode']);
+        $this->assertEquals('United States of America', $results[4]['country']);
+        $this->assertEquals('US', $results[4]['countryCode']);
     }
 
     public function testGetGeocodedDataWithRealAddressWithLocale()
     {
         $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'fr_FR');
-        $result   = $provider->getGeocodedData('10 allée Evariste Galois, Clermont ferrand');
+        $results  = $provider->getGeocodedData('10 allée Evariste Galois, Clermont ferrand');
 
-        $this->assertEquals(45.7586841, $result['latitude'], '', 0.01);
-        $this->assertEquals(3.1354075, $result['longitude'], '', 0.01);
-        $this->assertArrayHasKey('south', $result['bounds']);
-        $this->assertArrayHasKey('west', $result['bounds']);
-        $this->assertArrayHasKey('north', $result['bounds']);
-        $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(45.7576484680176, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(3.13258004188538, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(45.7595367431641, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(3.13707232475281, $result['bounds']['east'], '', 0.01);
-        $this->assertNull($result['streetNumber']);
-        $this->assertEquals('Allée Évariste Galois', $result['streetName']);
-        $this->assertEquals('63170', $result['zipcode']);
-        //$this->assertEquals('Aubière', $result['city']);
-        //$this->assertEquals('La Pardieu', $result['cityDistrict']);
-        //$this->assertEquals('Puy-de-Dôme', $result['county']);
-        $this->assertEquals('Auvergne', $result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertEquals('France', $result['country']);
-        $this->assertEquals('FR', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(2, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(45.7586841, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(3.1354075, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(45.7576484680176, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(3.13258004188538, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(45.7595367431641, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(3.13707232475281, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('Allée Évariste Galois', $results[0]['streetName']);
+        $this->assertEquals('63170', $results[0]['zipcode']);
+        $this->assertEquals('Clermont-Ferrand', $results[0]['city']);
+        $this->assertEquals('La Pardieu', $results[0]['cityDistrict']);
+        $this->assertEquals('Clermont-Ferrand', $results[0]['county']);
+        $this->assertEquals('Auvergne', $results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertEquals('France', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(45.7586841, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(3.1354075, $results[1]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertEquals(45.7576484680176, $results[1]['bounds']['south'], '', 0.01);
+        $this->assertEquals(3.13258004188538, $results[1]['bounds']['west'], '', 0.01);
+        $this->assertEquals(45.7595367431641, $results[1]['bounds']['north'], '', 0.01);
+        $this->assertEquals(3.13707232475281, $results[1]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[1]['streetNumber']);
+        $this->assertEquals('Allée Évariste Galois', $results[1]['streetName']);
+        $this->assertEquals('63170', $results[1]['zipcode']);
+        $this->assertEquals('Aubière', $results[1]['city']);
+        $this->assertEquals('Cap Sud', $results[1]['cityDistrict']);
+        $this->assertEquals('Clermont-Ferrand', $results[1]['county']);
+        $this->assertEquals('Auvergne', $results[1]['region']);
+        $this->assertNull($results[1]['regionCode']);
+        $this->assertEquals('France', $results[1]['country']);
+        $this->assertEquals('FR', $results[1]['countryCode']);
     }
 
     public function testGetReversedDataWithRealCoordinates()
     {
         $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getReversedData(array('60.4539471728726', '22.2567841926781'));
+        $results  = $provider->getReversedData(array('60.4539471728726', '22.2567841926781'));
 
+        $this->assertInternalType('array', $results);
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(60.4539, $result['latitude'], '', 0.001);
         $this->assertEquals(22.2568, $result['longitude'], '', 0.001);
         $this->assertNull($result['bounds']);
@@ -89,7 +212,7 @@ class OpenStreetMapsProviderTest extends TestCase
 
     /**
      * @expectedException Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=Hammm&format=xml&addressdetails=1&limit=1
+     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=Hammm&format=xml&addressdetails=1&limit=5
      */
     public function testGetGeocodedDataWithUnknownCity()
     {
@@ -100,28 +223,98 @@ class OpenStreetMapsProviderTest extends TestCase
     public function testGetReversedDataWithRealCoordinatesWithLocale()
     {
         $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'de_DE');
-        $result   = $provider->getGeocodedData('Kalbacher Hauptstraße, 60437 Frankfurt, Germany');
+        $results  = $provider->getGeocodedData('Kalbacher Hauptstraße, 60437 Frankfurt, Germany');
 
-        $this->assertEquals(50.1856803, $result['latitude'], '', 0.01);
-        $this->assertEquals(8.6506285, $result['longitude'], '', 0.01);
-        $this->assertArrayHasKey('south', $result['bounds']);
-        $this->assertArrayHasKey('west', $result['bounds']);
-        $this->assertArrayHasKey('north', $result['bounds']);
-        $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(50.1851196289062, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(8.64984607696533, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(50.1860122680664, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(8.65207576751709, $result['bounds']['east'], '', 0.01);
-        $this->assertNull($result['streetNumber']);
-        $this->assertEquals('Kalbacher Hauptstraße', $result['streetName']);
-        $this->assertEquals(60437, $result['zipcode']);
-        $this->assertEquals('Frankfurt am Main', $result['city']);
-        $this->assertEquals('Kalbach', $result['cityDistrict']);
-        $this->assertEquals('Frankfurt am Main', $result['county']);
-        $this->assertEquals('Hessen', $result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertEquals('Deutschland', $result['country']);
-        $this->assertEquals('DE', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(50.1856803, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(8.6506285, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(50.1851196289062, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(8.64984607696533, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(50.1860122680664, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(8.65207576751709, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('Kalbacher Hauptstraße', $results[0]['streetName']);
+        $this->assertEquals(60437, $results[0]['zipcode']);
+        $this->assertEquals('Frankfurt am Main', $results[0]['city']);
+        $this->assertEquals('Kalbach', $results[0]['cityDistrict']);
+        $this->assertEquals('Frankfurt am Main', $results[0]['county']);
+        $this->assertEquals('Hessen', $results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertEquals('Deutschland', $results[0]['country']);
+        $this->assertEquals('DE', $results[0]['countryCode']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(50.1845911, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(8.6540194, $results[1]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[1]['bounds']);
+        $this->assertArrayHasKey('west', $results[1]['bounds']);
+        $this->assertArrayHasKey('north', $results[1]['bounds']);
+        $this->assertArrayHasKey('east', $results[1]['bounds']);
+        $this->assertEquals(50.1840019226074, $results[1]['bounds']['south'], '', 0.01);
+        $this->assertEquals(8.65207481384277, $results[1]['bounds']['west'], '', 0.01);
+        $this->assertEquals(50.1851234436035, $results[1]['bounds']['north'], '', 0.01);
+        $this->assertEquals(8.65643787384033, $results[1]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[1]['streetNumber']);
+        $this->assertEquals('Kalbacher Hauptstraße', $results[1]['streetName']);
+        $this->assertEquals(60437, $results[1]['zipcode']);
+        $this->assertEquals('Frankfurt am Main', $results[1]['city']);
+        $this->assertEquals('Bonames', $results[1]['cityDistrict']);
+        $this->assertEquals('Frankfurt am Main', $results[1]['county']);
+        $this->assertEquals('Hessen', $results[1]['region']);
+        $this->assertNull($results[1]['regionCode']);
+        $this->assertEquals('Deutschland', $results[1]['country']);
+        $this->assertEquals('DE', $results[1]['countryCode']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(50.1862884, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(8.6493167, $results[2]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[2]['bounds']);
+        $this->assertArrayHasKey('west', $results[2]['bounds']);
+        $this->assertArrayHasKey('north', $results[2]['bounds']);
+        $this->assertArrayHasKey('east', $results[2]['bounds']);
+        $this->assertEquals(50.1862106323242, $results[2]['bounds']['south'], '', 0.01);
+        $this->assertEquals(8.64931583404541, $results[2]['bounds']['west'], '', 0.01);
+        $this->assertEquals(50.1862907409668, $results[2]['bounds']['north'], '', 0.01);
+        $this->assertEquals(8.64943981170654, $results[2]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[2]['streetNumber']);
+        $this->assertEquals('Kalbacher Hauptstraße', $results[2]['streetName']);
+        $this->assertEquals(60437, $results[2]['zipcode']);
+        $this->assertEquals('Frankfurt am Main', $results[2]['city']);
+        $this->assertEquals('Kalbach', $results[2]['cityDistrict']);
+        $this->assertEquals('Frankfurt am Main', $results[2]['county']);
+        $this->assertEquals('Hessen', $results[2]['region']);
+        $this->assertNull($results[2]['regionCode']);
+        $this->assertEquals('Deutschland', $results[2]['country']);
+        $this->assertEquals('DE', $results[2]['countryCode']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(50.1861344, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(8.649578, $results[3]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[3]['bounds']);
+        $this->assertArrayHasKey('west', $results[3]['bounds']);
+        $this->assertArrayHasKey('north', $results[3]['bounds']);
+        $this->assertArrayHasKey('east', $results[3]['bounds']);
+        $this->assertEquals(50.1860084533691, $results[3]['bounds']['south'], '', 0.01);
+        $this->assertEquals(8.64943885803223, $results[3]['bounds']['west'], '', 0.01);
+        $this->assertEquals(50.1862144470215, $results[3]['bounds']['north'], '', 0.01);
+        $this->assertEquals(8.64984703063965, $results[3]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[3]['streetNumber']);
+        $this->assertEquals('Kalbacher Hauptstraße', $results[3]['streetName']);
+        $this->assertEquals(60437, $results[3]['zipcode']);
+        $this->assertEquals('Frankfurt am Main', $results[3]['city']);
+        $this->assertEquals('Kalbach', $results[3]['cityDistrict']);
+        $this->assertEquals('Frankfurt am Main', $results[3]['county']);
+        $this->assertEquals('Hessen', $results[3]['region']);
+        $this->assertNull($results[3]['regionCode']);
+        $this->assertEquals('Deutschland', $results[3]['country']);
+        $this->assertEquals('DE', $results[3]['countryCode']);
     }
 
     public function testGetGeocodedDataWithLocalhostIPv4()
@@ -129,6 +322,11 @@ class OpenStreetMapsProviderTest extends TestCase
         $provider = new OpenStreetMapsProvider($this->getMockAdapter($this->never()));
         $result   = $provider->getGeocodedData('127.0.0.1');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertArrayNotHasKey('latitude', $result);
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
@@ -153,55 +351,73 @@ class OpenStreetMapsProviderTest extends TestCase
     public function testGetGeocodedDataWithRealIPv4()
     {
         $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('88.188.221.14');
+        $results  = $provider->getGeocodedData('88.188.221.14');
 
-        $this->assertEquals(43.6189768, $result['latitude'], '', 0.01);
-        $this->assertEquals(1.4564493, $result['longitude'], '', 0.01);
-        $this->assertArrayHasKey('south', $result['bounds']);
-        $this->assertArrayHasKey('west', $result['bounds']);
-        $this->assertArrayHasKey('north', $result['bounds']);
-        $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(43.6159553527832, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(1.45302963256836, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(43.623119354248, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(1.45882403850555, $result['bounds']['east'], '', 0.01);
-        $this->assertNull($result['streetNumber']);
-        //$this->assertEquals('Rue du Faubourg Bonnefoy', $result['streetName']);
-        $this->assertEquals(31506, $result['zipcode']);
-        $this->assertEquals(4, $result['cityDistrict']);
-        $this->assertEquals('Toulouse', $result['city']);
-        //$this->assertEquals('Haute-Garonne', $result['county']);
-        $this->assertEquals('Midi-Pyrénées', $result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertEquals('France métropolitaine', $result['country']);
-        $this->assertEquals('FR', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(43.6189768, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(1.4564493, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(43.6159553527832, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(1.45302963256836, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(43.623119354248, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(1.45882403850555, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        //$this->assertEquals('Rue du Faubourg Bonnefoy', $results[0]['streetName']);
+        $this->assertEquals(31506, $results[0]['zipcode']);
+        $this->assertEquals(4, $results[0]['cityDistrict']);
+        $this->assertEquals('Toulouse', $results[0]['city']);
+        //$this->assertEquals('Haute-Garonne', $results[0]['county']);
+        $this->assertEquals('Midi-Pyrénées', $results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertEquals('France métropolitaine', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertInternalType('array', $results[2]);
+        $this->assertInternalType('array', $results[3]);
+        $this->assertInternalType('array', $results[4]);
     }
 
     public function testGetGeocodedDataWithRealIPv4WithLocale()
     {
         $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'da_DK');
-        $result   = $provider->getGeocodedData('88.188.221.14');
+        $results  = $provider->getGeocodedData('88.188.221.14');
 
-        $this->assertEquals(43.6155351, $result['latitude'], '', 0.01);
-        $this->assertEquals(1.4525647, $result['longitude'], '', 0.01);
-        $this->assertArrayHasKey('south', $result['bounds']);
-        $this->assertArrayHasKey('west', $result['bounds']);
-        $this->assertArrayHasKey('north', $result['bounds']);
-        $this->assertArrayHasKey('east', $result['bounds']);
-        $this->assertEquals(43.6154556274414, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(1.4524964094162, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(43.6156005859375, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(1.45262920856476, $result['bounds']['east'], '', 0.01);
-        $this->assertNull($result['streetNumber']);
-        $this->assertEquals('Rue du Faubourg Bonnefoy', $result['streetName']);
-        $this->assertEquals(31506, $result['zipcode']);
-        $this->assertEquals(4, $result['cityDistrict']);
-        $this->assertEquals('Toulouse', $result['city']);
-        $this->assertEquals('Toulouse', $result['county']);
-        $this->assertEquals('Midi-Pyrénées', $result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertEquals('Frankrig', $result['country']);
-        $this->assertEquals('FR', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(43.6155351, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(1.4525647, $results[0]['longitude'], '', 0.01);
+        $this->assertArrayHasKey('south', $results[0]['bounds']);
+        $this->assertArrayHasKey('west', $results[0]['bounds']);
+        $this->assertArrayHasKey('north', $results[0]['bounds']);
+        $this->assertArrayHasKey('east', $results[0]['bounds']);
+        $this->assertEquals(43.6154556274414, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(1.4524964094162, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(43.6156005859375, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(1.45262920856476, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('Rue du Faubourg Bonnefoy', $results[0]['streetName']);
+        $this->assertEquals(31506, $results[0]['zipcode']);
+        $this->assertEquals(4, $results[0]['cityDistrict']);
+        $this->assertEquals('Toulouse', $results[0]['city']);
+        $this->assertEquals('Toulouse', $results[0]['county']);
+        $this->assertEquals('Midi-Pyrénées', $results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertEquals('Frankrig', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertInternalType('array', $results[2]);
+        $this->assertInternalType('array', $results[3]);
+        $this->assertInternalType('array', $results[4]);
     }
 
     /**
@@ -211,7 +427,7 @@ class OpenStreetMapsProviderTest extends TestCase
     public function testGetGeocodedDataWithRealIPv6()
     {
         $provider = new OpenStreetMapsProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('::ffff:88.188.221.14');
+        $provider->getGeocodedData('::ffff:88.188.221.14');
     }
 
     /**
@@ -226,7 +442,7 @@ class OpenStreetMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=L%C3%A4ntinen+Pitk%C3%A4katu+35%2C+Turku&format=xml&addressdetails=1&limit=1
+     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=L%C3%A4ntinen+Pitk%C3%A4katu+35%2C+Turku&format=xml&addressdetails=1&limit=5
      */
     public function testGetGeocodedDataWithAddressGetsEmptyContent()
     {
@@ -236,7 +452,7 @@ class OpenStreetMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=L%C3%A4ntinen+Pitk%C3%A4katu+35%2C+Turku&format=xml&addressdetails=1&limit=1
+     * @expectedExceptionMessage Could not execute query http://nominatim.openstreetmap.org/search?q=L%C3%A4ntinen+Pitk%C3%A4katu+35%2C+Turku&format=xml&addressdetails=1&limit=5
      */
     public function testGetGeocodedDataWithAddressGetsEmptyXML()
     {

--- a/tests/Geocoder/Tests/Provider/TomTomProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/TomTomProviderTest.php
@@ -26,7 +26,7 @@ class TomTomProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&maxResults=1&query=
+     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&query=&maxResults=5
      */
     public function testGetGeocodedDataWithNull()
     {
@@ -36,7 +36,7 @@ class TomTomProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&maxResults=1&query=
+     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&query=&maxResults=5
      */
     public function testGetGeocodedDataWithEmpty()
     {
@@ -46,7 +46,7 @@ class TomTomProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&maxResults=1&query=Tagensvej%2047%2C%202200%20K%C3%B8benhavn%20N
+     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&query=Tagensvej%2047%2C%202200%20K%C3%B8benhavn%20N&maxResults=5
      */
     public function testGetGeocodedDataWithAddressContentReturnNull()
     {
@@ -56,7 +56,7 @@ class TomTomProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&maxResults=1&query=Tagensvej%2047%2C%202200%20K%C3%B8benhavn%20N
+     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&query=Tagensvej%2047%2C%202200%20K%C3%B8benhavn%20N&maxResults=5
      */
     public function testGetGeocodedDataWithAddress()
     {
@@ -66,7 +66,7 @@ class TomTomProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&maxResults=1&query=foo
+     * @expectedExceptionMessage Could not execute query https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&query=foo&maxResults=5
      */
     public function testGetGeocodedDataNoResult()
     {
@@ -87,6 +87,11 @@ XML;
         $provider = new TomTomProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['TOMTOM_GEOCODING_KEY']);
         $result   = $provider->getGeocodedData('Tagensvej 47, 2200 København N');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(55.704389, $result['latitude'], '', 0.0001);
         $this->assertEquals(12.546129, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -111,6 +116,11 @@ XML;
         $provider = new TomTomProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['TOMTOM_GEOCODING_KEY'], 'fr_FR');
         $result   = $provider->getGeocodedData('Tagensvej 47, 2200 København N');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(55.704389, $result['latitude'], '', 0.0001);
         $this->assertEquals(12.546129, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -135,6 +145,11 @@ XML;
         $provider = new TomTomProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['TOMTOM_GEOCODING_KEY'], 'sv-SE');
         $result   = $provider->getGeocodedData('Tagensvej 47, 2200 København N');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(55.704389, $result['latitude'], '', 0.0001);
         $this->assertEquals(12.546129, $result['longitude'], '', 0.0001);
         $this->assertNull($result['bounds']);
@@ -148,6 +163,66 @@ XML;
         $this->assertEquals('Dania', $result['country']);
         $this->assertEquals('DNK', $result['countryCode']);
         $this->assertNull($result['timezone']);
+    }
+
+    public function testGetGeocodedDataWithRealAddressReturnsMultipleResults()
+    {
+        if (!isset($_SERVER['TOMTOM_GEOCODING_KEY'])) {
+            $this->markTestSkipped('You need to configure the TOMTOM_GEOCODING_KEY value in phpunit.xml');
+        }
+
+        $provider = new TomTomProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['TOMTOM_GEOCODING_KEY']);
+        $results  = $provider->getGeocodedData('Paris');
+
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.856898, $results[0]['latitude'], '', 0.0001);
+        $this->assertEquals(2.350844, $results[0]['longitude'], '', 0.0001);
+        $this->assertNull($results[0]['bounds']);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertNull($results[0]['streetName']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertEquals('Paris', $results[0]['city']);
+        $this->assertNull($results[0]['cityDistrict']);
+        $this->assertEquals('Ile-de-France', $results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertEquals('France', $results[0]['country']);
+        $this->assertEquals('FRA', $results[0]['countryCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(33.661426, $results[1]['latitude'], '', 0.0001);
+        $this->assertEquals(-95.556321, $results[1]['longitude'], '', 0.0001);
+        $this->assertEquals('Paris', $results[1]['city']);
+        $this->assertEquals('Texas', $results[1]['region']);
+        $this->assertEquals('United States', $results[1]['country']);
+        $this->assertEquals('USA', $results[1]['countryCode']);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(36.302754, $results[2]['latitude'], '', 0.0001);
+        $this->assertEquals(-88.326359, $results[2]['longitude'], '', 0.0001);
+        $this->assertEquals('Paris', $results[2]['city']);
+        $this->assertEquals('Tennessee', $results[2]['region']);
+        $this->assertEquals('United States', $results[2]['country']);
+        $this->assertEquals('USA', $results[2]['countryCode']);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(-19.039448, $results[3]['latitude'], '', 0.0001);
+        $this->assertEquals(29.560445, $results[3]['longitude'], '', 0.0001);
+        $this->assertEquals('Paris', $results[3]['city']);
+        $this->assertEquals('Midlands', $results[3]['region']);
+        $this->assertEquals('Zimbabwe', $results[3]['country']);
+        $this->assertEquals('ZWE', $results[3]['countryCode']);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(35.292105, $results[4]['latitude'], '', 0.0001);
+        $this->assertEquals(-93.729922, $results[4]['longitude'], '', 0.0001);
+        $this->assertEquals('Paris', $results[4]['city']);
+        $this->assertEquals('Arkansas', $results[4]['region']);
+        $this->assertEquals('United States', $results[4]['country']);
+        $this->assertEquals('USA', $results[4]['countryCode']);
     }
 
     /**
@@ -265,8 +340,13 @@ XML;
         }
 
         $provider = new TomTomProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), $_SERVER['TOMTOM_MAP_KEY']);
-        $result = $provider->getReversedData(array(48.86321648955345, 2.3887719959020615));
+        $result   = $provider->getReversedData(array(48.86321648955345, 2.3887719959020615));
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(48.86323, $result['latitude'], '', 0.001);
         $this->assertEquals(2.38877, $result['longitude'], '', 0.001);
         $this->assertNull($result['bounds']);
@@ -289,8 +369,13 @@ XML;
         }
 
         $provider = new TomTomProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(),  $_SERVER['TOMTOM_MAP_KEY']);
-        $result = $provider->getReversedData(array(56.5231, 10.0659));
+        $result   = $provider->getReversedData(array(56.5231, 10.0659));
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(56.52435, $result['latitude'], '', 0.001);
         $this->assertEquals(10.06744, $result['longitude'], '', 0.001);
         $this->assertNull($result['bounds']);

--- a/tests/Geocoder/Tests/Provider/YandexProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/YandexProviderTest.php
@@ -38,7 +38,7 @@ class YandexProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=
+     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?format=json&geocode=&results=5
      */
     public function testGetGeocodedDataWithNull()
     {
@@ -48,7 +48,7 @@ class YandexProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=
+     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?format=json&geocode=&results=5
      */
     public function testGetGeocodedDataWithEmpty()
     {
@@ -58,7 +58,7 @@ class YandexProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=foobar
+     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?format=json&geocode=foobar&results=5
      */
     public function testGetGeocodedDataWithInvalidData()
     {
@@ -68,7 +68,7 @@ class YandexProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=Kabasakal+Caddesi%2C+Istanbul%2C+Turkey
+     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?format=json&geocode=Kabasakal+Caddesi%2C+Istanbul%2C+Turkey&results=5
      */
     public function testGetGeocodedDataWithAddressGetsNullContent()
     {
@@ -78,7 +78,7 @@ class YandexProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=foobar
+     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?format=json&geocode=foobar&results=5
      */
     public function testGetGeocodedDataWithFakeAddress()
     {
@@ -89,76 +89,136 @@ class YandexProviderTest extends TestCase
     public function testGetGeocodedDataWithRealAddress()
     {
         $provider = new YandexProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result   = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
+        $results  = $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
 
-        $this->assertEquals(48.863277, $result['latitude'], '', 0.01);
-        $this->assertEquals(2.389016, $result['longitude'], '', 0.01);
-        $this->assertEquals(48.861926, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(2.386967, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(48.864629, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(2.391064, $result['bounds']['east'], '', 0.01);
-        $this->assertEquals(10, $result['streetNumber']);
-        $this->assertEquals('Иль-Де-Франс', $result['cityDistrict']);
-        $this->assertEquals('Avenue Gambetta', $result['streetName']);
-        $this->assertEquals('Франция', $result['country']);
-        $this->assertEquals('FR', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.863277, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(2.389016, $results[0]['longitude'], '', 0.01);
+        $this->assertEquals(48.861926, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.386967, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.864629, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.391064, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertEquals(10, $results[0]['streetNumber']);
+        $this->assertEquals('Иль-Де-Франс', $results[0]['cityDistrict']);
+        $this->assertEquals('Avenue Gambetta', $results[0]['streetName']);
+        $this->assertEquals('Франция', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
 
         // not provided
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['city']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertNull($result['timezone']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertNull($results[0]['city']);
+        $this->assertNull($results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(48.810138, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(2.435926, $results[1]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(48.892773, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(2.246174, $results[2]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(48.844640, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(2.420493, $results[3]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(48.813520, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(2.324642, $results[4]['longitude'], '', 0.01);
     }
 
     public function testGetGeocodedDataWithRealAddressWithUALocale()
     {
         $provider = new YandexProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'uk-UA');
-        $result   = $provider->getGeocodedData('Copenhagen, Denmark');
+        $results  = $provider->getGeocodedData('Copenhagen, Denmark');
 
-        $this->assertEquals(55.675682, $result['latitude'], '', 0.01);
-        $this->assertEquals(12.567602, $result['longitude'], '', 0.01);
-        $this->assertEquals(55.614999, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(12.45295, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(55.73259, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(12.65075, $result['bounds']['east'], '', 0.01);
-        $this->assertNull($result['streetNumber']);
-        $this->assertEquals('Капитал', $result['cityDistrict']);
-        $this->assertNull($result['streetName']);
-        $this->assertEquals('Данія', $result['country']);
-        $this->assertEquals('DK', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(55.675682, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(12.567602, $results[0]['longitude'], '', 0.01);
+        $this->assertEquals(55.614999, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(12.45295, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(55.73259, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(12.65075, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('Капитал', $results[0]['cityDistrict']);
+        $this->assertNull($results[0]['streetName']);
+        $this->assertEquals('Данія', $results[0]['country']);
+        $this->assertEquals('DK', $results[0]['countryCode']);
 
         // not provided
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['city']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertNull($result['timezone']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertNull($results[0]['city']);
+        $this->assertNull($results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(55.614439, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(12.645351, $results[1]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(55.713258, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(12.534930, $results[2]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(55.698878, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(12.578211, $results[3]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(55.690380, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(12.554827, $results[4]['longitude'], '', 0.01);
     }
 
     public function testGetGeocodedDataWithRealAddressWithUSLocale()
     {
         $provider = new YandexProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'en-US');
-        $result   = $provider->getGeocodedData('1600 Pennsylvania Ave, Washington');
+        $results  = $provider->getGeocodedData('1600 Pennsylvania Ave, Washington');
 
-        $this->assertEquals(38.898720, $result['latitude'], '', 0.01);
-        $this->assertEquals(-77.036384, $result['longitude'], '', 0.01);
-        $this->assertEquals(38.897119, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(-77.038432, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(38.90032, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(-77.034335, $result['bounds']['east'], '', 0.01);
-        $this->assertEquals(1600, $result['streetNumber']);
-        $this->assertEquals('District of Columbia', $result['cityDistrict']);
-        $this->assertEquals('Pennsylvania Ave NW', $result['streetName']);
-        $this->assertEquals('United States', $result['country']);
-        $this->assertEquals('US', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(38.898720, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(-77.036384, $results[0]['longitude'], '', 0.01);
+        $this->assertEquals(38.897119, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(-77.038432, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(38.90032, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(-77.034335, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertEquals(1600, $results[0]['streetNumber']);
+        $this->assertEquals('District of Columbia', $results[0]['cityDistrict']);
+        $this->assertEquals('Pennsylvania Ave NW', $results[0]['streetName']);
+        $this->assertEquals('United States', $results[0]['country']);
+        $this->assertEquals('US', $results[0]['countryCode']);
 
         // not provided
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['city']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertNull($result['timezone']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertNull($results[0]['city']);
+        $this->assertNull($results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(38.875642, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(-76.975442, $results[1]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(39.684978, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(-77.720720, $results[2]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(47.572849, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(-122.642072, $results[3]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(40.061443, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(-79.892317, $results[4]['longitude'], '', 0.01);
     }
 
     public function testGetGeocodedDataWithRealAddressWithBYLocale()
@@ -166,6 +226,11 @@ class YandexProviderTest extends TestCase
         $provider = new YandexProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'be-BY');
         $result   = $provider->getGeocodedData('ул.Ленина, 19, Минск 220030, Республика Беларусь');
 
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        $result = $result[0];
+        $this->assertInternalType('array', $result);
         $this->assertEquals(53.898077, $result['latitude'], '', 0.01);
         $this->assertEquals(27.563673, $result['longitude'], '', 0.01);
         $this->assertEquals(53.896867, $result['bounds']['south'], '', 0.01);
@@ -188,7 +253,7 @@ class YandexProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=2.000000,1.000000
+     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?format=json&geocode=2.000000,1.000000&results=5
      */
     public function testGetReversedData()
     {
@@ -198,7 +263,7 @@ class YandexProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=0.000000,0.000000
+     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?format=json&geocode=0.000000,0.000000&results=5
      */
     public function testGetReversedDataWithInvalidData()
     {
@@ -208,7 +273,7 @@ class YandexProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?results=1&format=json&geocode=2.388772,48.863216
+     * @expectedExceptionMessage Could not execute query http://geocode-maps.yandex.ru/1.x/?format=json&geocode=2.388772,48.863216&results=5
      */
     public function testGetReversedDataWithAddressGetsNullContent()
     {
@@ -219,100 +284,145 @@ class YandexProviderTest extends TestCase
     public function testGetReversedDataWithRealCoordinates()
     {
         $provider = new YandexProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter());
-        $result = $provider->getReversedData(array(48.863216489553, 2.388771995902061));
+        $results  = $provider->getReversedData(array(48.863216489553, 2.388771995902061));
 
-        $this->assertEquals(48.863212, $result['latitude'], '', 0.01);
-        $this->assertEquals(2.388773, $result['longitude'], '', 0.01);
-        $this->assertEquals(48.86294, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(2.387497, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(48.877038, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(2.423214, $result['bounds']['east'], '', 0.01);
-        $this->assertNull($result['streetNumber']);
-        $this->assertEquals('Иль-Де-Франс', $result['cityDistrict']);
-        $this->assertEquals('Avenue Gambetta', $result['streetName']);
-        $this->assertEquals('Франция', $result['country']);
-        $this->assertEquals('FR', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(3, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.863212, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(2.388773, $results[0]['longitude'], '', 0.01);
+        $this->assertEquals(48.86294, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.387497, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.877038, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.423214, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('Иль-Де-Франс', $results[0]['cityDistrict']);
+        $this->assertEquals('Avenue Gambetta', $results[0]['streetName']);
+        $this->assertEquals('Франция', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
 
         // not provided
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['city']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertNull($result['timezone']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertNull($results[0]['city']);
+        $this->assertNull($results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(48.709273, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(2.503371, $results[1]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(46.621810, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(2.452113, $results[2]['longitude'], '', 0.01);
     }
 
     public function testGetReversedDataWithRealCoordinatesWithUSLocaleAndStreeToponym()
     {
         $provider = new YandexProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'en-US', 'street');
-        $result = $provider->getReversedData(array(48.863216489553, 2.388771995902061));
+        $results  = $provider->getReversedData(array(48.863216489553, 2.388771995902061));
 
-        $this->assertEquals(48.87132, $result['latitude'], '', 0.01);
-        $this->assertEquals(2.404017, $result['longitude'], '', 0.01);
-        $this->assertEquals(48.86294, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(2.387497, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(48.877038, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(2.423214, $result['bounds']['east'], '', 0.01);
-        $this->assertNull($result['streetNumber']);
-        $this->assertEquals('Ile-de-France', $result['cityDistrict']);
-        $this->assertEquals('Avenue Gambetta', $result['streetName']);
-        $this->assertEquals('France', $result['country']);
-        $this->assertEquals('FR', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(48.87132, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(2.404017, $results[0]['longitude'], '', 0.01);
+        $this->assertEquals(48.86294, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(2.387497, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(48.877038, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(2.423214, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('Ile-de-France', $results[0]['cityDistrict']);
+        $this->assertEquals('Avenue Gambetta', $results[0]['streetName']);
+        $this->assertEquals('France', $results[0]['country']);
+        $this->assertEquals('FR', $results[0]['countryCode']);
 
         // not provided
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['city']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertNull($result['timezone']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertNull($results[0]['city']);
+        $this->assertNull($results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertEquals(48.863230, $results[1]['latitude'], '', 0.01);
+        $this->assertEquals(2.388261, $results[1]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[2]);
+        $this->assertEquals(48.866022, $results[2]['latitude'], '', 0.01);
+        $this->assertEquals(2.389662, $results[2]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[3]);
+        $this->assertEquals(48.863918, $results[3]['latitude'], '', 0.01);
+        $this->assertEquals(2.387767, $results[3]['longitude'], '', 0.01);
+
+        $this->assertInternalType('array', $results[4]);
+        $this->assertEquals(48.863787, $results[4]['latitude'], '', 0.01);
+        $this->assertEquals(2.389600, $results[4]['longitude'], '', 0.01);
     }
 
     public function testGetReversedDataWithRealCoordinatesWithUALocaleAndHouseToponym()
     {
         $provider = new YandexProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'uk-UA', 'house');
-        $result = $provider->getReversedData(array(60.4539471768582, 22.2567842183875));
+        $results  = $provider->getReversedData(array(60.4539471768582, 22.2567842183875));
 
-        $this->assertEquals(60.454462, $result['latitude'], '', 0.01);
-        $this->assertEquals(22.256561, $result['longitude'], '', 0.01);
-        $this->assertEquals(60.45345, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(22.254513, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(60.455474, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(22.258609, $result['bounds']['east'], '', 0.01);
-        $this->assertEquals(36, $result['streetNumber']);
-        $this->assertEquals('Исконная Финляндия', $result['cityDistrict']);
-        //$this->assertEquals('Bangårdsgatan', $result['streetName']);
-        $this->assertEquals('Фінляндія', $result['country']);
-        $this->assertEquals('FI', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(60.454462, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(22.256561, $results[0]['longitude'], '', 0.01);
+        $this->assertEquals(60.45345, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(22.254513, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(60.455474, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(22.258609, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertEquals(36, $results[0]['streetNumber']);
+        $this->assertEquals('Исконная Финляндия', $results[0]['cityDistrict']);
+        //$this->assertEquals('Bangårdsgatan', $results[0]['streetName']);
+        $this->assertEquals('Фінляндія', $results[0]['country']);
+        $this->assertEquals('FI', $results[0]['countryCode']);
 
         // not provided
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['city']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertNull($result['timezone']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertNull($results[0]['city']);
+        $this->assertNull($results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertNull($results[0]['timezone']);
     }
 
     public function testGetReversedDataWithRealCoordinatesWithTRLocaleAndLocalityToponym()
     {
         $provider = new YandexProvider(new \Geocoder\HttpAdapter\CurlHttpAdapter(), 'tr-TR', 'locality');
-        $result = $provider->getReversedData(array(40.900640, 29.198184));
+        $results  = $provider->getReversedData(array(40.900640, 29.198184));
 
-        $this->assertEquals(40.909452, $result['latitude'], '', 0.01);
-        $this->assertEquals(29.138608, $result['longitude'], '', 0.01);
-        $this->assertEquals(40.860413, $result['bounds']['south'], '', 0.01);
-        $this->assertEquals(29.072708, $result['bounds']['west'], '', 0.01);
-        $this->assertEquals(40.960403, $result['bounds']['north'], '', 0.01);
-        $this->assertEquals(29.204508, $result['bounds']['east'], '', 0.01);
-        $this->assertNull($result['streetNumber']);
-        $this->assertEquals('İstanbul', $result['cityDistrict']);
-        $this->assertNull($result['streetName']);
-        $this->assertEquals('Türkiye', $result['country']);
-        $this->assertEquals('TR', $result['countryCode']);
+        $this->assertInternalType('array', $results);
+        $this->assertCount(5, $results);
+
+        $this->assertInternalType('array', $results[0]);
+        $this->assertEquals(40.909452, $results[0]['latitude'], '', 0.01);
+        $this->assertEquals(29.138608, $results[0]['longitude'], '', 0.01);
+        $this->assertEquals(40.860413, $results[0]['bounds']['south'], '', 0.01);
+        $this->assertEquals(29.072708, $results[0]['bounds']['west'], '', 0.01);
+        $this->assertEquals(40.960403, $results[0]['bounds']['north'], '', 0.01);
+        $this->assertEquals(29.204508, $results[0]['bounds']['east'], '', 0.01);
+        $this->assertNull($results[0]['streetNumber']);
+        $this->assertEquals('İstanbul', $results[0]['cityDistrict']);
+        $this->assertNull($results[0]['streetName']);
+        $this->assertEquals('Türkiye', $results[0]['country']);
+        $this->assertEquals('TR', $results[0]['countryCode']);
 
         // not provided
-        $this->assertNull($result['zipcode']);
-        $this->assertNull($result['city']);
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
-        $this->assertNull($result['timezone']);
+        $this->assertNull($results[0]['zipcode']);
+        $this->assertNull($results[0]['city']);
+        $this->assertNull($results[0]['region']);
+        $this->assertNull($results[0]['regionCode']);
+        $this->assertNull($results[0]['timezone']);
+
+        $this->assertInternalType('array', $results[1]);
+        $this->assertInternalType('array', $results[2]);
+        $this->assertInternalType('array', $results[3]);
+        $this->assertInternalType('array', $results[4]);
     }
 }

--- a/tests/Geocoder/Tests/Result/DefaultResultFactoryTest.php
+++ b/tests/Geocoder/Tests/Result/DefaultResultFactoryTest.php
@@ -19,17 +19,33 @@ class DefaultResultFactoryTest extends TestCase
         $this->assertInstanceOf('Geocoder\Result\ResultInterface', $result);
     }
 
-    public function testCreateFromArray()
+    /**
+     * @dataProvider arrayProvider
+     */
+    public function testCreateFromArray($array, $expected)
     {
         $factory = new DefaultResultFactory();
-        $result  = $factory->createFromArray(array(
-            'latitude'  => 123,
-            'longitude' => 456,
-        ));
+        $result  = $factory->createFromArray($array);
 
         $this->assertInstanceOf('Geocoder\Result\Geocoded', $result);
         $this->assertInstanceOf('Geocoder\Result\ResultInterface', $result);
-        $this->assertEquals(123, $result->getLatitude());
-        $this->assertEquals(456, $result->getLongitude());
+        $this->assertEquals($expected['latitude'], $result->getLatitude());
+        $this->assertEquals($expected['longitude'], $result->getLongitude());
+    }
+
+    public function arrayProvider()
+    {
+        return array(
+            array(
+                array(
+                    array('latitude' => 123, 'longitude' => 456)
+                ),
+                array('latitude' => 123, 'longitude' => 456),
+            ),
+            array(
+                array('latitude' => 123, 'longitude' => 456),
+                array('latitude' => 123, 'longitude' => 456),
+            ),
+        );
     }
 }

--- a/tests/Geocoder/Tests/Result/GeocodedTest.php
+++ b/tests/Geocoder/Tests/Result/GeocodedTest.php
@@ -46,7 +46,7 @@ class GeocodedTest extends TestCase
         $coordinates = $this->geocoded->getCoordinates();
         $bounds = $this->geocoded->getBounds();
 
-        $this->assertTrue(is_array($coordinates));
+        $this->assertInternalType('array', $coordinates);
         $this->assertEquals(0.001, $coordinates[0]);
         $this->assertEquals(1, $coordinates[1]);
         $this->assertEquals(0.001, $this->geocoded->getLatitude());


### PR DESCRIPTION
- [x] FreeGeoIpProvider
- [x] HostIpProvider
- [x] IpInfoDbProvider
- [x] YahooProvider (REMOVED)
- [x] GoogleMapsProvider
- [x] GoogleMapsBusinessProvider
- [x] BingMapsProvider
- [x] OpenStreetMapsProvider
- [x] CloudMadeProvider
- [x] GeoipProvider
- [x] MapQuestProvider
- [x] OIORestProvider
- [x] GeocoderCaProvider
- [x] GeocoderUsProvider
- [x] IGNOpenLSProvider
- [x] DataScienceToolkitProvider
- [x] YandexProvider
- [x] GeoPluginProvider
- [x] GeoIPsProvider
- [x] MaxMindProvider
- [x] MaxMindBinaryProvider
- [x] GeonamesProvider
- [x] IpGeoBaseProvider
- [x] BaiduProvider
- [x] TomTomProvider
- [x] ArcGISOnlineProvider

@willdurand @Baachi What do you think ? 
