### PR TITLE
Add countrycode to Bing api calls

### DIFF
--- a/src/Geocoder/Provider/BingMaps.php
+++ b/src/Geocoder/Provider/BingMaps.php
@@ -25,12 +25,12 @@ class BingMaps extends AbstractHttpProvider implements LocaleAwareProvider
     /**
      * @var string
      */
-    const GEOCODE_ENDPOINT_URL = 'http://dev.virtualearth.net/REST/v1/Locations/?maxResults=%d&q=%s&key=%s';
+    const GEOCODE_ENDPOINT_URL = 'http://dev.virtualearth.net/REST/v1/Locations/?maxResults=%d&q=%s&key=%s&incl=ciso2';
 
     /**
      * @var string
      */
-    const REVERSE_ENDPOINT_URL = 'http://dev.virtualearth.net/REST/v1/Locations/%F,%F?key=%s';
+    const REVERSE_ENDPOINT_URL = 'http://dev.virtualearth.net/REST/v1/Locations/%F,%F?key=%s&incl=ciso2';
 
     /**
      * @var string
@@ -133,7 +133,8 @@ class BingMaps extends AbstractHttpProvider implements LocaleAwareProvider
             $zipcode      = property_exists($item->address, 'postalCode') ? (string) $item->address->postalCode : '';
             $city         = property_exists($item->address, 'locality') ? (string) $item->address->locality: '';
             $country      = property_exists($item->address, 'countryRegion') ? (string) $item->address->countryRegion: '';
-
+            $countryCode  = property_exists($item->address, 'countryRegionIso2') ? (string) $item->address->countryRegionIso2: '';
+            
             $adminLevels = [];
 
             foreach (['adminDistrict', 'adminDistrict2'] as $i => $property) {
@@ -152,6 +153,7 @@ class BingMaps extends AbstractHttpProvider implements LocaleAwareProvider
                 'postalCode'   => empty($zipcode) ? null : $zipcode,
                 'adminLevels'  => $adminLevels,
                 'country'      => empty($country) ? null : $country,
+                'countryCode'  => empty($countryCode) ? null : $countryCode,
             ]);
         }
 

--- a/tests/Geocoder/Tests/Provider/BingMapsTest.php
+++ b/tests/Geocoder/Tests/Provider/BingMapsTest.php
@@ -24,7 +24,7 @@ class BingMapsTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=foobar&key=api_key".
+     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=foobar&key=api_key&incl=ciso2".
      */
     public function testGeocodeWithInvalidData()
     {
@@ -34,7 +34,7 @@ class BingMapsTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=&key=api_key".
+     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=&key=api_key&incl=ciso2".
      */
     public function testGeocodeWithNull()
     {
@@ -44,7 +44,7 @@ class BingMapsTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=&key=api_key".
+     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=&key=api_key&incl=ciso2".
      */
     public function testGeocodeWithEmpty()
     {
@@ -74,7 +74,7 @@ class BingMapsTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=10+avenue+Gambetta%2C+Paris%2C+France&key=api_key".
+     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=10+avenue+Gambetta%2C+Paris%2C+France&key=api_key&incl=ciso2".
      */
     public function testGeocodeWithAddressGetsNullContent()
     {
@@ -85,7 +85,7 @@ class BingMapsTest extends TestCase
     public function testGeocodeReturnsMultipleResults()
     {
         $json = <<<JSON
-{"authenticationResultCode":"ValidCredentials","brandLogoUri":"http:\/\/dev.virtualearth.net\/Branding\/logo_powered_by.png","copyright":"Copyright © 2013 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.","resourceSets":[{"estimatedTotal":3,"resources":[{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.859354042429317,2.3809438666389395,48.86707947757067,2.3966003933610596],"name":"10 Avenue Gambetta, 75020 Paris","point":{"type":"Point","coordinates":[48.863216759999993,2.3887721299999995]},"address":{"addressLine":"10 Avenue Gambetta","adminDistrict":"IdF","adminDistrict2":"Paris","countryRegion":"France","formattedAddress":"10 Avenue Gambetta, 75020 Paris","locality":"Paris","postalCode":"75020"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.863216759999993,2.3887721299999995],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Ambiguous","Good"]},{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.809565092429317,2.3172171827738461,48.81729052757067,2.3328581572261538],"name":"10 Avenue Léon Gambetta, 92120 Montrouge","point":{"type":"Point","coordinates":[48.813427809999993,2.32503767]},"address":{"addressLine":"10 Avenue Léon Gambetta","adminDistrict":"IdF","adminDistrict2":"Hauts-de-Seine","countryRegion":"France","formattedAddress":"10 Avenue Léon Gambetta, 92120 Montrouge","locality":"Montrouge","postalCode":"92120"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.813427809999993,2.32503767],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Ambiguous","Good"]},{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.806278752429328,2.4278605052896745,48.814004187570681,2.4435004547103261],"name":"10 Avenue Gambetta, 94700 Maisons-Alfort","point":{"type":"Point","coordinates":[48.810141470000005,2.4356804800000003]},"address":{"addressLine":"10 Avenue Gambetta","adminDistrict":"IdF","adminDistrict2":"Val-De-Marne","countryRegion":"France","formattedAddress":"10 Avenue Gambetta, 94700 Maisons-Alfort","locality":"Maisons-Alfort","postalCode":"94700"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.810141470000005,2.4356804800000003],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Ambiguous","Good"]}]}],"statusCode":200,"statusDescription":"OK","traceId":"fd9b0b8fe1a34ad384923b5d0937bfb2|AMSM001404|02.00.139.700|AMSMSNVM002409, AMSMSNVM001862, AMSMSNVM001322, AMSMSNVM000044"}
+{"authenticationResultCode":"ValidCredentials","brandLogoUri":"http:\/\/dev.virtualearth.net\/Branding\/logo_powered_by.png","copyright":"Copyright © 2013 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.","resourceSets":[{"estimatedTotal":3,"resources":[{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.859354042429317,2.3809438666389395,48.86707947757067,2.3966003933610596],"name":"10 Avenue Gambetta, 75020 Paris","point":{"type":"Point","coordinates":[48.863216759999993,2.3887721299999995]},"address":{"addressLine":"10 Avenue Gambetta","adminDistrict":"IdF","adminDistrict2":"Paris","countryRegion":"France","countryRegionIso2":"FR","formattedAddress":"10 Avenue Gambetta, 75020 Paris","locality":"Paris","postalCode":"75020"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.863216759999993,2.3887721299999995],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Ambiguous","Good"]},{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.809565092429317,2.3172171827738461,48.81729052757067,2.3328581572261538],"name":"10 Avenue Léon Gambetta, 92120 Montrouge","point":{"type":"Point","coordinates":[48.813427809999993,2.32503767]},"address":{"addressLine":"10 Avenue Léon Gambetta","adminDistrict":"IdF","adminDistrict2":"Hauts-de-Seine","countryRegion":"France","countryRegionIso2":"FR","formattedAddress":"10 Avenue Léon Gambetta, 92120 Montrouge","locality":"Montrouge","postalCode":"92120"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.813427809999993,2.32503767],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Ambiguous","Good"]},{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.806278752429328,2.4278605052896745,48.814004187570681,2.4435004547103261],"name":"10 Avenue Gambetta, 94700 Maisons-Alfort","point":{"type":"Point","coordinates":[48.810141470000005,2.4356804800000003]},"address":{"addressLine":"10 Avenue Gambetta","adminDistrict":"IdF","adminDistrict2":"Val-De-Marne","countryRegion":"France","countryRegionIso2":"FR","formattedAddress":"10 Avenue Gambetta, 94700 Maisons-Alfort","locality":"Maisons-Alfort","postalCode":"94700"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.810141470000005,2.4356804800000003],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Ambiguous","Good"]}]}],"statusCode":200,"statusDescription":"OK","traceId":"fd9b0b8fe1a34ad384923b5d0937bfb2|AMSM001404|02.00.139.700|AMSMSNVM002409, AMSMSNVM001862, AMSMSNVM001322, AMSMSNVM000044"}
 JSON;
 
         $provider = new BingMaps($this->getMockAdapterReturns($json), 'api_key', 'fr_FR');
@@ -112,8 +112,8 @@ JSON;
         $this->assertEquals('Paris', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('IdF', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('France', $result->getCountry()->getName());
+        $this->assertEquals('FR', $result->getCountry()->getCode());
 
-        $this->assertNull($result->getCountry()->getCode());
         $this->assertNull($result->getTimezone());
 
         /** @var \Geocoder\Model\Address $result */
@@ -134,6 +134,7 @@ JSON;
         $this->assertEquals('Hauts-de-Seine', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('IdF', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('France', $result->getCountry()->getName());
+        $this->assertEquals('FR', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
         $result = $results->get(2);
@@ -153,12 +154,13 @@ JSON;
         $this->assertEquals('Val-De-Marne', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('IdF', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('France', $result->getCountry()->getName());
+        $this->assertEquals('FR', $result->getCountry()->getCode());
     }
 
     public function testReverseReturnsSingleResult()
     {
         $json = <<<JSON
-{"authenticationResultCode":"ValidCredentials","brandLogoUri":"http:\/\/dev.virtualearth.net\/Branding\/logo_powered_by.png","copyright":"Copyright © 2013 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.","resourceSets":[{"estimatedTotal":1,"resources":[{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.859353771982775,2.3809437325832983,48.867079207124128,2.3966002592208246],"name":"10 Avenue Gambetta, 75020 20e Arrondissement","point":{"type":"Point","coordinates":[48.863216489553452,2.3887719959020615]},"address":{"addressLine":"10 Avenue Gambetta","adminDistrict":"IdF","adminDistrict2":"Paris","countryRegion":"France","formattedAddress":"10 Avenue Gambetta, 75020 20e Arrondissement","locality":"20e Arrondissement","postalCode":"75020"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.863216489553452,2.3887719959020615],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Good"]}]}],"statusCode":200,"statusDescription":"OK","traceId":"0691dabd257043b381b678fbfaf799dd|AMSM001401|02.00.139.700|AMSMSNVM001951, AMSMSNVM002152"}
+{"authenticationResultCode":"ValidCredentials","brandLogoUri":"http:\/\/dev.virtualearth.net\/Branding\/logo_powered_by.png","copyright":"Copyright © 2013 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.","resourceSets":[{"estimatedTotal":1,"resources":[{"__type":"Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1","bbox":[48.859353771982775,2.3809437325832983,48.867079207124128,2.3966002592208246],"name":"10 Avenue Gambetta, 75020 20e Arrondissement","point":{"type":"Point","coordinates":[48.863216489553452,2.3887719959020615]},"address":{"addressLine":"10 Avenue Gambetta","adminDistrict":"IdF","adminDistrict2":"Paris","countryRegion":"France","countryRegionIso2":"FR","formattedAddress":"10 Avenue Gambetta, 75020 20e Arrondissement","locality":"20e Arrondissement","postalCode":"75020"},"confidence":"Medium","entityType":"Address","geocodePoints":[{"type":"Point","coordinates":[48.863216489553452,2.3887719959020615],"calculationMethod":"Interpolation","usageTypes":["Display","Route"]}],"matchCodes":["Good"]}]}],"statusCode":200,"statusDescription":"OK","traceId":"0691dabd257043b381b678fbfaf799dd|AMSM001401|02.00.139.700|AMSMSNVM001951, AMSMSNVM002152"}
 JSON;
 
         $provider = new BingMaps($this->getMockAdapterReturns($json), 'api_key');
@@ -185,8 +187,8 @@ JSON;
         $this->assertEquals('Paris', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('IdF', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('France', $result->getCountry()->getName());
+        $this->assertEquals('FR', $result->getCountry()->getCode());
 
-        $this->assertNull($result->getCountry()->getCode());
         $this->assertNull($result->getTimezone());
     }
 
@@ -220,10 +222,10 @@ JSON;
         $this->assertEquals('Paris', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('IdF', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('France', $result->getCountry()->getName());
+        $this->assertEquals('FR', $result->getCountry()->getCode());
 
         $this->assertNull($result->getAdminLevels()->get(2)->getCode());
         $this->assertNull($result->getAdminLevels()->get(1)->getCode());
-        $this->assertNull($result->getCountry()->getCode());
         $this->assertNull($result->getTimezone());
 
     }
@@ -258,6 +260,7 @@ JSON;
         $this->assertEquals('AT', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Piem.', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('Italie', $result->getCountry()->getName());
+        $this->assertEquals('IT', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
         $result = $results->get(1);
@@ -277,6 +280,7 @@ JSON;
         $this->assertEquals('TN', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Tr.A.A.', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('Italie', $result->getCountry()->getName());
+        $this->assertEquals('IT', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
         $result = $results->get(2);
@@ -296,6 +300,7 @@ JSON;
         $this->assertEquals('PC', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Em.Rom.', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('Italie', $result->getCountry()->getName());
+        $this->assertEquals('IT', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
         $result = $results->get(3);
@@ -315,6 +320,7 @@ JSON;
         $this->assertEquals('PO', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Tosc.', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('Italie', $result->getCountry()->getName());
+        $this->assertEquals('IT', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
         $result = $results->get(4);
@@ -334,11 +340,12 @@ JSON;
         $this->assertEquals('AQ', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Abr.', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('Italie', $result->getCountry()->getName());
+        $this->assertEquals('IT', $result->getCountry()->getCode());
     }
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/1.000000,2.000000?key=api_key".
+     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/1.000000,2.000000?key=api_key&incl=ciso2".
      */
     public function testReverse()
     {
@@ -348,7 +355,7 @@ JSON;
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/48.863216,2.388772?key=api_key".
+     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/48.863216,2.388772?key=api_key&incl=ciso2".
      */
     public function testReverseWithCoordinatesContentReturnNull()
     {
@@ -386,8 +393,8 @@ JSON;
         $this->assertEquals('Paris', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('IdF', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('France', $result->getCountry()->getName());
+        $this->assertEquals('FR', $result->getCountry()->getCode());
 
-        $this->assertNull($result->getCountry()->getCode());
         $this->assertNull($result->getTimezone());
     }
 


### PR DESCRIPTION
By default only country name is retreived from Bing Maps. With an extra request parameter the country code can be retreived as well.