### PR TITLE
Absense of results breaks batch encoding

### DIFF
--- a/src/Geocoder/Provider/ChainProvider.php
+++ b/src/Geocoder/Provider/ChainProvider.php
@@ -56,8 +56,6 @@ class ChainProvider implements ProviderInterface
             } catch (\Exception $e) {
             }
         }
-
-        throw new NoResultException(sprintf('No provider could provide the address "%s"', $address));
     }
 
     /**


### PR DESCRIPTION
In batch geoencoding if no results, script breaks https://github.com/willdurand/Geocoder/blob/master/src/Geocoder/Provider/ChainProvider.php#L60

Simple solution : remove the throw. Any other simple ideas to have the possibilities of batching ?
