### PR TITLE
Fix encoding issue for maxmind provider

### DIFF
--- a/src/Geocoder/Provider/MaxMind.php
+++ b/src/Geocoder/Provider/MaxMind.php
@@ -147,7 +147,7 @@ class MaxMind extends AbstractHttpProvider implements Provider
         }
 
         return $this->returnResults([
-            array_merge($this->getDefaults(), $data)
+            $this->fixEncoding(array_merge($this->getDefaults(), $data))
         ]);
     }
 

--- a/tests/.cached_responses/2f533a08ae0b6ca65e06bd8dd13f1ef50e94bba0
+++ b/tests/.cached_responses/2f533a08ae0b6ca65e06bd8dd13f1ef50e94bba0
@@ -1,0 +1,1 @@
+s:187:"US,"United States",UT,Utah,Provo,40.2181,-111.6133,770,801,America/Denver,NA,84606,"Unified Layer","Unified Layer",bluehost.com,"AS46606 Unified Layer",Corporate,residential,999,83,5,5,5,";

--- a/tests/.cached_responses/4f5cc7e59037868ffefe62f12e367592fdd3eafe
+++ b/tests/.cached_responses/4f5cc7e59037868ffefe62f12e367592fdd3eafe
@@ -1,0 +1,1 @@
+s:79:"US,UT,Provo,84606,40.218102,-111.613297,770,801,"Unified Layer","Unified Layer"";

--- a/tests/.cached_responses/b0b4edb754ec522d7b4ba93b159fa9b68e628393
+++ b/tests/.cached_responses/b0b4edb754ec522d7b4ba93b159fa9b68e628393
@@ -1,0 +1,1 @@
+s:215:"BR,Brazil,26,"Santa Catarina",Florianópolis,-27.5833,-48.5667,,,America/Sao_Paulo,SA,,"Global Village Telecom","Global Village Telecom",gvt.net.br,"AS18881 Global Village Telecom",Cable/DSL,residential,18,99,52,92,,";

--- a/tests/.cached_responses/c3487c0fe92a00d80eab35b6b3c5bfe916dd11c0
+++ b/tests/.cached_responses/c3487c0fe92a00d80eab35b6b3c5bfe916dd11c0
@@ -1,0 +1,1 @@
+s:96:"BR,26,Florianópolis,,-27.583300,-48.566700,0,0,"Global Village Telecom","Global Village Telecom"";

--- a/tests/Geocoder/Tests/Provider/MaxMindTest.php
+++ b/tests/Geocoder/Tests/Provider/MaxMindTest.php
@@ -362,6 +362,39 @@ class MaxMindTest extends TestCase
         $this->assertEquals('America/Chicago', $result->getTimezone());
     }
 
+    public function testGeocodeOmniServiceWithRealIPv4WithSslAndEncoding()
+    {
+        if (!isset($_SERVER['MAXMIND_API_KEY'])) {
+            $this->markTestSkipped('You need to configure the MAXMIND_API_KEY value in phpunit.xml');
+        }
+
+        $provider = new MaxMind($this->getAdapter(), $_SERVER['MAXMIND_API_KEY'],
+            MaxMind::OMNI_SERVICE, true);
+        $results  = $provider->geocode('189.26.128.80');
+
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
+        $this->assertCount(1, $results);
+
+        /** @var \Geocoder\Model\Address $result */
+        $result = $results->first();
+        $this->assertInstanceOf('\Geocoder\Model\Address', $result);
+        $this->assertEquals(-27.5833, $result->getLatitude(), '', 0.1);
+        $this->assertEquals(-48.5666, $result->getLongitude(), '', 0.1);
+        $this->assertFalse($result->getBounds()->isDefined());
+        $this->assertNull($result->getStreetNumber());
+        $this->assertNull($result->getStreetName());
+        $this->assertNull($result->getPostalCode());
+        $this->assertEquals('Florianópolis', $result->getLocality());
+        $this->assertNull($result->getSubLocality());
+        $this->assertNull($result->getCounty()->getName());
+        $this->assertNull($result->getCounty()->getCode());
+        $this->assertEquals('Santa Catarina', $result->getRegion()->getName());
+        $this->assertEquals('26', $result->getRegion()->getCode());
+        $this->assertEquals('Brazil', $result->getCountry()->getName());
+        $this->assertEquals('BR', $result->getCountry()->getCode());
+        $this->assertEquals('America/Sao_Paulo', $result->getTimezone());
+    }
+
     public function testGeocodeWithRealIPv6()
     {
         if (!isset($_SERVER['MAXMIND_API_KEY'])) {


### PR DESCRIPTION
This is related to https://github.com/geocoder-php/BazingaGeocoderBundle/issues/84 but a patch should be written for the `2.x` version as well.
