### PR TITLE
Fix emergency message in Geoip provider

### DIFF
--- a/src/Geocoder/Provider/Geoip.php
+++ b/src/Geocoder/Provider/Geoip.php
@@ -54,8 +54,13 @@ class Geoip extends AbstractProvider implements Provider
             throw new NoResult(sprintf('Could not find "%s" IP address in database.', $address));
         }
 
-        $timezone = @geoip_time_zone_by_country_and_region($results['country_code'], $results['region']) ?: null;
-        $region   = @geoip_region_name_by_code($results['country_code'], $results['region']) ?: $results['region'];
+        if (!empty($results['region']) && !empty($results['country_code'])) {
+            $timezone = @geoip_time_zone_by_country_and_region($results['country_code'], $results['region']) ?: null;
+            $region   = @geoip_region_name_by_code($results['country_code'], $results['region']) ?: $results['region'];
+        } else {
+            $timezone = null;
+            $region = $results['region'];
+        }
 
         return $this->returnResults([
             $this->fixEncoding(array_merge($this->getDefaults(), [


### PR DESCRIPTION
The `geoip_region_name_by_code()` and `geoip_time_zone_by_country_and_region()` require both arguments (country and region) should be provided. Code which previously served as a part of this verification has been removed 16.11.2012 (b4c48686) by Christaudo contributor. Now behaviour is wrong becouse of empty `region` in `geoip_record_by_name` very common situation and provide `You need to specify the country and region codes.` error message.

This pull request add this verification back.