### PR TITLE
Fixes Travis-Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,10 @@ matrix:
           env: deps="low"
 
 before_script:
-    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then pecl install geoip; fi
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "7.0" ]; then pecl install geoip; fi
     - composer self-update
     - if [ "$deps" = "low" ]; then composer update --prefer-dist --prefer-lowest; fi
     - if [ "$deps" = "" ]; then composer install --prefer-dist --no-interaction; fi
+    - if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then composer require "geoip/geoip"; fi
 
 script: phpunit --coverage-text


### PR DESCRIPTION
This adds a check for PHP7 to the HHVM-Check. Therefore on PHP7 the
PECL-GeoIP-Extension shouldn't be loaded. Instead the
geoip/geoip-package is required on PHP7.

It could also be required for HHVM, but I'm not sure that works...