### PR TITLE
Use hhvm-nightly instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ php:
     - 5.3
     - 5.4
     - 5.5
-    - hhvm
+    - hhvm-nightly
 
 matrix:
     allow_failures:
-        - php: hhvm
+        - php: hhvm-nightly
 
 before_script:
     - composer self-update


### PR DESCRIPTION
The HHVM nigthly fixes https://github.com/geocoder-php/Geocoder/issues/271 as you can see here https://travis-ci.org/toin0u/Geocoder/jobs/25292156 :)

There is still a weird output:

``` text
Entity: line 1: parser error : Start tag expected, '<' not found
https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&query=&maxResults=5
^
.Entity: line 1: parser error : Start tag expected, '<' not found
https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&query=&maxResults=5
^
..Entity: line 1: parser error : Start tag expected, '<' not found
https://api.tomtom.com/lbs/geocoding/geocode?key=api_key&query=Tagensvej%2047%2C
^
..SSSS.....Entity: line 1: parser error : Start tag expected, '<' not found
https://api.tomtom.com/lbs/services/reverseGeocode/3/xml?key=api_key&point=1.000
```

I've looked closer to this, it's something with `SimpleXmlElement` here https://github.com/geocoder-php/Geocoder/blob/master/src/Geocoder/Provider/TomTomProvider.php#L107. Maybe a coming version of HHVM will fix this problem..
