### PR TITLE
[RFC] Introduce AddressCollection class

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ It also contains methods to control the number of results:
 * `limit($limit)`
 * `getLimit()`
 
-Both `geocode()` and `reverse()` methods return an array of `Address` objects,
-each providing the following API:
+### Address & AddressCollection
+
+Both `geocode()` and `reverse()` methods return a collection of `Address`
+objects (`AddressCollection`), each providing the following API:
 
 * `getCoordinates()` will return a `Coordinates` object (with `latitude` and
   `longitude` properties);
@@ -136,6 +138,16 @@ each providing the following API:
   properties);
 * `getCountryCode()` will return the ISO `country` code;
 * `getTimezone()` will return the `timezone`.
+
+The `AddressCollection` exposes the following methods:
+
+* `count()` (this class implements `Countable`);
+* `first()` retrieves the first `Address`;
+* `slice($offset, $length = null)` returns `Address` objects between `$offset`
+  and `length`;
+* `get($index)` fetches an `Address` using its `$index`;
+* `all()` returns all `Address` objects;
+* `getIterator()` (this class implements `IteratorAggregate`).
 
 ### Locale Aware Providers
 
@@ -208,7 +220,7 @@ $reader   = new \GeoIp2\Database\Reader('/path/to/database');
 $adapter  = new \Geocoder\Adapter\GeoIP2Adapter($reader);
 $geocoder = new \Geocoder\Provider\GeoIP2($adapter);
 
