### PR TITLE
geoplugin returns 206 for anonymous proxies

### DIFF
--- a/src/Geocoder/Provider/GeoPluginProvider.php
+++ b/src/Geocoder/Provider/GeoPluginProvider.php
@@ -76,7 +76,7 @@ class GeoPluginProvider extends AbstractProvider implements ProviderInterface
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 
-        if (!array_key_exists('geoplugin_status', $json) || (200 !== $json['geoplugin_status'])) {
+        if (!array_key_exists('geoplugin_status', $json) || (200 !== $json['geoplugin_status'] && 206 !== $json['geoplugin_status'])) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 


### PR DESCRIPTION
GeoPlugin returns 206 as `geoplugin_status` for anonymous proxies. Currently only 200 is checkod for successful queries. 206 also needs to be checked
