### PR TITLE
improve Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,33 @@
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - libgeoip-dev
+
 language: php
+
+env:
+    global:
+        - deps=""
 
 php:
     - 5.4
     - 5.5
     - 5.6
+    - nightly
     - hhvm-nightly
 
+matrix:
+    fast_finish: true
+    include:
+        - php: 5.4
+          env: deps="low"
+
 before_script:
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then sudo apt-get install -y --force-yes libgeoip-dev; fi'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then pecl install geoip; fi'
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then pecl install geoip; fi
     - composer self-update
-    - composer install --dev --prefer-dist --no-interaction
+    - if [ "$deps" = "low" ]; then composer update --prefer-dist --prefer-lowest; fi
+    - if [ "$deps" = "" ]; then composer install --prefer-dist --no-interaction; fi
 
 script: phpunit --coverage-text


### PR DESCRIPTION
* use the faster container-based infrastructure
* remove unneeded `sh` wrapper
* don't specify default `--dev` argument
* run tests against the lowest possible dependency versions too