### PR TITLE
Fixed dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "egeloen/http-adapter": "~0.1",
+        "egeloen/http-adapter": "0.5.*",
         "igorw/get-in": "~1.0"
     },
     "require-dev": {
-        "geoip2/geoip2": "~0.6",
+        "geoip2/geoip2": "~2.0",
         "symfony/stopwatch": "~2.5"
     },
     "suggest": {


### PR DESCRIPTION
NB, 0.x builds can break between minor releases so we must not use `~0.1` for a version constraint.