### PR TITLE
Updating GeoIPs provider to expect a single location response

### DIFF
--- a/src/Geocoder/Provider/GeoIPsProvider.php
+++ b/src/Geocoder/Provider/GeoIPsProvider.php
@@ -157,25 +157,23 @@ class GeoIPsProvider extends AbstractProvider implements ProviderInterface
         }
 
         // Make sure that we do have proper result array
-        if (empty($response['locations']) || !is_array($response['locations']) || empty($response['locations'][0])) {
+        if (empty($response['location']) || !is_array($response['location'])) {
             throw new NoResultException(sprintf('Invalid response from GeoIPs server for query %s', $query));
         }
 
-        // Pick the first location from the response
         $locations = array();
-        foreach ($response['locations'] as $location) {
-            $locations[] = array_merge($this->getDefaults(), array(
-                'country'     => '' === $location['country_name'] ? null : $location['country_name'],
-                'countryCode' => '' === $location['country_code'] ? null : $location['country_code'],
-                'region'      => '' === $location['region_name']  ? null : $location['region_name'],
-                'regionCode'  => '' === $location['region_code']  ? null : $location['region_code'],
-                'county'      => '' === $location['county_name']  ? null : $location['county_name'],
-                'city'        => '' === $location['city_name']    ? null : $location['city_name'],
-                'latitude'    => '' === $location['latitude']     ? null : $location['latitude'],
-                'longitude'   => '' === $location['longitude']    ? null : $location['longitude'],
-                'timezone'    => '' === $location['timezone']     ? null : $location['timezone'],
-            ));
-        }
+        $location = $response['location'];
+        $locations[] = array_merge($this->getDefaults(), array(
+            'country'     => '' === $location['country_name'] ? null : $location['country_name'],
+            'countryCode' => '' === $location['country_code'] ? null : $location['country_code'],
+            'region'      => '' === $location['region_name']  ? null : $location['region_name'],
+            'regionCode'  => '' === $location['region_code']  ? null : $location['region_code'],
+            'county'      => '' === $location['county_name']  ? null : $location['county_name'],
+            'city'        => '' === $location['city_name']    ? null : $location['city_name'],
+            'latitude'    => '' === $location['latitude']     ? null : $location['latitude'],
+            'longitude'   => '' === $location['longitude']    ? null : $location['longitude'],
+            'timezone'    => '' === $location['timezone']     ? null : $location['timezone'],
+        ));
 
         return $locations;
     }

--- a/tests/Geocoder/Tests/Provider/GeoIPsProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoIPsProviderTest.php
@@ -110,7 +110,7 @@ class GeoIPsProviderTest extends TestCase
             "message": "Success",
             "notes": "The following results has been returned",
             "code": "200_1",
-            "locations": [{
+            "location": {
                 "ip" : "66.147.244.214",
                 "owner" : "",
                 "continent_name" : "",
@@ -124,7 +124,7 @@ class GeoIPsProviderTest extends TestCase
                 "latitude" : "",
                 "longitude" : "",
                 "timezone" : ""
-            }],
+            },
             "unit_test": {
                 "elapsed_time": "0.0676",
                 "memory_usage": "2.2MB"
@@ -156,7 +156,7 @@ class GeoIPsProviderTest extends TestCase
             "message": "Success",
             "notes": "The following results has been returned",
             "code": "200_1",
-            "locations": [{
+            "location": {
                 "ip" : "66.147.244.214",
                 "owner" : "BLUEHOST INC.",
                 "continent_name" : "NORTH AMERICA",
@@ -170,7 +170,7 @@ class GeoIPsProviderTest extends TestCase
                 "latitude" : "40.3402",
                 "longitude" : "-111.6073",
                 "timezone" : "MST"
-            }]
+            }
         }}';
 
         $provider = new GeoIPsProvider($this->getMockAdapterReturns($json), 'api_key');


### PR DESCRIPTION
One change to expect multiple locations returned by the service as proposed in PR #273 and merged at https://github.com/geocoder-php/Geocoder/commit/622ac5e88a7a1630d829a66a8b1d65d8d60021f9 seems not to be valid anymore.

The <a href="http://www.geoips.com/en/developer/api-guide">API Documentation</a> describes a single `location` xml element in accordance with the response i get from querying the service.

FYI ping @Thinkscape
