### PR TITLE
Readme with provider table

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Currently, there are many providers for the following APIs:
 
 Address-based geocoding
 
+
 provider      | reverse | SSL | coverage | terms 
-:------------- |:--------- |:--------- |:--------- 
+:------------- |:--------- |:--------- |:--------- |:-----
 [Google Maps](https://developers.google.com/maps/documentation/geocoding/) | yes | no | worldwide | requires API key. Limit 2500 requests per day
 [Google Maps for Business](https://developers.google.com/maps/documentation/business/) | yes | no | worldwide | requires API key. Limit 100,000 requests per day
 [Bing Maps](http://msdn.microsoft.com/en-us/library/ff701713.aspx) | yes | no | worldwide | requires API key. Limit 10,000 requests per month.
@@ -49,6 +50,8 @@ Nominatim    | yes | supported | worldwide | requires a domain name (e.g. local 
 [TomTom](https://geocoder.tomtom.com/app/view/index)  | yes | required | worldwide | requires API key. First 2500 requests or 30 days free
 [ArcGIS Online](https://developers.arcgis.com/en/features/geocoding/) | yes | supported | worldwide | requires API key. 1250 requests free
 ChainProvider | | | | meta provider which iterates over a list of providers
+
+
 
 
 IP-based geocoding


### PR DESCRIPTION
I converted the list of providers into a table and split address- and ip-based geocoders (datasciencetoolkit is in both tables). I also added most terms and limit. Actually the terms of service of some providers are quite strict. Google and Bing for example allow geocoding only to be used with their maps, others require strict attribution or forbid storing or caching of any kind...

In my opinion it's more read-able but I can understand if you disagree or prefer text-only lists.

Disclaimer: I work for OpenCage so I had a ready list of terms from various providers in an Excel spreadsheet already.
