### PR TITLE
fix: use statement for a phpdoc return tag

### DIFF
--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -13,6 +13,7 @@ namespace Geocoder;
 use Geocoder\Provider\ProviderInterface;
 use Geocoder\Result\ResultFactoryInterface;
 use Geocoder\Result\DefaultResultFactory;
+use Geocoder\Result\ResultInterface;
 
 /**
  * @author William Durand <william.durand1@gmail.com>


### PR DESCRIPTION
I don't know if version 2.x  is still maintained ... but if it can be help.
