### PR TITLE
ignore tests for export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.gitattributes export-ignore
+phpunit.xml.dist export-ignore
+tests export-ignore


### PR DESCRIPTION
Please ignore your test suite for export, otherwise it will blow the vendor directory due to that large `GeoLiteCity.dat`.