-$address   = $geocoder->geocode('74.200.247.59');
+$address   = $geocoder->geocode('74.200.247.59')->first();
 ```
 
 ### TomTom

--- a/src/Geocoder/Model/AddressCollection.php
+++ b/src/Geocoder/Model/AddressCollection.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Geocoder\Model;
+
+final class AddressCollection implements \IteratorAggregate, \Countable
+{
+    /**
+     * @var Address[]
+     */
+    private $addresses;
+
+    public function __construct(array $addresses = [])
+    {
+        $this->addresses = array_values($addresses);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->all());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count()
+    {
+        return count($this->addresses);
+    }
+
+    /**
+     * @return Address
+     */
+    public function first()
+    {
+        if (empty($this->addresses)) {
+            return null;
+        }
+
+        return reset($this->addresses);
+    }
+
+    /**
+     * @return Address[]
+     */
+    public function slice($offset, $length = null)
+    {
+        return array_slice($this->addresses, $offset, $length);
+    }
+
+    /**
+     * @return Address
+     */
+    public function get($index)
+    {
+        if (!isset($this->addresses[$index])) {
+            throw new \OutOfBoundsException(sprintf('The index "%s" does not exist in this collection.', $index));
+        }
+
+        return $this->addresses[$index];
+    }
+
+    /**
+     * @return Address[]
+     */
+    public function all()
+    {
+        return $this->addresses;
+    }
+}

--- a/src/Geocoder/Model/AddressFactory.php
+++ b/src/Geocoder/Model/AddressFactory.php
@@ -52,7 +52,7 @@ final class AddressFactory
             );
         }
 
-        return $addresses;
+        return new AddressCollection($addresses);
     }
 
     /**

--- a/src/Geocoder/Provider/IpInfoDb.php
+++ b/src/Geocoder/Provider/IpInfoDb.php
@@ -42,8 +42,8 @@ class IpInfoDb extends AbstractHttpProvider implements Provider
     private $endpointUrl;
 
     /**
-     * @param HttpAdapterInterface $adapter An HTTP adapter.
-     * @param string               $apiKey  An API key.
+     * @param HttpAdapterInterface $adapter   An HTTP adapter.
+     * @param string               $apiKey    An API key.
      * @param string               $precision The endpoint precision. Either "city" or "country" (faster)
      *
      * @throws Geocoder\Exception\InvalidArgument

--- a/tests/Geocoder/Tests/Model/AddressFactoryTest.php
+++ b/tests/Geocoder/Tests/Model/AddressFactoryTest.php
@@ -27,7 +27,7 @@ class AddressFactoryTest extends TestCase
             [ 'streetNumber' => 3 ],
         ]);
 
-        $this->assertTrue(is_array($addresses));
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $addresses);
         $this->assertCount(3, $addresses);
 
         $i = 1;
@@ -52,8 +52,7 @@ class AddressFactoryTest extends TestCase
         $addresses = $this->factory->createFromArray([
             [ 'streetName' => '1st ave 1A' ],
         ]);
-        $address   = current($addresses);
 
-        $this->assertEquals('1st ave 1A', $address->getStreetName());
+        $this->assertEquals('1st ave 1A', $addresses->first()->getStreetName());
     }
 }

--- a/tests/Geocoder/Tests/Provider/ArcGISOnlineTest.php
+++ b/tests/Geocoder/Tests/Provider/ArcGISOnlineTest.php
@@ -77,11 +77,11 @@ class ArcGISOnlineTest extends TestCase
         $provider = new ArcGISOnline($this->getAdapter());
         $results  = $provider->geocode('10 avenue Gambetta, Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.863279997000461, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result->getLongitude(), '', 0.0001);
@@ -106,11 +106,11 @@ class ArcGISOnlineTest extends TestCase
         $provider = new ArcGISOnline($this->getAdapter(), null, true);
         $results  = $provider->geocode('10 avenue Gambetta, Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.863279997000461, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result->getLongitude(), '', 0.0001);
@@ -176,11 +176,11 @@ class ArcGISOnlineTest extends TestCase
         $provider = new ArcGISOnline($this->getAdapter());
         $results  = $provider->reverse(48.863279997000461, 2.3890199980004354);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.863279997000461, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result->getLongitude(), '', 0.0001);
@@ -205,11 +205,11 @@ class ArcGISOnlineTest extends TestCase
         $provider = new ArcGISOnline($this->getAdapter(), null, true);
         $results  = $provider->reverse(48.863279997000461, 2.3890199980004354);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.863279997000461, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result->getLongitude(), '', 0.0001);
@@ -234,11 +234,11 @@ class ArcGISOnlineTest extends TestCase
         $provider = new ArcGISOnline($this->getAdapter());
         $results  = $provider->geocode('Hannover');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(52.370518568000477, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(9.7332166860004463, $result->getLongitude(), '', 0.0001);
@@ -258,7 +258,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertNull($result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(47.111386795000499, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-101.4265391569997, $result->getLongitude(), '', 0.0001);
@@ -268,7 +268,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertEquals('USA', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(39.391768472000479, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-77.440257128999633, $result->getLongitude(), '', 0.0001);
@@ -278,7 +278,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertEquals('USA', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(53.174198173, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(8.5069383810005, $result->getLongitude(), '', 0.0001);
@@ -289,7 +289,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertEquals('DEU', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[4];
+        $result = $results->get(4);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(-26.281805980999593, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-48.849389793999649, $result->getLongitude(), '', 0.0001);

--- a/tests/Geocoder/Tests/Provider/BingMapsTest.php
+++ b/tests/Geocoder/Tests/Provider/BingMapsTest.php
@@ -91,11 +91,11 @@ JSON;
         $provider = new BingMaps($this->getMockAdapterReturns($json), 'api_key', 'fr_FR');
         $results  = $provider->geocode('10 avenue Gambetta, Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(3, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.86321675999999, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.3887721299999995, $result->getLongitude(), '', 0.01);
@@ -116,7 +116,7 @@ JSON;
         $this->assertNull($result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.81342781, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.32503767, $result->getLongitude(), '', 0.01);
@@ -134,7 +134,7 @@ JSON;
         $this->assertEquals('France', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.81014147, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.43568048, $result->getLongitude(), '', 0.01);
@@ -161,11 +161,11 @@ JSON;
         $provider = new BingMaps($this->getMockAdapterReturns($json), 'api_key');
         $results  = $provider->reverse(48.86321648955345, 2.3887719959020615);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.86321648955345, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(2.3887719959020615, $result->getLongitude(), '', 0.0001);
@@ -195,11 +195,11 @@ JSON;
         $provider = new BingMaps($this->getAdapter(), $_SERVER['BINGMAPS_API_KEY'], 'fr-FR');
         $results  = $provider->geocode('10 avenue Gambetta, Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(3, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.86321675999999, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.3887721299999995, $result->getLongitude(), '', 0.01);
@@ -220,7 +220,7 @@ JSON;
         $this->assertNull($result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.81342781, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.32503767, $result->getLongitude(), '', 0.01);
@@ -238,7 +238,7 @@ JSON;
         $this->assertEquals('France', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.81014147, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.43568048, $result->getLongitude(), '', 0.01);
@@ -285,11 +285,11 @@ JSON;
         $provider = new BingMaps($this->getAdapter(), $_SERVER['BINGMAPS_API_KEY']);
         $results  = $provider->reverse(48.86321648955345, 2.3887719959020615);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.86321648955345, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(2.3887719959020615, $result->getLongitude(), '', 0.0001);

--- a/tests/Geocoder/Tests/Provider/FreeGeoIpTest.php
+++ b/tests/Geocoder/Tests/Provider/FreeGeoIpTest.php
@@ -48,11 +48,11 @@ class FreeGeoIpTest extends TestCase
         $provider = new FreeGeoIp($this->getMockAdapter($this->never()));
         $results  = $provider->geocode('127.0.0.1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('localhost', $result->getLocality());
         $this->assertEquals('localhost', $result->getCounty()->getName());
@@ -65,11 +65,11 @@ class FreeGeoIpTest extends TestCase
         $provider = new FreeGeoIp($this->getMockAdapter($this->never()));
         $results  = $provider->geocode('::1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('localhost', $result->getLocality());
         $this->assertEquals('localhost', $result->getCounty()->getName());
@@ -102,11 +102,11 @@ class FreeGeoIpTest extends TestCase
         $provider = new FreeGeoIp($this->getAdapter());
         $results  = $provider->geocode('74.200.247.59');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(33.0347, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-96.8134, $result->getLongitude(), '', 0.01);
@@ -122,11 +122,11 @@ class FreeGeoIpTest extends TestCase
         $provider = new FreeGeoIp($this->getAdapter());
         $results  = $provider->geocode('::ffff:74.200.247.59');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(33.0347, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-96.8134, $result->getLongitude(), '', 0.01);
@@ -152,10 +152,10 @@ class FreeGeoIpTest extends TestCase
         $provider = new FreeGeoIp($this->getAdapter());
         $results  = $provider->geocode('74.200.247.59');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
-        $this->assertEquals('48', $results[0]->getRegion()->getCode());
+        $this->assertEquals('48', $results->first()->getRegion()->getCode());
     }
 
     public function testGeocodeWithUSIPv6()
@@ -163,10 +163,10 @@ class FreeGeoIpTest extends TestCase
         $provider = new FreeGeoIp($this->getAdapter());
         $results  = $provider->geocode('::ffff:74.200.247.59');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
-        $this->assertEquals('48', $results[0]->getRegion()->getCode());
+        $this->assertEquals('48', $results->first()->getRegion()->getCode());
     }
 
     public function testGeocodeWithUKIPv4()
@@ -174,10 +174,10 @@ class FreeGeoIpTest extends TestCase
         $provider = new FreeGeoIp($this->getAdapter());
         $results  = $provider->geocode('132.185.255.60');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
-        $this->assertEquals('H9', $results[0]->getRegion()->getCode());
+        $this->assertEquals('H9', $results->first()->getRegion()->getCode());
     }
 
     public function testGeocodeWithUKIPv6()
@@ -185,10 +185,10 @@ class FreeGeoIpTest extends TestCase
         $provider = new FreeGeoIp($this->getAdapter());
         $results  = $provider->geocode('::ffff:132.185.255.60');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
-        $this->assertEquals('H9', $results[0]->getRegion()->getCode());
+        $this->assertEquals('H9', $results->first()->getRegion()->getCode());
     }
 
     /**

--- a/tests/Geocoder/Tests/Provider/GeoIP2Test.php
+++ b/tests/Geocoder/Tests/Provider/GeoIP2Test.php
@@ -47,11 +47,11 @@ class GeoIP2Test extends TestCase
     {
         $results  = $this->provider->geocode('127.0.0.1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('localhost', $result->getLocality());
         $this->assertEquals('localhost', $result->getCounty()->getName());
@@ -137,11 +137,11 @@ class GeoIP2Test extends TestCase
 
         $results = $provider->geocode($address);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals($expectedGeodata['latitude'], $result->getLatitude());
         $this->assertEquals($expectedGeodata['longitude'], $result->getLongitude());

--- a/tests/Geocoder/Tests/Provider/GeoIPsTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoIPsTest.php
@@ -57,11 +57,11 @@ class GeoIPsTest extends TestCase
         $provider = new GeoIPs($this->getMockAdapter($this->never()), 'api_key');
         $results  = $provider->geocode('127.0.0.1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('localhost', $result->getLocality());
         $this->assertEquals('localhost', $result->getCounty()->getName());
@@ -130,11 +130,11 @@ class GeoIPsTest extends TestCase
         $provider = new GeoIPs($this->getMockAdapterReturns($json), 'api_key');
         $results  = $provider->geocode('66.147.244.214');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertNull($result->getLatitude());
         $this->assertNull($result->getLongitude());
@@ -173,11 +173,11 @@ class GeoIPsTest extends TestCase
         $provider = new GeoIPs($this->getMockAdapterReturns($json), 'api_key');
         $results  = $provider->geocode('66.147.244.214');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(40.3402, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-111.6073, $result->getLongitude(), '', 0.0001);
@@ -331,11 +331,11 @@ class GeoIPsTest extends TestCase
         $provider = new GeoIPs($this->getAdapter(), $_SERVER['GEOIPS_API_KEY']);
         $results  = $provider->geocode('66.147.244.214');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(40.3402, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-111.6073, $result->getLongitude(), '', 0.0001);

--- a/tests/Geocoder/Tests/Provider/GeoPluginTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoPluginTest.php
@@ -48,10 +48,10 @@ class GeoPluginTest extends TestCase
         $provider = new GeoPlugin($this->getMockAdapter($this->never()));
         $results  = $provider->geocode('127.0.0.1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
-        $result = $results[0];
+        $result = $results->first();
         $this->assertEquals('localhost', $result->getLocality());
         $this->assertEquals('localhost', $result->getCounty()->getName());
         $this->assertEquals('localhost', $result->getRegion()->getName());
@@ -63,10 +63,10 @@ class GeoPluginTest extends TestCase
         $provider = new GeoPlugin($this->getMockAdapter($this->never()));
         $results  = $provider->geocode('::1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
-        $result = $results[0];
+        $result = $results->first();
         $this->assertEquals('localhost', $result->getLocality());
         $this->assertEquals('localhost', $result->getCounty()->getName());
         $this->assertEquals('localhost', $result->getRegion()->getName());
@@ -98,10 +98,10 @@ class GeoPluginTest extends TestCase
         $provider = new GeoPlugin($this->getAdapter());
         $results  = $provider->geocode('66.147.244.214');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
-        $result = $results[0];
+        $result = $results->first();
 
         $this->assertEquals(40.711101999999997, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-73.946899000000002, $result->getLongitude(), '', 0.0001);

--- a/tests/Geocoder/Tests/Provider/GeoipTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoipTest.php
@@ -57,11 +57,11 @@ class GeoipTest extends TestCase
         $provider = new Geoip();
         $results  = $provider->geocode('127.0.0.1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertNull($result->getLatitude());
         $this->assertNull($result->getLongitude());

--- a/tests/Geocoder/Tests/Provider/GeonamesTest.php
+++ b/tests/Geocoder/Tests/Provider/GeonamesTest.php
@@ -89,11 +89,11 @@ JSON;
         $provider = new Geonames($this->getAdapter(), $_SERVER['GEONAMES_USERNAME']);
         $results  = $provider->geocode('London');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(51.508528775863, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-0.12574195861816, $result->getLongitude(), '', 0.01);
@@ -110,7 +110,7 @@ JSON;
         $this->assertEquals('Europe/London', $result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(-33.015285093464, $result->getLatitude(), '', 0.01);
         $this->assertEquals(27.911624908447, $result->getLongitude(), '', 0.01);
@@ -127,7 +127,7 @@ JSON;
         $this->assertEquals('Africa/Johannesburg', $result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(51.512788890295, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-0.091838836669922, $result->getLongitude(), '', 0.01);
@@ -144,7 +144,7 @@ JSON;
         $this->assertEquals('Europe/London', $result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(42.983389283, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-81.233042387, $result->getLongitude(), '', 0.01);
@@ -161,7 +161,7 @@ JSON;
         $this->assertEquals('America/Toronto', $result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[4];
+        $result = $results->get(4);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(41.3556539, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-72.0995209, $result->getLongitude(), '', 0.01);
@@ -187,11 +187,11 @@ JSON;
         $provider = new Geonames($this->getAdapter(), $_SERVER['GEONAMES_USERNAME'], 'it_IT');
         $results  = $provider->geocode('London');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(51.50853, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-0.12574, $result->getLongitude(), '', 0.01);
@@ -208,7 +208,7 @@ JSON;
         $this->assertEquals('Europe/London', $result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(-33.015285093464, $result->getLatitude(), '', 0.01);
         $this->assertEquals(27.911624908447, $result->getLongitude(), '', 0.01);
@@ -225,7 +225,7 @@ JSON;
         $this->assertEquals('Africa/Johannesburg', $result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(51.512788890295, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-0.091838836669922, $result->getLongitude(), '', 0.01);
@@ -242,7 +242,7 @@ JSON;
         $this->assertEquals('Europe/London', $result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(42.983389283, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-81.233042387, $result->getLongitude(), '', 0.01);
@@ -259,7 +259,7 @@ JSON;
         $this->assertEquals('America/Toronto', $result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[4];
+        $result = $results->get(4);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(41.3556539, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-72.0995209, $result->getLongitude(), '', 0.01);
@@ -285,11 +285,11 @@ JSON;
         $provider = new Geonames($this->getAdapter(), $_SERVER['GEONAMES_USERNAME']);
         $results  = $provider->reverse(51.50853, -0.12574);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(51.50853, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-0.12574, $result->getLongitude(), '', 0.01);
@@ -310,11 +310,11 @@ JSON;
         $provider = new Geonames($this->getAdapter(), $_SERVER['GEONAMES_USERNAME'], 'it_IT');
         $results  = $provider->reverse(51.50853, -0.12574);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(51.50853, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-0.12574, $result->getLongitude(), '', 0.01);

--- a/tests/Geocoder/Tests/Provider/GoogleMapsTest.php
+++ b/tests/Geocoder/Tests/Provider/GoogleMapsTest.php
@@ -113,11 +113,11 @@ class GoogleMapsTest extends TestCase
         $provider = new GoogleMaps($this->getAdapter(), 'fr-FR', 'Île-de-France');
         $results  = $provider->geocode('10 avenue Gambetta, Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.8630462, $result->getLatitude(), '', 0.001);
         $this->assertEquals(2.3882487, $result->getLongitude(), '', 0.001);
@@ -144,11 +144,11 @@ class GoogleMapsTest extends TestCase
         $provider = new GoogleMaps($this->getAdapter(), null, null, true);
         $results  = $provider->geocode('10 avenue Gambetta, Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.8630462, $result->getLatitude(), '', 0.001);
         $this->assertEquals(2.3882487, $result->getLongitude(), '', 0.001);
@@ -175,11 +175,11 @@ class GoogleMapsTest extends TestCase
         $provider = new GoogleMaps($this->getAdapter());
         $results  = $provider->geocode('Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertTrue($result->getBounds()->isDefined());
         $this->assertEquals(48.815573, $result->getBounds()->getSouth(), '', 0.0001);
@@ -193,11 +193,11 @@ class GoogleMapsTest extends TestCase
         $provider = new GoogleMaps($this->getAdapter());
         $results  = $provider->geocode('Paris');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.856614, $result->getLatitude(), '', 0.001);
         $this->assertEquals(2.3522219, $result->getLongitude(), '', 0.001);
@@ -206,7 +206,7 @@ class GoogleMapsTest extends TestCase
         $this->assertEquals('FR', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(33.6609389, $result->getLatitude(), '', 0.001);
         $this->assertEquals(-95.555513, $result->getLongitude(), '', 0.001);
@@ -215,7 +215,7 @@ class GoogleMapsTest extends TestCase
         $this->assertEquals('US', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(36.3020023, $result->getLatitude(), '', 0.001);
         $this->assertEquals(-88.3267107, $result->getLongitude(), '', 0.001);
@@ -224,7 +224,7 @@ class GoogleMapsTest extends TestCase
         $this->assertEquals('US', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(39.611146, $result->getLatitude(), '', 0.001);
         $this->assertEquals(-87.6961374, $result->getLongitude(), '', 0.001);
@@ -233,7 +233,7 @@ class GoogleMapsTest extends TestCase
         $this->assertEquals('US', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[4];
+        $result = $results->get(4);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(38.2097987, $result->getLatitude(), '', 0.001);
         $this->assertEquals(-84.2529869, $result->getLongitude(), '', 0.001);
@@ -257,11 +257,11 @@ class GoogleMapsTest extends TestCase
         $provider = new GoogleMaps($this->getAdapter());
         $results  = $provider->reverse(48.8631507, 2.388911);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(1, $result->getStreetNumber());
         $this->assertEquals('Avenue Gambetta', $result->getStreetName());
@@ -288,11 +288,11 @@ class GoogleMapsTest extends TestCase
         $provider = new GoogleMaps($this->getAdapter());
         $results  = $provider->geocode('Kalbacher Hauptstraße 10, 60437 Frankfurt, Germany');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('Kalbach-Riedberg', $result->getSubLocality());
     }
@@ -317,11 +317,11 @@ class GoogleMapsTest extends TestCase
 
         $results = $provider->geocode('Columbia University');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertNotNull($result->getLatitude());
         $this->assertNotNull($result->getLongitude());

--- a/tests/Geocoder/Tests/Provider/HostIpTest.php
+++ b/tests/Geocoder/Tests/Provider/HostIpTest.php
@@ -48,11 +48,11 @@ class HostIpTest extends TestCase
         $provider = new HostIp($this->getMockAdapter($this->never()));
         $results  = $provider->geocode('127.0.0.1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertNull($result->getLatitude());
         $this->assertNull($result->getLongitude());
@@ -100,11 +100,11 @@ class HostIpTest extends TestCase
         $provider = new HostIp($this->getAdapter());
         $results  = $provider->geocode('88.188.221.14');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(45.5333, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(2.6167, $result->getLongitude(), '', 0.0001);
@@ -140,11 +140,11 @@ class HostIpTest extends TestCase
         $provider = new HostIp($this->getAdapter());
         $results  = $provider->geocode('33.33.33.22');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertNull($result->getLatitude());
         $this->assertNull($result->getLongitude());

--- a/tests/Geocoder/Tests/Provider/IpInfoDbTest.php
+++ b/tests/Geocoder/Tests/Provider/IpInfoDbTest.php
@@ -76,11 +76,11 @@ class IpInfoDbTest extends TestCase
         $provider = new IpInfoDb($this->getMockAdapter($this->never()), 'api_key');
         $results  = $provider->geocode('127.0.0.1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertNull($result->getLatitude());
         $this->assertNull($result->getLongitude());
@@ -132,11 +132,11 @@ class IpInfoDbTest extends TestCase
         $provider = new IpInfoDb($this->getAdapter(), $_SERVER['IPINFODB_API_KEY']);
         $results  = $provider->geocode('74.125.45.100');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(37.406, $result->getLatitude(), '', 0.001);
         $this->assertEquals(-122.079, $result->getLongitude(), '', 0.001);
@@ -174,11 +174,11 @@ class IpInfoDbTest extends TestCase
         $provider = new IpInfoDb($this->getAdapter(), $_SERVER['IPINFODB_API_KEY'], 'country');
         $results = $provider->geocode('74.125.45.100');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertNull($result->getLatitude());
         $this->assertNull($result->getLongitude());

--- a/tests/Geocoder/Tests/Provider/MapQuestTest.php
+++ b/tests/Geocoder/Tests/Provider/MapQuestTest.php
@@ -57,11 +57,11 @@ class MapQuestTest extends TestCase
         $provider = new MapQuest($this->getAdapter(), $_SERVER['MAPQUEST_API_KEY']);
         $results  = $provider->geocode('10 avenue Gambetta, Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.866205, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.389089, $result->getLongitude(), '', 0.01);
@@ -101,11 +101,11 @@ class MapQuestTest extends TestCase
         $provider = new MapQuest($this->getAdapter(), $_SERVER['MAPQUEST_API_KEY']);
         $results  = $provider->reverse(54.0484068, -2.7990345);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(54.0484068, $result->getLatitude(), '', 0.001);
         $this->assertEquals(-2.7990345, $result->getLongitude(), '', 0.001);
@@ -132,11 +132,11 @@ class MapQuestTest extends TestCase
         $provider = new MapQuest($this->getAdapter(), $_SERVER['MAPQUEST_API_KEY']);
         $results  = $provider->geocode('Hanover');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(52.374478, $result->getLatitude(), '', 0.01);
         $this->assertEquals(9.738553, $result->getLongitude(), '', 0.01);
@@ -146,7 +146,7 @@ class MapQuestTest extends TestCase
         $this->assertEquals('DE', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(52.374478000000003, $result->getLatitude(), '', 0.01);
         $this->assertEquals(9.7385529999999996, $result->getLongitude(), '', 0.01);
@@ -156,7 +156,7 @@ class MapQuestTest extends TestCase
         $this->assertEquals('DE', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(52.374478000000003, $result->getLatitude(), '', 0.01);
         $this->assertEquals(9.7385529999999996, $result->getLongitude(), '', 0.01);
@@ -166,7 +166,7 @@ class MapQuestTest extends TestCase
         $this->assertEquals('DE', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(52.374478000000003, $result->getLatitude(), '', 0.01);
         $this->assertEquals(9.7385529999999996, $result->getLongitude(), '', 0.01);
@@ -185,11 +185,11 @@ class MapQuestTest extends TestCase
         $provider = new MapQuest($this->getAdapter(), $_SERVER['MAPQUEST_API_KEY']);
         $results  = $provider->geocode('Kalbacher Hauptstraße 10, 60437 Frankfurt, Germany');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(50.189062, $result->getLatitude(), '', 0.01);
         $this->assertEquals(8.636567, $result->getLongitude(), '', 0.01);

--- a/tests/Geocoder/Tests/Provider/MaxMindBinaryTest.php
+++ b/tests/Geocoder/Tests/Provider/MaxMindBinaryTest.php
@@ -46,11 +46,11 @@ class MaxMindBinaryTest extends TestCase
         $provider = new MaxMindBinary($this->binaryFile);
         $results  = $provider->geocode('24.24.24.24');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
 
         $this->assertEquals('43.089200000000005', $result->getLatitude(), '', 0.001);
@@ -75,11 +75,11 @@ class MaxMindBinaryTest extends TestCase
         $provider = new MaxMindBinary($this->binaryFile);
         $results  = $provider->geocode('80.24.24.24');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
 
         $this->assertEquals('41.543299999999988', $result->getLatitude(), '', 0.001);
@@ -107,11 +107,11 @@ class MaxMindBinaryTest extends TestCase
         $provider = new MaxMindBinary($this->binaryFile);
         $results  = $provider->geocode($ip);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals($expectedCity, $result->getLocality());
         $this->assertEquals($expectedCountry, $result->getCountry()->getName());
@@ -123,7 +123,7 @@ class MaxMindBinaryTest extends TestCase
         $results  = $provider->geocode('212.51.181.237');
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertSame('Châlette-sur-loing', $result->getLocality());
     }

--- a/tests/Geocoder/Tests/Provider/MaxMindTest.php
+++ b/tests/Geocoder/Tests/Provider/MaxMindTest.php
@@ -57,11 +57,11 @@ class MaxMindTest extends TestCase
         $provider = new MaxMind($this->getMockAdapter($this->never()), 'api_key');
         $results  = $provider->geocode('127.0.0.1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('localhost', $result->getLocality());
         $this->assertEquals('localhost', $result->getCounty()->getName());
@@ -74,11 +74,11 @@ class MaxMindTest extends TestCase
         $provider = new MaxMind($this->getMockAdapter($this->never()), 'api_key');
         $results  = $provider->geocode('::1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('localhost', $result->getLocality());
         $this->assertEquals('localhost', $result->getCounty()->getName());
@@ -131,11 +131,11 @@ class MaxMindTest extends TestCase
         $provider = new MaxMind($this->getMockAdapterReturns(',,,,,,,,,'), 'api_key');
         $results  = $provider->geocode('74.200.247.59');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertNull($result->getLatitude());
         $this->assertNull($result->getLongitude());
@@ -159,11 +159,11 @@ class MaxMindTest extends TestCase
             'US,TX,Plano,75093,33.034698486328,-96.813400268555,,,,'), 'api_key');
         $results  = $provider->geocode('74.200.247.59');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(33.034698486328, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-96.813400268555, $result->getLongitude(), '', 0.0001);
@@ -182,21 +182,21 @@ class MaxMindTest extends TestCase
 
         $provider2 = new MaxMind($this->getMockAdapterReturns('FR,,,,,,,,,'), 'api_key');
         $result2   = $provider2->geocode('74.200.247.59');
-        $this->assertEquals('France', $result2[0]->getCountry()->getName());
+        $this->assertEquals('France', $result2->first()->getCountry()->getName());
 
         $provider3 = new MaxMind($this->getMockAdapterReturns('GB,,,,,,,,,'), 'api_key');
         $result3   = $provider3->geocode('74.200.247.59');
-        $this->assertEquals('United Kingdom', $result3[0]->getCountry()->getName());
+        $this->assertEquals('United Kingdom', $result3->first()->getCountry()->getName());
 
         $provider4 = new MaxMind($this->getMockAdapterReturns(
             'US,CA,San Francisco,94110,37.748402,-122.415604,807,415,"Layered Technologies","Automattic"'), 'api_key');
         $results   = $provider4->geocode('74.200.247.59');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(37.748402, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-122.415604, $result->getLongitude(), '', 0.0001);
@@ -306,11 +306,11 @@ class MaxMindTest extends TestCase
         $provider = new MaxMind($this->getAdapter(), $_SERVER['MAXMIND_API_KEY']);
         $results  = $provider->geocode('74.200.247.159');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(33.034698, $result->getLatitude(), '', 0.1);
         $this->assertEquals(-96.813400, $result->getLongitude(), '', 0.1);
@@ -339,11 +339,11 @@ class MaxMindTest extends TestCase
             MaxMind::OMNI_SERVICE);
         $results  = $provider->geocode('74.200.247.159');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(33.0347, $result->getLatitude(), '', 0.1);
         $this->assertEquals(-96.8134, $result->getLongitude(), '', 0.1);
@@ -371,11 +371,11 @@ class MaxMindTest extends TestCase
         $provider = new MaxMind($this->getAdapter(), $_SERVER['MAXMIND_API_KEY']);
         $results  = $provider->geocode('2002:4293:f4d6:0:0:0:0:0');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(40.2181, $result->getLatitude(), '', 0.1);
         $this->assertEquals(-111.6133, $result->getLongitude(), '', 0.1);
@@ -404,11 +404,11 @@ class MaxMindTest extends TestCase
             MaxMind::OMNI_SERVICE, true);
         $results  = $provider->geocode('2002:4293:f4d6:0:0:0:0:0');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(40.2181, $result->getLatitude(), '', 0.1);
         $this->assertEquals(-111.6133, $result->getLongitude(), '', 0.1);

--- a/tests/Geocoder/Tests/Provider/OpenCageTest.php
+++ b/tests/Geocoder/Tests/Provider/OpenCageTest.php
@@ -55,11 +55,11 @@ class OpenCageTest extends TestCase
         $provider = new OpenCage($this->getAdapter(), $_SERVER['OPENCAGE_API_KEY']);
         $results  = $provider->geocode('10 avenue Gambetta, Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(3, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.866205, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.389089, $result->getLongitude(), '', 0.01);
@@ -101,11 +101,11 @@ class OpenCageTest extends TestCase
         $provider = new OpenCage($this->getAdapter(), $_SERVER['OPENCAGE_API_KEY']);
         $results  = $provider->reverse(54.0484068, -2.7990345);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(54.0484068, $result->getLatitude(), '', 0.001);
         $this->assertEquals(-2.7990345, $result->getLongitude(), '', 0.001);
@@ -134,11 +134,11 @@ class OpenCageTest extends TestCase
         $provider = new OpenCage($this->getAdapter(), $_SERVER['OPENCAGE_API_KEY']);
         $results  = $provider->geocode('Hanover');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(52.374478, $result->getLatitude(), '', 0.01);
         $this->assertEquals(9.738553, $result->getLongitude(), '', 0.01);
@@ -148,7 +148,7 @@ class OpenCageTest extends TestCase
         $this->assertEquals('Germany', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(37.744783, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-77.4464165, $result->getLongitude(), '', 0.01);
@@ -157,7 +157,7 @@ class OpenCageTest extends TestCase
         $this->assertEquals('United States of America', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(18.3840489, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-78.131485, $result->getLongitude(), '', 0.01);
@@ -166,7 +166,7 @@ class OpenCageTest extends TestCase
         $this->assertEquals('Jamaica', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(43.7033073, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-72.2885663, $result->getLongitude(), '', 0.01);
@@ -185,11 +185,11 @@ class OpenCageTest extends TestCase
         $provider = new OpenCage($this->getAdapter(), $_SERVER['OPENCAGE_API_KEY']);
         $results  = $provider->geocode('Kalbacher Hauptstraße 10, 60437 Frankfurt, Germany');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(2, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(50.189062, $result->getLatitude(), '', 0.01);
         $this->assertEquals(8.636567, $result->getLongitude(), '', 0.01);
@@ -214,11 +214,11 @@ class OpenCageTest extends TestCase
         $provider = new OpenCage($this->getAdapter(), $_SERVER['OPENCAGE_API_KEY'], true, 'es');
         $results  = $provider->geocode('London');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('Londres', $result->getLocality());
         $this->assertEquals('Londres', $result->getCounty()->getName());

--- a/tests/Geocoder/Tests/Provider/OpenStreetMapTest.php
+++ b/tests/Geocoder/Tests/Provider/OpenStreetMapTest.php
@@ -18,11 +18,11 @@ class OpenStreetMapTest extends TestCase
         $provider = new OpenStreetMap($this->getAdapter());
         $results  = $provider->geocode('Paris');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.8565056, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.3521334, $result->getLongitude(), '', 0.01);
@@ -43,7 +43,7 @@ class OpenStreetMapTest extends TestCase
         $this->assertEquals('FR', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.8588408, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.32003465529896, $result->getLongitude(), '', 0.01);
@@ -64,7 +64,7 @@ class OpenStreetMapTest extends TestCase
         $this->assertEquals('FR', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(35.28687645, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-93.7354879210082, $result->getLongitude(), '', 0.01);
@@ -85,7 +85,7 @@ class OpenStreetMapTest extends TestCase
         $this->assertEquals('US', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(33.6751155, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-95.5502662477703, $result->getLongitude(), '', 0.01);
@@ -106,7 +106,7 @@ class OpenStreetMapTest extends TestCase
         $this->assertEquals('US', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[4];
+        $result = $results->get(4);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(38.2097987, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-84.2529869, $result->getLongitude(), '', 0.01);
@@ -132,11 +132,11 @@ class OpenStreetMapTest extends TestCase
         $provider = new OpenStreetMap($this->getAdapter(), 'fr_FR');
         $results  = $provider->geocode('10 allée Evariste Galois, Clermont ferrand');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(2, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(45.7586841, $result->getLatitude(), '', 0.01);
         $this->assertEquals(3.1354075, $result->getLongitude(), '', 0.01);
@@ -157,7 +157,7 @@ class OpenStreetMapTest extends TestCase
         $this->assertEquals('FR', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(45.7586841, $result->getLatitude(), '', 0.01);
         $this->assertEquals(3.1354075, $result->getLongitude(), '', 0.01);
@@ -183,11 +183,11 @@ class OpenStreetMapTest extends TestCase
         $provider = new OpenStreetMap($this->getAdapter());
         $results  = $provider->reverse(60.4539471728726, 22.2567841926781);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(60.4539, $result->getLatitude(), '', 0.001);
         $this->assertEquals(22.2568, $result->getLongitude(), '', 0.001);
@@ -218,11 +218,11 @@ class OpenStreetMapTest extends TestCase
         $provider = new OpenStreetMap($this->getAdapter(), 'de_DE');
         $results  = $provider->geocode('Kalbacher Hauptstraße, 60437 Frankfurt, Germany');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(50.1856803, $result->getLatitude(), '', 0.01);
         $this->assertEquals(8.6506285, $result->getLongitude(), '', 0.01);
@@ -243,7 +243,7 @@ class OpenStreetMapTest extends TestCase
         $this->assertEquals('DE', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(50.1845911, $result->getLatitude(), '', 0.01);
         $this->assertEquals(8.6540194, $result->getLongitude(), '', 0.01);
@@ -264,7 +264,7 @@ class OpenStreetMapTest extends TestCase
         $this->assertEquals('DE', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(50.1862884, $result->getLatitude(), '', 0.01);
         $this->assertEquals(8.6493167, $result->getLongitude(), '', 0.01);
@@ -285,7 +285,7 @@ class OpenStreetMapTest extends TestCase
         $this->assertEquals('DE', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(50.1861344, $result->getLatitude(), '', 0.01);
         $this->assertEquals(8.649578, $result->getLongitude(), '', 0.01);
@@ -311,11 +311,11 @@ class OpenStreetMapTest extends TestCase
         $provider = new OpenStreetMap($this->getMockAdapter($this->never()));
         $results  = $provider->geocode('127.0.0.1');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('localhost', $result->getLocality());
         $this->assertEquals('localhost', $result->getCounty()->getName());
@@ -338,11 +338,11 @@ class OpenStreetMapTest extends TestCase
         $provider = new OpenStreetMap($this->getAdapter());
         $results  = $provider->geocode('88.188.221.14');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(43.6189768, $result->getLatitude(), '', 0.01);
         $this->assertEquals(1.4564493, $result->getLongitude(), '', 0.01);
@@ -368,11 +368,11 @@ class OpenStreetMapTest extends TestCase
         $provider = new OpenStreetMap($this->getAdapter(), 'da_DK');
         $results  = $provider->geocode('88.188.221.14');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(43.6155351, $result->getLatitude(), '', 0.01);
         $this->assertEquals(1.4525647, $result->getLongitude(), '', 0.01);
@@ -477,11 +477,11 @@ XML;
         $provider = new OpenStreetMap($this->getAdapter(), 'fr_FR');
         $results  = $provider->reverse(48.86, 2.35);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals('Rue Quincampoix', $result->getStreetName());
     }

--- a/tests/Geocoder/Tests/Provider/TomTomTest.php
+++ b/tests/Geocoder/Tests/Provider/TomTomTest.php
@@ -87,11 +87,11 @@ XML;
         $provider = new TomTom($this->getAdapter(), $_SERVER['TOMTOM_MAP_KEY']);
         $results  = $provider->geocode('Tagensvej 47, 2200 København N');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(55.704389, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(12.546129, $result->getLongitude(), '', 0.0001);
@@ -117,11 +117,11 @@ XML;
         $provider = new TomTom($this->getAdapter(), $_SERVER['TOMTOM_MAP_KEY'], 'fr_FR');
         $results  = $provider->geocode('Tagensvej 47, 2200 København N');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(55.704389, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(12.546129, $result->getLongitude(), '', 0.0001);
@@ -147,11 +147,11 @@ XML;
         $provider = new TomTom($this->getAdapter(), $_SERVER['TOMTOM_MAP_KEY'], 'sv-SE');
         $results  = $provider->geocode('Tagensvej 47, 2200 København N');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(55.704389, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(12.546129, $result->getLongitude(), '', 0.0001);
@@ -177,11 +177,11 @@ XML;
         $provider = new TomTom($this->getAdapter(), $_SERVER['TOMTOM_MAP_KEY']);
         $results  = $provider->geocode('Paris');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.856898, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(2.350844, $result->getLongitude(), '', 0.0001);
@@ -198,7 +198,7 @@ XML;
         $this->assertNull($result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(33.661426, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-95.556321, $result->getLongitude(), '', 0.0001);
@@ -208,7 +208,7 @@ XML;
         $this->assertEquals('USA', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(36.302754, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-88.326359, $result->getLongitude(), '', 0.0001);
@@ -218,7 +218,7 @@ XML;
         $this->assertEquals('USA', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(-19.039448, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(29.560445, $result->getLongitude(), '', 0.0001);
@@ -228,7 +228,7 @@ XML;
         $this->assertEquals('ZWE', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[4];
+        $result = $results->get(4);
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(35.292105, $result->getLatitude(), '', 0.0001);
         $this->assertEquals(-93.729922, $result->getLongitude(), '', 0.0001);
@@ -355,11 +355,11 @@ XML;
         $provider = new TomTom($this->getAdapter(), $_SERVER['TOMTOM_MAP_KEY']);
         $results  = $provider->reverse(48.86321648955345, 2.3887719959020615);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(48.86323, $result->getLatitude(), '', 0.001);
         $this->assertEquals(2.38877, $result->getLongitude(), '', 0.001);
@@ -385,11 +385,11 @@ XML;
         $provider = new TomTom($this->getAdapter(),  $_SERVER['TOMTOM_MAP_KEY']);
         $results  = $provider->reverse(56.5231, 10.0659);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(56.52435, $result->getLatitude(), '', 0.001);
         $this->assertEquals(10.06744, $result->getLongitude(), '', 0.001);

--- a/tests/Geocoder/Tests/Provider/YandexTest.php
+++ b/tests/Geocoder/Tests/Provider/YandexTest.php
@@ -91,11 +91,11 @@ class YandexTest extends TestCase
         $provider = new Yandex($this->getAdapter());
         $results  = $provider->geocode('10 avenue Gambetta, Paris, France');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.863277, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.389016, $result->getLongitude(), '', 0.01);
@@ -118,25 +118,25 @@ class YandexTest extends TestCase
         $this->assertNull($result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.810138, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.435926, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.892773, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.246174, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.844640, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.420493, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[4];
+        $result = $results->get(4);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.813520, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.324642, $result->getLongitude(), '', 0.01);
@@ -147,11 +147,11 @@ class YandexTest extends TestCase
         $provider = new Yandex($this->getAdapter(), 'uk-UA');
         $results  = $provider->geocode('Copenhagen, Denmark');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);;
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(55.675682, $result->getLatitude(), '', 0.01);
         $this->assertEquals(12.567602, $result->getLongitude(), '', 0.01);
@@ -174,25 +174,25 @@ class YandexTest extends TestCase
         $this->assertNull($result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(55.614439, $result->getLatitude(), '', 0.01);
         $this->assertEquals(12.645351, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(55.713258, $result->getLatitude(), '', 0.01);
         $this->assertEquals(12.534930, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(55.698878, $result->getLatitude(), '', 0.01);
         $this->assertEquals(12.578211, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[4];
+        $result = $results->get(4);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(55.690380, $result->getLatitude(), '', 0.01);
         $this->assertEquals(12.554827, $result->getLongitude(), '', 0.01);
@@ -203,11 +203,11 @@ class YandexTest extends TestCase
         $provider = new Yandex($this->getAdapter(), 'en-US');
         $results  = $provider->geocode('1600 Pennsylvania Ave, Washington');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(38.898720, $result->getLatitude(), '', 0.01);
         $this->assertEquals(-77.036384, $result->getLongitude(), '', 0.01);
@@ -235,11 +235,11 @@ class YandexTest extends TestCase
         $provider = new Yandex($this->getAdapter(), 'be-BY');
         $results  = $provider->geocode('ул.Ленина, 19, Минск 220030, Республика Беларусь');
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(53.898077, $result->getLatitude(), '', 0.01);
         $this->assertEquals(27.563673, $result->getLongitude(), '', 0.01);
@@ -297,11 +297,11 @@ class YandexTest extends TestCase
         $provider = new Yandex($this->getAdapter());
         $results  = $provider->reverse(48.863216489553, 2.388771995902061);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(3, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.863212, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.388773, $result->getLongitude(), '', 0.01);
@@ -324,13 +324,13 @@ class YandexTest extends TestCase
         $this->assertNull($result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.709273, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.503371, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(46.621810, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.452113, $result->getLongitude(), '', 0.01);
@@ -341,11 +341,11 @@ class YandexTest extends TestCase
         $provider = new Yandex($this->getAdapter(), 'en-US', 'street');
         $results  = $provider->reverse(48.863216489553, 2.388771995902061);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.87132, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.404017, $result->getLongitude(), '', 0.01);
@@ -368,25 +368,25 @@ class YandexTest extends TestCase
         $this->assertNull($result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[1];
+        $result = $results->get(1);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.863230, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.388261, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[2];
+        $result = $results->get(2);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.866022, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.389662, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[3];
+        $result = $results->get(3);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.863918, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.387767, $result->getLongitude(), '', 0.01);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[4];
+        $result = $results->get(4);
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(48.863787, $result->getLatitude(), '', 0.01);
         $this->assertEquals(2.389600, $result->getLongitude(), '', 0.01);
@@ -397,11 +397,11 @@ class YandexTest extends TestCase
         $provider = new Yandex($this->getAdapter(), 'uk-UA', 'house');
         $results  = $provider->reverse(60.4539471768582, 22.2567842183875);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(60.454462, $result->getLatitude(), '', 0.01);
         $this->assertEquals(22.256561, $result->getLongitude(), '', 0.01);
@@ -429,11 +429,11 @@ class YandexTest extends TestCase
         $provider = new Yandex($this->getAdapter(), 'tr-TR', 'locality');
         $results  = $provider->reverse(40.900640, 29.198184);
 
-        $this->assertInternalType('array', $results);
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(5, $results);
 
         /** @var \Geocoder\Model\Address $result */
-        $result = $results[0];
+        $result = $results->first();
         $this->assertInstanceOf('Geocoder\Model\Address', $result);
         $this->assertEquals(40.909452, $result->getLatitude(), '', 0.01);
         $this->assertEquals(29.138608, $result->getLongitude(), '', 0.01);

--- a/tests/Geocoder/Tests/TestCase.php
+++ b/tests/Geocoder/Tests/TestCase.php
@@ -88,7 +88,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     {
         $addresses = (new AddressFactory())->createFromArray([ $data ]);
 
-        return 0 === count($addresses) ? null : $addresses[0];
+        return 0 === count($addresses) ? null : $addresses->first();
     }
 
     protected function createEmptyAddress()


### PR DESCRIPTION
I think that this could be interesting since we always return a set of results rather than only one result. Moreover, having a class rather than relying on the `array` primitive type seems a bit more robust, and makes the API more fluent:

```
// Before:
$addresses = $geocoder->geocode('foobar');
$address   = empty($addresses) ? null : reset($addresses);

// After:
$address = $geocoder->geocode('foobar')->first();
```

WDYT?
