### PR TITLE
[RFC] Make Provider extends Geocoder

### DIFF
--- a/src/Geocoder/Provider/AbstractProvider.php
+++ b/src/Geocoder/Provider/AbstractProvider.php
@@ -10,6 +10,7 @@
 
 namespace Geocoder\Provider;
 
+use Geocoder\Model\AddressFactory;
 use Geocoder\ProviderBasedGeocoder;
 use Ivory\HttpAdapter\HttpAdapterInterface;
 
@@ -34,6 +35,11 @@ abstract class AbstractProvider
     protected $maxResults = ProviderBasedGeocoder::MAX_RESULTS;
 
     /**
+     * @var AddressFactory
+     */
+    protected $factory;
+
+    /**
      * @param HttpAdapterInterface $adapter An HTTP adapter.
      * @param string               $locale  A locale (optional).
      */
@@ -41,6 +47,7 @@ abstract class AbstractProvider
     {
         $this->setAdapter($adapter);
         $this->setLocale($locale);
+        $this->factory  = new AddressFactory();
     }
 
     /**
@@ -162,5 +169,15 @@ abstract class AbstractProvider
         return array_map(function ($value) {
             return is_string($value) ? utf8_encode($value) : $value;
         }, $results);
+    }
+
+    /**
+     * @param array $data An array of data.
+     *
+     * @return \Geocoder\Model\Address[]
+     */
+    protected function returnResult(array $data = [])
+    {
+        return $this->factory->createFromArray($data);
     }
 }

--- a/src/Geocoder/Provider/GoogleMaps.php
+++ b/src/Geocoder/Provider/GoogleMaps.php
@@ -10,10 +10,11 @@
 
 namespace Geocoder\Provider;
 
+use Geocoder\Exception\InvalidCredentials;
 use Geocoder\Exception\NoResult;
 use Geocoder\Exception\QuotaExceeded;
 use Geocoder\Exception\UnsupportedOperation;
-use Geocoder\Exception\InvalidCredentials;
+use Geocoder\Model\AddressFactory;
 use Ivory\HttpAdapter\HttpAdapterInterface;
 
 /**
@@ -62,10 +63,17 @@ class GoogleMaps extends AbstractProvider implements LocaleAwareProvider
         $this->apiKey = $apiKey;
     }
 
+    public function setRegion($region)
+    {
+        $this->region = $region;
+
+        return $this;
+    }
+
     /**
      * {@inheritDoc}
      */
