### PR TITLE
Package egeloen/http-adapter is abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^5.4|^7.0",
-        "egeloen/http-adapter": "~0.8|~1.0",
+        "php-http/httplug": "~1.0",
         "igorw/get-in": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Package egeloen/http-adapter is abandoned, you should avoid using it. Use php-http/httplug instead.