### PR TITLE
FreeGeoIp - Change postalCode field

### DIFF
--- a/src/Geocoder/Provider/FreeGeoIp.php
+++ b/src/Geocoder/Provider/FreeGeoIp.php
@@ -82,7 +82,7 @@ class FreeGeoIp extends AbstractProvider implements Provider
                 'latitude'    => isset($data['latitude']) ? $data['latitude'] : null,
                 'longitude'   => isset($data['longitude']) ? $data['longitude'] : null,
                 'locality'    => isset($data['city']) ? $data['city'] : null,
-                'postalCode'  => isset($data['zipcode']) ? $data['zipcode'] : null,
+                'postalCode'  => isset($data['zip_code']) ? $data['zip_code'] : null,
                 'region'      => isset($data['region_name']) ? $data['region_name'] : null,
                 'regionCode'  => isset($data['region_code']) ? $data['region_code'] : null,
                 'country'     => isset($data['country_name']) ? $data['country_name'] : null,


### PR DESCRIPTION
FreeGeoIp updated API to 3.0 (cf. https://github.com/fiorix/freegeoip/commit/0e7907bd8b80a4759e2291f50f20b3e6e726cb4c) and changed how to handle zip code field. The field is "zip_code" now.