-    public function getGeocodedData($address)
+    public function geocode($address)
     {
         // Google API returns invalid data if IP address given
         // This API doesn't handle IPs
@@ -84,9 +92,9 @@ class GoogleMaps extends AbstractProvider implements LocaleAwareProvider
     /**
      * {@inheritDoc}
      */
-    public function getReversedData(array $coordinates)
+    public function reverse($latitude, $longitude)
     {
-        return $this->getGeocodedData(sprintf('%F,%F', $coordinates[0], $coordinates[1]));
+        return $this->getGeocodedData(sprintf('%F,%F', $latitude, $longitude));
     }
 
     /**
@@ -197,7 +205,7 @@ class GoogleMaps extends AbstractProvider implements LocaleAwareProvider
             $results[] = array_merge($this->getDefaults(), $resultset);
         }
 
-        return $results;
+        return $this->returnResult($results);
     }
 
     /**

--- a/src/Geocoder/Provider/Provider.php
+++ b/src/Geocoder/Provider/Provider.php
@@ -10,41 +10,16 @@
 
 namespace Geocoder\Provider;
 
-use Geocoder\Exception\NoResult;
 use Geocoder\Exception\InvalidCredentials;
+use Geocoder\Exception\NoResult;
 use Geocoder\Exception\UnsupportedOperation;
+use Geocoder\Geocoder;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
  */
-interface Provider
+interface Provider extends Geocoder
 {
-    /**
-     * Returns an associative array with data treated by the provider.
-     *
-     * @param string $address An address (IP or street).
-     *
-     * @throws NoResult             If the address could not be resolved
-     * @throws InvalidCredentials   If the credentials are invalid
-     * @throws UnsupportedOperation If IPv4, IPv6 or street is not supported
-     *
-     * @return array
-     */
-    public function getGeocodedData($address);
-
-    /**
-     * Returns an associative array with data treated by the provider.
-     *
-     * @param array $coordinates Coordinates (latitude, longitude).
-     *
-     * @throws NoResult             If the coordinates could not be resolved
-     * @throws InvalidCredentials   If the credentials are invalid
-     * @throws UnsupportedOperation If reverse geocoding is not supported
-     *
-     * @return array
-     */
-    public function getReversedData(array $coordinates);
-
     /**
      * Returns the provider's name.
      *

--- a/src/Geocoder/ProviderBasedGeocoder.php
+++ b/src/Geocoder/ProviderBasedGeocoder.php
@@ -12,7 +12,6 @@ namespace Geocoder;
 
 use Geocoder\Exception\ProviderNotRegistered;
 use Geocoder\Provider\Provider;
-use Geocoder\Model\AddressFactory;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -35,11 +34,6 @@ class ProviderBasedGeocoder implements Geocoder
     private $provider;
 
     /**
-     * @var AddressFactory
-     */
-    private $factory;
-
-    /**
      * @var integer
      */
     private $maxResults;
@@ -51,7 +45,6 @@ class ProviderBasedGeocoder implements Geocoder
     public function __construct(Provider $provider = null, $maxResults = self::MAX_RESULTS)
     {
         $this->provider = $provider;
-        $this->factory  = new AddressFactory();
 
         $this->limit($maxResults);
     }
@@ -61,15 +54,16 @@ class ProviderBasedGeocoder implements Geocoder
      */
     public function geocode($value)
     {
+        $value = trim($value);
+
         if (empty($value)) {
             // let's save a request
             return [];
         }
 
         $provider = $this->getProvider()->setMaxResults($this->getMaxResults());
-        $data     = $provider->getGeocodedData(trim($value));
 
-        return $this->returnResult($data);
+        return $provider->geocode($value);
     }
 
     /**
@@ -83,9 +77,8 @@ class ProviderBasedGeocoder implements Geocoder
         }
 
         $provider = $this->getProvider()->setMaxResults($this->getMaxResults());
-        $data     = $provider->getReversedData([ $latitude, $longitude ]);
 
-        return $this->returnResult($data);
+        return $provider->reverse($latitude, $longitude);
     }
 
     /**
@@ -184,15 +177,5 @@ class ProviderBasedGeocoder implements Geocoder
         }
 
         return $this->provider;
-    }
-
-    /**
-     * @param array $data An array of data.
-     *
-     * @return \Geocoder\Model\Address[]
-     */
-    protected function returnResult(array $data = [])
-    {
-        return $this->factory->createFromArray($data);
     }
 }


### PR DESCRIPTION
One thing I'm not sure to understand is why there are both `Geocoder` and `Provider` interfaces.

Those 2 interfaces are almost identical (`geocode()` vs `getGeocodedData()` / `reverse` vs `getReversedData()`) and then bring no real value.

What I'm suggesting here is to make the `Provider`s extending the `Geocoder`s. Thus the `ProviderBasedGeocoder` just acts as an aggregator and each provider can be used individually as a valid `Geocoder` instance.

It facilitates the use of specific provider options and then it allows to bypass the level of abstraction I described at https://github.com/geocoder-php/Geocoder/issues/322#issuecomment-58175915, which is for me the most blocking thing that prevent me from using this lib correctly.

In this PR I only fixed the GoogleMaps provider for the demo, and add a `setRegion()` method to it:

``` php
$adapter = new Ivory\HttpAdapter\CurlHttpAdapter();
$geocoder = new Geocoder\Provider\GoogleMaps($adapter);

$data = $geocoder->geocode('Toledo');
echo $data[0]->getCountry()->getCode(); // US

$geocoder->setRegion('ES');
$data = $geocoder->geocode('Toledo');
echo $data[0]->getCountry()->getCode(); // ES
```

Let me know what you think about it.
