### PR TITLE
replace extension_exists() by function_exists() for mbstring

### DIFF
--- a/src/Geocoder/Result/AbstractResult.php
+++ b/src/Geocoder/Result/AbstractResult.php
@@ -60,7 +60,7 @@ abstract class AbstractResult implements \ArrayAccess
      */
     protected function formatString($str)
     {
-        if (extension_loaded('mbstring')) {
+        if (function_exists('mb_convert_case')) {
             $str = mb_convert_case($str, MB_CASE_TITLE, 'UTF-8');
         } else {
             $str = $this->lowerize($str);
@@ -82,7 +82,7 @@ abstract class AbstractResult implements \ArrayAccess
      */
     protected function lowerize($str)
     {
-        return extension_loaded('mbstring') ? mb_strtolower($str, 'UTF-8') : strtolower($str);
+        return function_exists('mb_strtolower') ? mb_strtolower($str, 'UTF-8') : strtolower($str);
     }
 
     /**
@@ -94,6 +94,6 @@ abstract class AbstractResult implements \ArrayAccess
      */
     protected function upperize($str)
     {
-        return extension_loaded('mbstring') ? mb_strtoupper($str, 'UTF-8') : strtoupper($str);
+        return function_exists('mb_strtoupper') ? mb_strtoupper($str, 'UTF-8') : strtoupper($str);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!extension_loaded('curl') || !function_exists('curl_init')) {
+if (!function_exists('curl_init')) {
     die(<<<EOT
 cURL has to be enabled!
 EOT


### PR DESCRIPTION
Alternative implementations exists for mbstring features,
this patch uses function_exists() instead of extension_exists() to check for "feature" instead of "implementation".
See https://packagist.org/packages/patchwork/utf8
