### PR TITLE
Add support for a Google Maps API key

### DIFF
--- a/src/Geocoder/Provider/GoogleMapsProvider.php
+++ b/src/Geocoder/Provider/GoogleMapsProvider.php
@@ -13,6 +13,7 @@ namespace Geocoder\Provider;
 use Geocoder\Exception\NoResultException;
 use Geocoder\Exception\QuotaExceededException;
 use Geocoder\Exception\UnsupportedException;
+use Geocoder\Exception\InvalidCredentialsException;
 use Geocoder\HttpAdapter\HttpAdapterInterface;
 
 /**
@@ -39,19 +40,26 @@ class GoogleMapsProvider extends AbstractProvider implements LocaleAwareProvider
      * @var bool
      */
     private $useSsl = false;
+    
+    /**
+     * @var string
+     */
+    private $key = null;
 
     /**
      * @param HttpAdapterInterface $adapter An HTTP adapter.
      * @param string               $locale  A locale (optional).
      * @param string               $region  Region biasing (optional).
      * @param bool                 $useSsl  Whether to use an SSL connection (optional)
+     * @param string               $key     Google Geocoding API key (optional)
      */
-    public function __construct(HttpAdapterInterface $adapter, $locale = null, $region = null, $useSsl = false)
+    public function __construct(HttpAdapterInterface $adapter, $locale = null, $region = null, $useSsl = false, $key = null)
     {
         parent::__construct($adapter, $locale);
 
         $this->region = $region;
         $this->useSsl = $useSsl;
+        $this->key = $key;
     }
 
     /**
@@ -103,6 +111,10 @@ class GoogleMapsProvider extends AbstractProvider implements LocaleAwareProvider
         if (null !== $this->getRegion()) {
             $query = sprintf('%s&region=%s', $query, $this->getRegion());
         }
+        
+        if (null !== $this->getKey()) {
+            $query = sprintf('%s&key=%s', $query, $this->getKey());
+        }
 
         return $query;
     }
@@ -127,6 +139,10 @@ class GoogleMapsProvider extends AbstractProvider implements LocaleAwareProvider
         // API error
         if (!isset($json)) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
+        }
+
+        if('REQUEST_DENIED' === $json->status && 'The provided API key is invalid.' == $json->error_message) {
+            throw new InvalidCredentialsException(sprintf('API key is invalid %s', $query));
         }
 
         // you are over your quota
@@ -241,5 +257,15 @@ class GoogleMapsProvider extends AbstractProvider implements LocaleAwareProvider
     protected function getRegion()
     {
         return $this->region;
+    }
+    
+    /**
+     * Returns the configured key or null.
+     *
+     * @return string|null
+     */
+    protected function getKey()
+    {
+        return $this->key;
     }
 }

--- a/tests/Geocoder/Tests/Provider/GoogleMapsProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GoogleMapsProviderTest.php
@@ -286,4 +286,14 @@ class GoogleMapsProviderTest extends TestCase
         $this->assertInternalType('array', $result);
         $this->assertEquals('Kalbach-Riedberg', $result['cityDistrict']);
     }
+
+    /**
+     * @expectedException \Geocoder\Exception\InvalidCredentialsException
+     * @expectedExceptionMessage API key is invalid http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France&sensor=false
+     */
+    public function testGetGeocodedDataWithInavlidApiKey()
+    {
+        $provider = new GoogleMapsProvider($this->getMockAdapterReturns('{"error_message":"The provided API key is invalid.", "status":"REQUEST_DENIED"}'));
+        $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
+    }
 }


### PR DESCRIPTION
From https://developers.google.com/maps/documentation/geocoding/#api_key:
All Geocoding API applications should use an API key. Including a key in your request:
- Allows you to monitor your application's API usage in the APIs Console.
- Enables per-key instead of per-IP-address quota limits.
- Ensures that Google can contact you about your application if necessary.
