### PR TITLE
[FreeGeoIp] Add the missing timezone field

### DIFF
--- a/src/Geocoder/Provider/FreeGeoIp.php
+++ b/src/Geocoder/Provider/FreeGeoIp.php
@@ -99,6 +99,7 @@ class FreeGeoIp extends AbstractHttpProvider implements Provider
                 'adminLevels' => $adminLevels,
                 'country'     => isset($data['country_name']) ? $data['country_name'] : null,
                 'countryCode' => isset($data['country_code']) ? $data['country_code'] : null,
+                'timezone'    => isset($data['time_zone']) ? $data['time_zone'] : null,
             ))
         ]);
     }


### PR DESCRIPTION
Add the missing `timezone` field for `FreeGeoIp` provider.