### PR TITLE
Not Enforcing String on Geocode Data

### DIFF
--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -95,13 +95,17 @@ class Geocoder implements GeocoderInterface
      */
     public function geocode($value)
     {
+        if (is_string($value)) {
+            $value = trim($value);
+        }
+
         if (empty($value)) {
             // let's save a request
             return $this->returnResult(array());
         }
 
         $provider = $this->getProvider()->setMaxResults($this->getMaxResults());
-        $data     = $provider->getGeocodedData(trim($value));
+        $data     = $provider->getGeocodedData($value);
         $result   = $this->returnResult($data);
 
         return $result;


### PR DESCRIPTION
My data collection comes in as an array, and my customer provider sends data to the geocoding service parameterized, and it would be easier to not have to pre-json encode and then json decode the data on the provider end of things.  The only thing that really requires the data be in string format is the trim().

This will also help out if someone passes in a string with only white space.
