### PR TITLE
Added IpInfoDB country precision endpoint

### DIFF
--- a/tests/.cached_responses/48f20f73811a6fb236311b5e3f9d9ca044549f80
+++ b/tests/.cached_responses/48f20f73811a6fb236311b5e3f9d9ca044549f80
@@ -1,0 +1,7 @@
+s:136:"{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "74.125.45.100",
+	"countryCode" : "US",
+	"countryName" : "UNITED STATES"
+}";

--- a/tests/.cached_responses/fd67cf38c744900c2fbaff37ee04f5cbd04a9345
+++ b/tests/.cached_responses/fd67cf38c744900c2fbaff37ee04f5cbd04a9345
@@ -1,0 +1,13 @@
+s:294:"{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "74.125.45.100",
+	"countryCode" : "US",
+	"countryName" : "UNITED STATES",
+	"regionName" : "CALIFORNIA",
+	"cityName" : "MOUNTAIN VIEW",
+	"zipCode" : "94043",
+	"latitude" : "37.406",
+	"longitude" : "-122.079",
+	"timeZone" : "-08:00"
+}";

--- a/tests/Geocoder/Tests/CachedResponseAdapter.php
+++ b/tests/Geocoder/Tests/CachedResponseAdapter.php
@@ -6,6 +6,7 @@ use Ivory\HttpAdapter\AbstractHttpAdapter;
 use Ivory\HttpAdapter\HttpAdapterInterface;
 use Ivory\HttpAdapter\Message\InternalRequestInterface;
 use Ivory\HttpAdapter\Message\Stream\StringStream;
+use Ivory\HttpAdapter\Message\RequestInterface;
 
 class CachedResponseAdapter extends AbstractHttpAdapter
 {
@@ -44,7 +45,7 @@ class CachedResponseAdapter extends AbstractHttpAdapter
             $body    = new StringStream($content);
 
             $response = $this->adapter->getConfiguration()->getMessageFactory()->createResponse(
-                200, 'OK', '1.1', [], $body
+                200, 'OK', RequestInterface::PROTOCOL_VERSION_1_1, [], $body
             );
 
             if (!empty($content)) {


### PR DESCRIPTION
This PR allows to use the country precision endpoint of IpInfoDB (http://ipinfodb.com/ip_location_api.php).
It's said to be faster and recommended when not needing the city precision.

Also, this PR fixes interfaces from http-message in the tests.
For example, the `Psr\Http\Message\ResponseInterface` does not exist in`psr/http-message ~0.5.0` which is required by `egeloen/http-adapter ~0.1` which is required by `willdurand/geocoder dev-master`: https://github.com/php-fig/http-message/tree/0.5.1/src

In fact the testsuite failed on a fresh install with:

``` console
$ phpunit                                                           [127]
PHPUnit 4.3.5 by Sebastian Bergmann.

Configuration read from /home/gildas/projects/Geocoder/phpunit.xml.dist

...........................................PHP Fatal error:  Call to undefined method Mock_ResponseInterface_d5ae35c4::getBody() in /home/gildas/projects/Geocoder/src/Geocoder/Provider/ArcGISOnline.php on line 176
PHP Stack trace:
PHP   1. {main}() /home/gildas/.composer/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /home/gildas/.composer/vendor/phpunit/phpunit/phpunit:56
PHP   3. PHPUnit_TextUI_Command->run() /home/gildas/.composer/vendor/phpunit/phpunit/src/TextUI/Command.php:138
PHP   4. PHPUnit_TextUI_TestRunner->doRun() /home/gildas/.composer/vendor/phpunit/phpunit/src/TextUI/Command.php:186
PHP   5. PHPUnit_Framework_TestSuite->run() /home/gildas/.composer/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:423
PHP   6. PHPUnit_Framework_TestSuite->run() /home/gildas/.composer/vendor/phpunit/phpunit/src/Framework/TestSuite.php:751
PHP   7. PHPUnit_Framework_TestCase->run() /home/gildas/.composer/vendor/phpunit/phpunit/src/Framework/TestSuite.php:751
PHP   8. PHPUnit_Framework_TestResult->run() /home/gildas/.composer/vendor/phpunit/phpunit/src/Framework/TestCase.php:711
PHP   9. PHPUnit_Framework_TestCase->runBare() /home/gildas/.composer/vendor/phpunit/phpunit/src/Framework/TestResult.php:643
PHP  10. PHPUnit_Framework_TestCase->runTest() /home/gildas/.composer/vendor/phpunit/phpunit/src/Framework/TestCase.php:775
PHP  11. ReflectionMethod->invokeArgs() /home/gildas/.composer/vendor/phpunit/phpunit/src/Framework/TestCase.php:905
PHP  12. Geocoder\Tests\Provider\ArcGISOnlineTest->testGetGeocodedDataWithInvalidData() /home/gildas/.composer/vendor/phpunit/phpunit/src/Framework/TestCase.php:905
PHP  13. Geocoder\Provider\ArcGISOnline->getGeocodedData() /home/gildas/projects/Geocoder/tests/Geocoder/Tests/Provider/ArcGISOnlineTest.php:22
PHP  14. Geocoder\Provider\ArcGISOnline->executeQuery() /home/gildas/projects/Geocoder/src/Geocoder/Provider/ArcGISOnline.php:71
```
