### PR TITLE
Add ability to change providers locale at runtime

### DIFF
--- a/src/Geocoder/Provider/AbstractProvider.php
+++ b/src/Geocoder/Provider/AbstractProvider.php
@@ -78,11 +78,7 @@ abstract class AbstractProvider
     }
 
     /**
-     * Sets the locale to be used.
-     *
-     * @param string|null $locale If no locale is set, the provider or service will fallback.
-     *
-     * @return AbstractProvider
+     * {@inheritDoc}
      */
     public function setLocale($locale = null)
     {

--- a/src/Geocoder/Provider/LocaleAwareProvider.php
+++ b/src/Geocoder/Provider/LocaleAwareProvider.php
@@ -20,4 +20,13 @@ interface LocaleAwareProvider extends Provider
      * @return string|null
      */
     public function getLocale();
+
+    /**
+     * Sets the locale to be used.
+     *
+     * @param string|null $locale If no locale is set, the provider or service will fallback.
+     *
+     * @return LocaleAwareProvider Self object
+     */
+    public function setLocale($locale = null);
 }

--- a/src/Geocoder/ProviderBasedGeocoder.php
+++ b/src/Geocoder/ProviderBasedGeocoder.php
@@ -11,8 +11,9 @@
 namespace Geocoder;
 
 use Geocoder\Exception\ProviderNotRegistered;
-use Geocoder\Provider\Provider;
 use Geocoder\Model\AddressFactory;
+use Geocoder\Provider\LocaleAwareProvider;
+use Geocoder\Provider\Provider;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -166,6 +167,20 @@ class ProviderBasedGeocoder implements Geocoder
     public function getMaxResults()
     {
         return $this->maxResults;
+    }
+
+    /**
+     * Change the locale to be used in locale aware requests.
+     *
+     * @param string
+     */
+    public function setLocale($locale)
+    {
+        foreach ($this->providers as $provider) {
+            if ($provider instanceof LocaleAwareProvider) {
+                $provider->setLocale($locale);
+            }
+        }
     }
 
     /**

--- a/tests/Geocoder/TestsProviderBasedGeocoderTest.php
+++ b/tests/Geocoder/TestsProviderBasedGeocoderTest.php
@@ -2,10 +2,11 @@
 
 namespace Geocoder\Tests;
 
-use Geocoder\ProviderBasedGeocoder;
-use Geocoder\Provider\Provider;
 use Geocoder\Model\Address;
 use Geocoder\Model\AddressFactory;
+use Geocoder\ProviderBasedGeocoder;
+use Geocoder\Provider\LocaleAwareProvider;
+use Geocoder\Provider\Provider;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -150,6 +151,19 @@ class ProviderBasedGeocoderTest extends TestCase
         $this->assertSame(3, $this->geocoder->getMaxResults());
     }
 
+    public function testSetLocale()
+    {
+        $provider1 = new MockProvider('test1');
+        $provider2 = new MockLocaleAwareProvider('test2');
+
+        $this->geocoder->registerProviders([$provider1, $provider2]);
+        $this->geocoder->setLocale('en');
+        $this->assertEquals('en', $provider2->getLocale());
+
+        $this->geocoder->setLocale(null);
+        $this->assertNull($provider2->getLocale());
+    }
+
     public function testDefaultMaxResults()
     {
         $this->assertSame(ProviderBasedGeocoder::MAX_RESULTS, $this->geocoder->getMaxResults());
@@ -187,6 +201,23 @@ class MockProvider implements Provider
 
     public function setMaxResults($maxResults)
     {
+        return $this;
+    }
+}
+
+class MockLocaleAwareProvider extends MockProvider implements LocaleAwareProvider
+{
+    protected $locale;
+
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    public function setLocale($locale = null)
+    {
+        $this->locale = $locale;
+
         return $this;
     }
 }


### PR DESCRIPTION
This simply adds a `setLocale()` method on the `ProviderBasedGeocoder` class which set the locale on every registered providers implementing `LocaleAwareProvider`.

Fix #322 
