### PR TITLE
Revert GoogleBusinessProvider "client_id" parameter back to just "client"

### DIFF
--- a/src/Geocoder/Provider/GoogleMapsBusinessProvider.php
+++ b/src/Geocoder/Provider/GoogleMapsBusinessProvider.php
@@ -61,7 +61,7 @@ class GoogleMapsBusinessProvider extends GoogleMapsProvider
     protected function buildQuery($query)
     {
         $query = parent::buildQuery($query);
-        $query = sprintf('%s&client_id=%s', $query, $this->clientId);
+        $query = sprintf('%s&client=%s', $query, $this->clientId);
 
         if (null !== $this->privateKey) {
             $query = $this->signQuery($query);

--- a/tests/Geocoder/Tests/Provider/GoogleMapsBusinessProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GoogleMapsBusinessProviderTest.php
@@ -28,7 +28,8 @@ class GoogleMapsBusinessProviderTest extends TestCase
 
         $query = 'http://maps.googleapis.com/maps/api/geocode/json?address=blah&sensor=false';
 
-        $this->assertEquals($query.'&client_id=foo', $method->invoke($provider, $query));
+
+        $this->assertEquals($query.'&client=foo', $method->invoke($provider, $query));
     }
 
     public function testBuildQueryWithPrivateKey()
@@ -47,7 +48,7 @@ class GoogleMapsBusinessProviderTest extends TestCase
 
         $query = 'http://maps.googleapis.com/maps/api/geocode/json?address=blah&sensor=false';
 
-        $this->assertEquals($query.'&client_id=foo&signature=jIGtKeuAW-UjGrj9Mfcclww0rmc=', $method->invoke($provider, $query));
+        $this->assertEquals($query.'&client=foo&signature=JY4upbd7fi76C-bMGYk410gmB5g=', $method->invoke($provider, $query));
     }
 
     public function testSignQuery()


### PR DESCRIPTION
This reverts commit 532345bbd41221d2460591844dfffb04194c662a and a918a19d148911ce8d686246f789285060b579a5.

See: https://github.com/willdurand/Geocoder/commit/a918a19d148911ce8d686246f789285060b579a5
