### PR TITLE
Adding tests/ to namespace autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "geoip/geoip": "If you are going to use the MaxMindBinaryProvider (conflict with geoip extension)."
     },
     "autoload": {
-        "psr-0": { "Geocoder": "src/" }
+        "psr-0": { "Geocoder": ["src/", "tests/"] }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
When extending and writing customer providers, being able to use the pre-built classes available to test within your own unit tests is always a good time.
