### PR TITLE
fix HHVM builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,9 @@ php:
     - 5.6
     - hhvm-nightly
 
-matrix:
-    allow_failures:
-        - php: hhvm-nightly
-
 before_script:
-    - sudo apt-get install -y --force-yes libgeoip-dev
-    - pecl install geoip
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then sudo apt-get install -y --force-yes libgeoip-dev; fi'
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then pecl install geoip; fi'
     - composer self-update
     - composer install --dev --prefer-dist --no-interaction
 

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     },
     "require-dev": {
         "geoip2/geoip2": "~0.6",
-        "symfony/stopwatch": "~2.5",
-        "ext-geoip": "*"
+        "symfony/stopwatch": "~2.5"
     },
     "suggest": {
         "ext-geoip": "Enabling the geoip extension allows you to use the MaxMindProvider.",


### PR DESCRIPTION
The `pecl` command is not available for HHVM environments. So, we
should skip installing packages required for the GeoIP feature. This
resolves #373.
