### PR TITLE
Remove GeoIP2 Omni support

### DIFF
--- a/src/Geocoder/HttpAdapter/GeoIP2Adapter.php
+++ b/src/Geocoder/HttpAdapter/GeoIP2Adapter.php
@@ -24,7 +24,6 @@ class GeoIP2Adapter implements HttpAdapterInterface
      */
     const GEOIP2_MODEL_CITY    = 'city';
     const GEOIP2_MODEL_COUNTRY = 'country';
-    const GEOIP2_MODEL_OMNI    = 'omni';
 
     /**
      * @var ProviderInterface
@@ -129,7 +128,6 @@ class GeoIP2Adapter implements HttpAdapterInterface
         $availableMethods = array(
             self::GEOIP2_MODEL_CITY,
             self::GEOIP2_MODEL_COUNTRY,
-            self::GEOIP2_MODEL_OMNI
         );
 
         return in_array($method, $availableMethods);

--- a/tests/Geocoder/Tests/HttpAdapter/GeoIP2AdapterTest.php
+++ b/tests/Geocoder/Tests/HttpAdapter/GeoIP2AdapterTest.php
@@ -72,7 +72,6 @@ class GeoIP2AdapterTest extends TestCase
         return array(
             array(GeoIP2Adapter::GEOIP2_MODEL_CITY),
             array(GeoIP2Adapter::GEOIP2_MODEL_COUNTRY),
-            array(GeoIP2Adapter::GEOIP2_MODEL_OMNI),
         );
     }
 
@@ -81,8 +80,6 @@ class GeoIP2AdapterTest extends TestCase
      */
     public function testIpAddressIsPassedCorrectToReader($geoIp2Model)
     {
-        $this->markTestSkipped('FIXME: issue with jsonSerialize() method...');
-
         $geoIp2Provider = $this->getGeoIP2ProviderMock();
         $geoIp2Provider
             ->expects($this->any())


### PR DESCRIPTION
This was removed from the GeoIP2 API. It is still in pre-1.0 state, and there were some API breakage between 0.x releases. A 1.0.0 release should be available in the next couple of weeks, and Semantic Versioning will be used.

The other alternative would be to pin 0.6.x.
