### PR TITLE
Fix timed geocoder with exception flow

### DIFF
--- a/src/Geocoder/TimedGeocoder.php
+++ b/src/Geocoder/TimedGeocoder.php
@@ -35,7 +35,15 @@ class TimedGeocoder implements Geocoder
     public function geocode($value)
     {
         $this->stopwatch->start('geocode', 'geocoder');
-        $result = $this->delegate->geocode($value);
+
+        try {
+            $result = $this->delegate->geocode($value);
+        } catch (\Exception $e) {
+            $this->stopwatch->stop('geocode');
+
+            throw $e;
+        }
+
         $this->stopwatch->stop('geocode');
 
         return $result;
@@ -47,7 +55,15 @@ class TimedGeocoder implements Geocoder
     public function reverse($latitude, $longitude)
     {
         $this->stopwatch->start('reverse', 'geocoder');
-        $result = $this->delegate->reverse($latitude, $longitude);
+
+        try {
+            $result = $this->delegate->reverse($latitude, $longitude);
+        } catch (\Exception $e) {
+            $this->stopwatch->stop('reverse');
+
+            throw $e;
+        }
+
         $this->stopwatch->stop('reverse');
 
         return $result;

--- a/tests/Geocoder/Tests/TimedGeocoderTest.php
+++ b/tests/Geocoder/Tests/TimedGeocoderTest.php
@@ -7,34 +7,68 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
 class TimedGeocoderTest extends TestCase
 {
-   protected function setUp()
-   {
-       $this->stopwatch = new Stopwatch();
-       $this->delegate = $this->getMock('Geocoder\Geocoder');
-       $this->geocoder = new TimedGeocoder($this->delegate, $this->stopwatch);
-   }
+    protected function setUp()
+    {
+        $this->stopwatch = new Stopwatch();
+        $this->delegate = $this->getMock('Geocoder\Geocoder');
+        $this->geocoder = new TimedGeocoder($this->delegate, $this->stopwatch);
+    }
 
-   public function testGeocode()
-   {
-      $this->delegate->expects($this->once())
-           ->method('geocode')
-           ->with($this->equalTo('foo'))
-           ->will($this->returnValue([]));
+    public function testGeocode()
+    {
+        $this->delegate->expects($this->once())
+             ->method('geocode')
+             ->with($this->equalTo('foo'))
+             ->will($this->returnValue([]));
 
-      $this->geocoder->geocode('foo');
+        $this->geocoder->geocode('foo');
 
-      $this->assertCount(1, $this->stopwatch->getSectionEvents('__root__'));
-   }
+        $this->assertCount(1, $this->stopwatch->getSectionEvents('__root__'));
+    }
 
-   public function testReverse()
-   {
-      $this->delegate->expects($this->once())
-           ->method('reverse')
-           ->with($this->equalTo(0, 0))
-           ->will($this->returnValue([]));
+    public function testGeocodeThrowsException()
+    {
+        $this->delegate->expects($this->once())
+             ->method('geocode')
+             ->with($this->equalTo('foo'))
+             ->will($this->throwException($exception = new \Exception()));
 
-      $this->geocoder->reverse(0, 0);
+        try {
+            $this->geocoder->geocode('foo');
+            $this->fail('Geocoder::geocode should throw an exception');
+        } catch (\Exception $e) {
+            $this->assertSame($exception, $e);
+        }
 
-      $this->assertCount(1, $this->stopwatch->getSectionEvents('__root__'));
-   }
+        $this->assertCount(1, $this->stopwatch->getSectionEvents('__root__'));
+    }
+
+    public function testReverse()
+    {
+        $this->delegate->expects($this->once())
+             ->method('reverse')
+             ->with($this->equalTo(0, 0))
+             ->will($this->returnValue([]));
+
+        $this->geocoder->reverse(0, 0);
+
+        $this->assertCount(1, $this->stopwatch->getSectionEvents('__root__'));
+    }
+
+    public function testReverseThrowsException()
+    {
+        $this->delegate->expects($this->once())
+             ->method('reverse')
+             ->with($this->equalTo(0, 0))
+             ->will($this->throwException($exception = new \Exception()));
+
+        try {
+            $this->geocoder->reverse(0, 0);
+            $this->fail('Geocoder::reverse should throw an exception');
+        } catch (\Exception $e) {
+            $this->assertSame($exception, $e);
+        }
+
+        $this->assertCount(1, $this->stopwatch->getSectionEvents('__root__'));
+    }
 }


### PR DESCRIPTION
All is in the title. Before this PR, the timed geocoder didn't stop the stopwatch component when a exception was thrown.
