### PR TITLE
Adds coutry-code to MapQuest-Results

### DIFF
--- a/src/Geocoder/Provider/MapQuest.php
+++ b/src/Geocoder/Provider/MapQuest.php
@@ -159,6 +159,7 @@ class MapQuest extends AbstractHttpProvider implements Provider
                     'postalCode'  => $location['postalCode'] ?: null,
                     'adminLevels' => $admins,
                     'country'     => $location['adminArea1'] ?: null,
+                    'countryCode' => $location['adminArea1'] ?: null,
                 ));
             }
         }

--- a/tests/Geocoder/Tests/Provider/MapQuestTest.php
+++ b/tests/Geocoder/Tests/Provider/MapQuestTest.php
@@ -72,11 +72,11 @@ class MapQuestTest extends TestCase
         $this->assertEquals('Paris', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Ile-de-France', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('FR', $result->getCountry()->getName());
+        $this->assertEquals('FR', $result->getCountry()->getCode());
 
         $this->assertFalse($result->getBounds()->isDefined());
         $this->assertNull($result->getStreetNumber());
         $this->assertNull($result->getAdminLevels()->get(1)->getCode());
-        $this->assertNull($result->getCountry()->getCode());
         $this->assertNull($result->getTimezone());
     }
 
@@ -117,11 +117,11 @@ class MapQuestTest extends TestCase
         $this->assertEquals('Lancashire', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('England', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('GB', $result->getCountry()->getName());
+        $this->assertEquals('GB', $result->getCountry()->getCode());
 
         $this->assertFalse($result->getBounds()->isDefined());
         $this->assertNull($result->getStreetNumber());
         $this->assertNull($result->getAdminLevels()->get(1)->getCode());
-        $this->assertNull($result->getCountry()->getCode());
         $this->assertNull($result->getTimezone());
     }
 
@@ -147,6 +147,7 @@ class MapQuestTest extends TestCase
         $this->assertEquals('Region Hannover', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Lower Saxony', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('DE', $result->getCountry()->getName());
+        $this->assertEquals('DE', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
         $result = $results->first();
@@ -158,6 +159,7 @@ class MapQuestTest extends TestCase
         $this->assertEquals('Region Hannover', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Lower Saxony', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('DE', $result->getCountry()->getName());
+        $this->assertEquals('DE', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
         $result = $results->first();
@@ -169,6 +171,7 @@ class MapQuestTest extends TestCase
         $this->assertEquals('Region Hannover', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Lower Saxony', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('DE', $result->getCountry()->getName());
+        $this->assertEquals('DE', $result->getCountry()->getCode());
 
         /** @var \Geocoder\Model\Address $result */
         $result = $results->first();
@@ -180,6 +183,7 @@ class MapQuestTest extends TestCase
         $this->assertEquals('Region Hannover', $result->getAdminLevels()->get(2)->getName());
         $this->assertEquals('Lower Saxony', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('DE', $result->getCountry()->getName());
+        $this->assertEquals('DE', $result->getCountry()->getCode());
     }
 
     public function testGeocodeWithCityDistrict()
@@ -205,11 +209,11 @@ class MapQuestTest extends TestCase
         $this->assertCount(1, $result->getAdminLevels());
         $this->assertEquals('Hesse', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('DE', $result->getCountry()->getName());
+        $this->assertEquals('DE', $result->getCountry()->getCode());
 
         $this->assertFalse($result->getBounds()->isDefined());
         $this->assertNull($result->getStreetNumber());
         $this->assertNull($result->getAdminLevels()->get(1)->getCode());
-        $this->assertNull($result->getCountry()->getCode());
         $this->assertNull($result->getTimezone());
     }
 


### PR DESCRIPTION
The MapQuest API returns a two-letter country-code and no country name. Currently that Country-code is returned as country name when using the MapQuest-Adapter. But it is not returned as CountryCode though.

This PR solves that by adding the CountryCode.

To handle BC returning that 2 letter code as country-name is kept AS IS.