### PR TITLE
Add a @return tag

### DIFF
--- a/src/Geocoder/Provider/FreeGeoIp.php
+++ b/src/Geocoder/Provider/FreeGeoIp.php
@@ -59,6 +59,8 @@ class FreeGeoIp extends AbstractHttpProvider implements Provider
 
     /**
      * @param string $query
+     *
+     * @return \Geocoder\Model\AddressCollection
      */
     private function executeQuery($query)
     {


### PR DESCRIPTION
- FreeGeoIp exectueQuery's method didn't have a return tag, though it returns \Geocoder\Model\AddressCollection