### PR TITLE
Curl needs the abillity to set a custom user agent with nominatim

### DIFF
--- a/src/Geocoder/HttpAdapter/CurlHttpAdapter.php
+++ b/src/Geocoder/HttpAdapter/CurlHttpAdapter.php
@@ -21,10 +21,13 @@ class CurlHttpAdapter implements HttpAdapterInterface
 
     private $connectTimeout;
 
-    public function __construct($timeout = null, $connectTimeout = null)
+    private $userAgent;
+
+    public function __construct($timeout = null, $connectTimeout = null, $userAgent = null)
     {
         $this->timeout = $timeout;
         $this->connectTimeout = $connectTimeout;
+        $this->userAgent = $userAgent;
     }
 
     /**
@@ -46,6 +49,10 @@ class CurlHttpAdapter implements HttpAdapterInterface
 
         if ($this->connectTimeout) {
             curl_setopt($c, CURLOPT_CONNECTTIMEOUT, $this->connectTimeout);
+        }
+        
+        if ($this->userAgent) {
+            curl_setopt($c, CURLOPT_USERAGENT, $this->userAgent);
         }
 
         $content = curl_exec($c);


### PR DESCRIPTION
If no user agent is set, it would be possible to get a php notice inside the result.

see https://github.com/twain47/Nominatim/blob/master/lib/log.php#L45

If not set the content of the nominatim response is:

```
string(1769) "
Notice: Undefined index: HTTP_USER_AGENT in /home/xxx/Nominatim-2.2.0/lib/log.php on line 28



Rue de ParisGambettaNîmesNimesLanguedoc-Roussillon30900fr
10Rue GambettaMassif-ArmoricainPôle de proximité Nantes-LoireNantesNantesPays de la Loire44000fr"
```
