### PR TITLE
Google API Sensor paramater is no longer required

### DIFF
--- a/src/Geocoder/Provider/GoogleMapsProvider.php
+++ b/src/Geocoder/Provider/GoogleMapsProvider.php
@@ -24,12 +24,12 @@ class GoogleMapsProvider extends AbstractProvider implements LocaleAwareProvider
     /**
      * @var string
      */
-    const ENDPOINT_URL = 'http://maps.googleapis.com/maps/api/geocode/json?address=%s&sensor=false';
+    const ENDPOINT_URL = 'http://maps.googleapis.com/maps/api/geocode/json?address=%s';
 
     /**
      * @var string
      */
-    const ENDPOINT_URL_SSL = 'https://maps.googleapis.com/maps/api/geocode/json?address=%s&sensor=false';
+    const ENDPOINT_URL_SSL = 'https://maps.googleapis.com/maps/api/geocode/json?address=%s';
 
     /**
      * @var string

--- a/tests/Geocoder/Tests/Provider/GoogleMapsBusinessProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GoogleMapsBusinessProviderTest.php
@@ -26,7 +26,7 @@ class GoogleMapsBusinessProviderTest extends TestCase
 
         $provider = new GoogleMapsBusinessProvider($this->getMockAdapter($this->never()), $this->testClientId);
 
-        $query = 'http://maps.googleapis.com/maps/api/geocode/json?address=blah&sensor=false';
+        $query = 'http://maps.googleapis.com/maps/api/geocode/json?address=blah';
 
         $this->assertEquals($query.'&client=foo', $method->invoke($provider, $query));
     }
@@ -45,7 +45,7 @@ class GoogleMapsBusinessProviderTest extends TestCase
             $this->testPrivateKey
         );
 
-        $query = 'http://maps.googleapis.com/maps/api/geocode/json?address=blah&sensor=false';
+        $query = 'http://maps.googleapis.com/maps/api/geocode/json?address=blah';
 
         $this->assertEquals($query.'&client=foo&signature=JY4upbd7fi76C-bMGYk410gmB5g=', $method->invoke($provider, $query));
     }
@@ -64,14 +64,14 @@ class GoogleMapsBusinessProviderTest extends TestCase
             $this->testPrivateKey
         );
 
-        $query = 'http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France&sensor=false';
+        $query = 'http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France';
 
         $this->assertEquals($query.'&signature=yd07DufNspPyDE-Vj6nTeI5Fk-o=', $method->invoke($provider, $query));
     }
 
     /**
      * @expectedException Geocoder\Exception\InvalidCredentialsException
-     * @expectedExceptionMessage Invalid client ID / API Key https://maps.googleapis.com/maps/api/geocode/json?address=Columbia%20University&sensor=false&client=foo&signature=xhvnqoQoLos6iqijCu3b1Odmqr0=
+     * @expectedExceptionMessage Invalid client ID / API Key https://maps.googleapis.com/maps/api/geocode/json?address=Columbia%20University&client=foo&signature=xhvnqoQoLos6iqijCu3b1Odmqr0=
      */
     public function testGetGeocodedDataWithInvalidClientIdAndKey()
     {
@@ -82,7 +82,7 @@ class GoogleMapsBusinessProviderTest extends TestCase
 
     /**
      * @expectedException Geocoder\Exception\InvalidCredentialsException
-     * @expectedExceptionMessage Invalid client ID / API Key http://maps.googleapis.com/maps/api/geocode/json?address=Columbia%20University&sensor=false&client=foo&signature=xhvnqoQoLos6iqijCu3b1Odmqr0=
+     * @expectedExceptionMessage Invalid client ID / API Key http://maps.googleapis.com/maps/api/geocode/json?address=Columbia%20University&client=foo&signature=xhvnqoQoLos6iqijCu3b1Odmqr0=
      */
     public function testGetGeocodedDataWithINvalidClientIdAndKeyNoSsl()
     {

--- a/tests/Geocoder/Tests/Provider/GoogleMapsProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/GoogleMapsProviderTest.php
@@ -20,7 +20,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=foobar&sensor=false
+     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=foobar
      */
     public function testGetGeocodedData()
     {
@@ -30,7 +30,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=&sensor=false
+     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=
      */
     public function testGetGeocodedDataWithNull()
     {
@@ -40,7 +40,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=&sensor=false
+     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=
      */
     public function testGetGeocodedDataWithEmpty()
     {
@@ -80,7 +80,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France&sensor=false
+     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France
      */
     public function testGetGeocodedDataWithAddressGetsNullContent()
     {
@@ -90,7 +90,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France&sensor=false
+     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France
      */
     public function testGetGeocodedDataWithAddressGetsEmptyContent()
     {
@@ -100,7 +100,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\QuotaExceededException
-     * @expectedExceptionMessage Daily quota exceeded http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France&sensor=false
+     * @expectedExceptionMessage Daily quota exceeded http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France
      */
     public function testGetGeocodedDataWithQuotaExceeded()
     {
@@ -241,7 +241,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=1.000000%2C2.000000&sensor=false
+     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=1.000000%2C2.000000
      */
     public function testGetReversedData()
     {
@@ -271,7 +271,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResultException
-     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=48.863151%2C2.388911&sensor=false
+     * @expectedExceptionMessage Could not execute query http://maps.googleapis.com/maps/api/geocode/json?address=48.863151%2C2.388911
      */
     public function testGetReversedDataWithCoordinatesGetsNullContent()
     {
@@ -294,7 +294,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\InvalidCredentialsException
-     * @expectedExceptionMessage API key is invalid http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France&sensor=false
+     * @expectedExceptionMessage API key is invalid http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France
      */
     public function testGetGeocodedDataWithInavlidApiKey()
     {
@@ -326,7 +326,7 @@ class GoogleMapsProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\InvalidCredentialsException
-     * @expectedExceptionMessage API key is invalid https://maps.googleapis.com/maps/api/geocode/json?address=Columbia%20University&sensor=false&key=fake_key
+     * @expectedExceptionMessage API key is invalid https://maps.googleapis.com/maps/api/geocode/json?address=Columbia%20University&key=fake_key
      */
     public function testGetGeocodedDataWithRealInvalidApiKey()
     {


### PR DESCRIPTION
The Google API previously required that you include the sensor parameter to indicate whether your application used a sensor to determine the user's location. This parameter is no longer required.
- https://developers.google.com/maps/documentation/geocoding/#Sensor
