### PR TITLE
Throw InvalidCredentialsException with GoogleMBP

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ Rename the `phpunit.xml.dist` file to `phpunit.xml`, then uncomment the followin
     <!-- <server name="BAIDU_API_KEY" value="YOUR_API_KEY" /> -->
     <!-- <server name="TOMTOM_GEOCODING_KEY" value="YOUR_GEOCODING_KEY" /> -->
     <!-- <server name="TOMTOM_MAP_KEY" value="YOUR_MAP_KEY" /> -->
+    <!-- <server name="GOOGLE_GEOCODING_KEY" value="YOUR_GEOCODING_KEY" /> -->
 </php>
 ```
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,7 @@
         <!-- <server name="BAIDU_API_KEY" value="YOUR_API_KEY" /> -->
         <!-- <server name="TOMTOM_GEOCODING_KEY" value="YOUR_GEOCODING_KEY" /> -->
         <!-- <server name="TOMTOM_MAP_KEY" value="YOUR_MAP_KEY" /> -->
+        <!-- <server name="GOOGLE_GEOCODING_KEY" value="YOUR_GEOCODING_KEY" /> -->
     </php>
     <testsuites>
         <testsuite name="Geocoder Test Suite">

--- a/src/Geocoder/Provider/GoogleMapsProvider.php
+++ b/src/Geocoder/Provider/GoogleMapsProvider.php
@@ -130,6 +130,11 @@ class GoogleMapsProvider extends AbstractProvider implements LocaleAwareProvider
 
         $content = $this->getAdapter()->getContent($query);
 
+        // Throw exception if invalid clientID and/or privateKey used with GoogleMapsBusinessProvider
+        if (strpos($content, "Provided 'signature' is not valid for the provided client ID") !== false) {
+            throw new InvalidCredentialsException(sprintf('Invalid client ID / API Key %s', $query));
+        }
+
         if (null === $content) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }

--- a/tests/Geocoder/Tests/Provider/GoogleMapsBusinessProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GoogleMapsBusinessProviderTest.php
@@ -68,4 +68,26 @@ class GoogleMapsBusinessProviderTest extends TestCase
 
         $this->assertEquals($query.'&signature=yd07DufNspPyDE-Vj6nTeI5Fk-o=', $method->invoke($provider, $query));
     }
+
+    /**
+     * @expectedException Geocoder\Exception\InvalidCredentialsException
+     * @expectedExceptionMessage Invalid client ID / API Key https://maps.googleapis.com/maps/api/geocode/json?address=Columbia%20University&sensor=false&client=foo&signature=xhvnqoQoLos6iqijCu3b1Odmqr0=
+     */
+    public function testGetGeocodedDataWithInvalidClientIdAndKey()
+    {
+        $provider = new GoogleMapsBusinessProvider($this->getAdapter(), $this->testClientId, $this->testPrivateKey, null, null, true);
+
+        $provider->getGeocodedData('Columbia University');
+    }
+
+    /**
+     * @expectedException Geocoder\Exception\InvalidCredentialsException
+     * @expectedExceptionMessage Invalid client ID / API Key http://maps.googleapis.com/maps/api/geocode/json?address=Columbia%20University&sensor=false&client=foo&signature=xhvnqoQoLos6iqijCu3b1Odmqr0=
+     */
+    public function testGetGeocodedDataWithINvalidClientIdAndKeyNoSsl()
+    {
+        $provider = new GoogleMapsBusinessProvider($this->getAdapter(), $this->testClientId, $this->testPrivateKey, null, null, false);
+
+        $provider->getGeocodedData('Columbia University', true);
+    }
 }


### PR DESCRIPTION
- When an invalid clientID / privateKey
  combination is used with the
  GoogleMapsBusinessProvider, throw an
  InvalidCredentialsException instead of a
  NoResultException.
- Test that the exception is thrown with the
  testGetGeocodedDataWithInvalidClientIdAndKey(),
  and
  testGetGeocodedDataWithINvalidClientIdAndKeyNoSsl()
  methods.
- Add two tests for the GoogleMapsProvider to
  test that expected results are returned when using
  a valid API Key (commented example added to
  phpunit.xml.dist and README.md) and that an
  InvalidCredentialsException is thrown when an
  incorrect API Key is used.
