### PR TITLE
Fix exception type

### DIFF
--- a/src/Geocoder/Provider/AbstractHttpProvider.php
+++ b/src/Geocoder/Provider/AbstractHttpProvider.php
@@ -10,6 +10,8 @@
 
 namespace Geocoder\Provider;
 
+use Geocoder\Exception\HttpError;
+use Ivory\HttpAdapter\HttpAdapterException;
 use Ivory\HttpAdapter\HttpAdapterInterface;
 
 /**
@@ -40,5 +42,20 @@ class AbstractHttpProvider extends AbstractProvider
     public function getAdapter()
     {
         return $this->adapter;
+    }
+
+    /**
+     * @param string $query
+     *
+     * @return string
+     * @throws HttpError
+     */
+    protected function getQueryContent($query)
+    {
+        try {
+            return (string) $this->getAdapter()->get($query)->getBody();
+        } catch (HttpAdapterException $exception) {
+            throw new HttpError(sprintf('Could not execute query "%s".', $query), 0, $exception);
+        }
     }
 }

--- a/src/Geocoder/Provider/ArcGISOnline.php
+++ b/src/Geocoder/Provider/ArcGISOnline.php
@@ -168,7 +168,7 @@ class ArcGISOnline extends AbstractHttpProvider implements Provider
     private function executeQuery($query)
     {
         $query   = $this->buildQuery($query);
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (empty($content)) {
             throw new NoResult(sprintf('Could not execute query "%s".', $query));

--- a/src/Geocoder/Provider/BingMaps.php
+++ b/src/Geocoder/Provider/BingMaps.php
@@ -100,7 +100,7 @@ class BingMaps extends AbstractHttpProvider implements LocaleAwareProvider
             $query = sprintf('%s&culture=%s', $query, str_replace('_', '-', $this->getLocale()));
         }
 
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (empty($content)) {
             throw new NoResult(sprintf('Could not execute query "%s".', $query));

--- a/src/Geocoder/Provider/FreeGeoIp.php
+++ b/src/Geocoder/Provider/FreeGeoIp.php
@@ -65,7 +65,7 @@ class FreeGeoIp extends AbstractHttpProvider implements Provider
      */
     private function executeQuery($query)
     {
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (empty($content)) {
             throw new NoResult(sprintf('Could not execute query %s', $query));

--- a/src/Geocoder/Provider/GeoIPs.php
+++ b/src/Geocoder/Provider/GeoIPs.php
@@ -107,7 +107,7 @@ class GeoIPs extends AbstractHttpProvider implements Provider
      */
     private function executeQuery($query)
     {
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (empty($content)) {
             throw new NoResult(sprintf('Invalid response from GeoIPs API for query "%s".', $query));

--- a/src/Geocoder/Provider/GeoPlugin.php
+++ b/src/Geocoder/Provider/GeoPlugin.php
@@ -62,7 +62,7 @@ class GeoPlugin extends AbstractHttpProvider implements Provider
      */
     private function executeQuery($query)
     {
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (empty($content)) {
             throw new NoResult(sprintf('Could not execute query "%s".', $query));

--- a/src/Geocoder/Provider/Geonames.php
+++ b/src/Geocoder/Provider/Geonames.php
@@ -102,7 +102,7 @@ class Geonames extends AbstractHttpProvider implements LocaleAwareProvider
             $query = sprintf('%s&lang=%s', $query, substr($this->getLocale(), 0, 2));
         }
 
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (empty($content)) {
             throw new NoResult(sprintf('Could not execute query "%s".', $query));

--- a/src/Geocoder/Provider/GoogleMaps.php
+++ b/src/Geocoder/Provider/GoogleMaps.php
@@ -136,7 +136,7 @@ class GoogleMaps extends AbstractHttpProvider implements LocaleAwareProvider
     private function executeQuery($query)
     {
         $query   = $this->buildQuery($query);
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         // Throw exception if invalid clientID and/or privateKey used with GoogleMapsBusinessProvider
         if (strpos($content, "Provided 'signature' is not valid for the provided client ID") !== false) {

--- a/src/Geocoder/Provider/HostIp.php
+++ b/src/Geocoder/Provider/HostIp.php
@@ -69,7 +69,7 @@ class HostIp extends AbstractHttpProvider implements Provider
      */
     private function executeQuery($query)
     {
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         $data = json_decode($content, true);
 

--- a/src/Geocoder/Provider/IpInfoDb.php
+++ b/src/Geocoder/Provider/IpInfoDb.php
@@ -121,7 +121,7 @@ class IpInfoDb extends AbstractHttpProvider implements Provider
      */
     private function executeQuery($query)
     {
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (empty($content)) {
             throw new NoResult(sprintf('Could not execute query "%s".', $query));

--- a/src/Geocoder/Provider/MapQuest.php
+++ b/src/Geocoder/Provider/MapQuest.php
@@ -120,7 +120,7 @@ class MapQuest extends AbstractHttpProvider implements Provider
      */
     private function executeQuery($query)
     {
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (empty($content)) {
             throw new NoResult(sprintf('Could not execute query "%s".', $query));

--- a/src/Geocoder/Provider/MaxMind.php
+++ b/src/Geocoder/Provider/MaxMind.php
@@ -116,7 +116,7 @@ class MaxMind extends AbstractHttpProvider implements Provider
      */
     private function executeQuery($query)
     {
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
         $fields  = $this->fieldsForService($this->service);
 
         if (null === $content || '' === $content) {

--- a/src/Geocoder/Provider/Nominatim.php
+++ b/src/Geocoder/Provider/Nominatim.php
@@ -163,7 +163,7 @@ class Nominatim extends AbstractHttpProvider implements LocaleAwareProvider
             $query = sprintf('%s&accept-language=%s', $query, $this->getLocale());
         }
 
-        return (string) $this->getAdapter()->get($query)->getBody();
+        return $this->getQueryContent($query);
     }
 
     private function getGeocodeEndpointUrl()

--- a/src/Geocoder/Provider/OpenCage.php
+++ b/src/Geocoder/Provider/OpenCage.php
@@ -99,7 +99,7 @@ class OpenCage extends AbstractHttpProvider implements LocaleAwareProvider
             $query = sprintf('%s&language=%s', $query, $this->getLocale());
         }
 
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (empty($content)) {
             throw new NoResult(sprintf('Could not execute query "%s".', $query));

--- a/src/Geocoder/Provider/TomTom.php
+++ b/src/Geocoder/Provider/TomTom.php
@@ -102,7 +102,7 @@ class TomTom extends AbstractHttpProvider implements LocaleAwareProvider
             $query = sprintf('%s&language=%s', $query, substr($this->getLocale(), 0, 2));
         }
 
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
 
         if (false !== stripos($content, "Developer Inactive")) {
             throw new InvalidCredentials('Map API Key provided is not valid.');

--- a/src/Geocoder/Provider/Yandex.php
+++ b/src/Geocoder/Provider/Yandex.php
@@ -97,7 +97,7 @@ class Yandex extends AbstractHttpProvider implements LocaleAwareProvider
 
         $query = sprintf('%s&results=%d', $query, $this->getLimit());
 
-        $content = (string) $this->getAdapter()->get($query)->getBody();
+        $content = $this->getQueryContent($query);
         $json    = (array) json_decode($content, true);
 
         if (empty($json) || isset($json['error']) ||

--- a/tests/Geocoder/Tests/Provider/ArcGISOnlineTest.php
+++ b/tests/Geocoder/Tests/Provider/ArcGISOnlineTest.php
@@ -72,6 +72,16 @@ class ArcGISOnlineTest extends TestCase
         $provider->geocode('10 avenue Gambetta, Paris, France');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?text=10+avenue+Gambetta%2C+Paris%2C+France&maxLocations=5&f=json&outFields=*".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new ArcGISOnline($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'));
+        $provider->geocode('10 avenue Gambetta, Paris, France');
+    }
+
     public function testGeocodeWithRealAddress()
     {
         $provider = new ArcGISOnline($this->getAdapter());

--- a/tests/Geocoder/Tests/Provider/BingMapsTest.php
+++ b/tests/Geocoder/Tests/Provider/BingMapsTest.php
@@ -82,6 +82,16 @@ class BingMapsTest extends TestCase
         $provider->geocode('10 avenue Gambetta, Paris, France');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=10+avenue+Gambetta%2C+Paris%2C+France&key=api_key&incl=ciso2".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new BingMaps($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'api_key');
+        $provider->geocode('10 avenue Gambetta, Paris, France');
+    }
+
     public function testGeocodeReturnsMultipleResults()
     {
         $json = <<<JSON

--- a/tests/Geocoder/Tests/Provider/FreeGeoIpTest.php
+++ b/tests/Geocoder/Tests/Provider/FreeGeoIpTest.php
@@ -93,6 +93,16 @@ class FreeGeoIpTest extends TestCase
         $provider->geocode('74.200.247.59');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://freegeoip.net/json/74.200.247.59".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new FreeGeoIp($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'));
+        $provider->geocode('74.200.247.59');
+    }
+
     public function testGeocodeWithRealIPv4()
     {
         $provider = new FreeGeoIp($this->getAdapter());

--- a/tests/Geocoder/Tests/Provider/GeoIPsTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoIPsTest.php
@@ -97,6 +97,16 @@ class GeoIPsTest extends TestCase
         $provider->geocode('74.200.247.59');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://api.geoips.com/ip/74.200.247.59/key/api_key/output/json/timezone/true/".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new GeoIPs($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'api_key');
+        $provider->geocode('74.200.247.59');
+    }
+
     public function testGeocodeWithRealIPv4GetsFakeContentFormattedEmpty()
     {
         $json = '{"response":{

--- a/tests/Geocoder/Tests/Provider/GeoPluginTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoPluginTest.php
@@ -89,6 +89,16 @@ class GeoPluginTest extends TestCase
         $provider->geocode('74.200.247.59');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://www.geoplugin.net/json.gp?ip=74.200.247.59".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new GeoPlugin($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'));
+        $provider->geocode('74.200.247.59');
+    }
+
     public function testGeocodeWithRealIPv4()
     {
         $provider = new GeoPlugin($this->getAdapter());

--- a/tests/Geocoder/Tests/Provider/GeoipTest.php
+++ b/tests/Geocoder/Tests/Provider/GeoipTest.php
@@ -52,6 +52,16 @@ class GeoipTest extends TestCase
         $provider->geocode('10 avenue Gambetta, Paris, France');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=10+avenue+Gambetta%2C+Paris%2C+France&key=api_key&incl=ciso2".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new BingMaps($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'api_key');
+        $provider->geocode('10 avenue Gambetta, Paris, France');
+    }
+
     public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new Geoip();

--- a/tests/Geocoder/Tests/Provider/GeonamesTest.php
+++ b/tests/Geocoder/Tests/Provider/GeonamesTest.php
@@ -64,6 +64,16 @@ class GeonamesTest extends TestCase
     }
 
     /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://api.geonames.org/searchJSON?q=London&maxRows=5&style=full&username=username".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new Geonames($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'username');
+        $provider->geocode('London');
+    }
+
+    /**
      * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage No places found for query "http://api.geonames.org/searchJSON?q=BlaBlaBla&maxRows=5&style=full&username=username".
      */

--- a/tests/Geocoder/Tests/Provider/GoogleMapsBusinessTest.php
+++ b/tests/Geocoder/Tests/Provider/GoogleMapsBusinessTest.php
@@ -90,4 +90,14 @@ class GoogleMapsBusinessTest extends TestCase
 
         $provider->geocode('Columbia University', true);
     }
+
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://maps.googleapis.com/maps/api/geocode/json?address=Columbia%20University&client=foo&signature=9dJq1hPF7_iwafUpnqXUqEkP0gY=".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new GoogleMapsBusiness($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), $this->testClientId, $this->testPrivateKey, null, null, false);
+        $provider->geocode('Columbia University', true);
+    }
 }

--- a/tests/Geocoder/Tests/Provider/GoogleMapsTest.php
+++ b/tests/Geocoder/Tests/Provider/GoogleMapsTest.php
@@ -108,6 +108,16 @@ class GoogleMapsTest extends TestCase
         $provider->geocode('10 avenue Gambetta, Paris, France');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://maps.googleapis.com/maps/api/geocode/json?address=10%20avenue%20Gambetta%2C%20Paris%2C%20France&language=fr-FR&region=Île-de-France".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new GoogleMaps($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'fr-FR', 'Île-de-France');
+        $provider->geocode('10 avenue Gambetta, Paris, France');
+    }
+
     public function testGeocodeWithRealAddress()
     {
         $provider = new GoogleMaps($this->getAdapter(), 'fr-FR', 'Île-de-France');

--- a/tests/Geocoder/Tests/Provider/HostIpTest.php
+++ b/tests/Geocoder/Tests/Provider/HostIpTest.php
@@ -43,6 +43,16 @@ class HostIpTest extends TestCase
         $provider->geocode('10 avenue Gambetta, Paris, France');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://api.hostip.info/get_json.php?ip=88.188.221.14&position=true".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new HostIp($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'));
+        $provider->geocode('88.188.221.14');
+    }
+
     public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new HostIp($this->getMockAdapter($this->never()));

--- a/tests/Geocoder/Tests/Provider/IpInfoDbTest.php
+++ b/tests/Geocoder/Tests/Provider/IpInfoDbTest.php
@@ -71,6 +71,16 @@ class IpInfoDbTest extends TestCase
         $provider->geocode('10 avenue Gambetta, Paris, France');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://api.ipinfodb.com/v3/ip-city/?key=api_key&format=json&ip=74.125.45.100".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new IpInfoDb($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'api_key');
+        $provider->geocode('74.125.45.100');
+    }
+
     public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new IpInfoDb($this->getMockAdapter($this->never()), 'api_key');

--- a/tests/Geocoder/Tests/Provider/MapQuestTest.php
+++ b/tests/Geocoder/Tests/Provider/MapQuestTest.php
@@ -48,6 +48,16 @@ class MapQuestTest extends TestCase
         $provider->reverse(123, 456);
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://open.mapquestapi.com/geocoding/v1/address?location=10+avenue+Gambetta%2C+Paris%2C+France&outFormat=json&maxResults=5&key=api_key&thumbMaps=false".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new MapQuest($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'api_key');
+        $provider->geocode('10 avenue Gambetta, Paris, France');
+    }
+
     public function testGeocodeWithRealAddress()
     {
         if (!isset($_SERVER['MAPQUEST_API_KEY'])) {

--- a/tests/Geocoder/Tests/Provider/MaxMindBinaryTest.php
+++ b/tests/Geocoder/Tests/Provider/MaxMindBinaryTest.php
@@ -41,6 +41,16 @@ class MaxMindBinaryTest extends TestCase
         new MaxMindBinary('not_exist.dat');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://dev.virtualearth.net/REST/v1/Locations/?maxResults=5&q=10+avenue+Gambetta%2C+Paris%2C+France&key=api_key&incl=ciso2".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new BingMaps($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'api_key');
+        $provider->geocode('10 avenue Gambetta, Paris, France');
+    }
+
     public function testLocationResultContainsExpectedFieldsForAnAmericanIp()
     {
         $provider = new MaxMindBinary($this->binaryFile);

--- a/tests/Geocoder/Tests/Provider/MaxMindTest.php
+++ b/tests/Geocoder/Tests/Provider/MaxMindTest.php
@@ -52,6 +52,16 @@ class MaxMindTest extends TestCase
         $provider->geocode('10 avenue Gambetta, Paris, France');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://geoip.maxmind.com/f?l=api_key&i=74.200.247.59".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new MaxMind($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'api_key');
+        $provider->geocode('74.200.247.59');
+    }
+
     public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new MaxMind($this->getMockAdapter($this->never()), 'api_key');

--- a/tests/Geocoder/Tests/Provider/OpenCageTest.php
+++ b/tests/Geocoder/Tests/Provider/OpenCageTest.php
@@ -46,6 +46,16 @@ class OpenCageTest extends TestCase
         $provider->geocode('10 avenue Gambetta, Paris, France');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://api.opencagedata.com/geocode/v1/json?key=api_key&query=10+avenue+Gambetta%2C+Paris%2C+France&limit=5&pretty=1".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new OpenCage($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'api_key');
+        $provider->geocode('10 avenue Gambetta, Paris, France');
+    }
+
     public function testGeocodeWithRealAddress()
     {
         if (!isset($_SERVER['OPENCAGE_API_KEY'])) {

--- a/tests/Geocoder/Tests/Provider/OpenStreetMapTest.php
+++ b/tests/Geocoder/Tests/Provider/OpenStreetMapTest.php
@@ -222,6 +222,16 @@ class OpenStreetMapTest extends TestCase
         $provider->geocode('Hammm');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "http://nominatim.openstreetmap.org/search?q=Kalbacher+Hauptstra%C3%9Fe%2C+60437+Frankfurt%2C+Germany&format=xml&addressdetails=1&limit=5&accept-language=de_DE".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new OpenStreetMap($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'de_DE');
+        $provider->geocode('Kalbacher Hauptstraße, 60437 Frankfurt, Germany');
+    }
+
     public function testReverseWithRealCoordinatesWithLocale()
     {
         $provider = new OpenStreetMap($this->getAdapter(), 'de_DE');

--- a/tests/Geocoder/Tests/Provider/TomTomTest.php
+++ b/tests/Geocoder/Tests/Provider/TomTomTest.php
@@ -78,6 +78,16 @@ XML;
         $provider->geocode('foo');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "https://api.tomtom.com/lbs/services/geocode/4/geocode?key=api_key&query=foo&maxResults=5".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new TomTom($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'), 'api_key');
+        $provider->geocode('foo');
+    }
+
     public function testGeocodeWithRealAddress()
     {
         if (!isset($_SERVER['TOMTOM_MAP_KEY'])) {

--- a/tests/Geocoder/Tests/Provider/YandexTest.php
+++ b/tests/Geocoder/Tests/Provider/YandexTest.php
@@ -86,6 +86,16 @@ class YandexTest extends TestCase
         $provider->geocode('foobar');
     }
 
+    /**
+     * @expectedException \Geocoder\Exception\HttpError
+     * @expectedExceptionMessage Could not execute query "https://geocode-maps.yandex.ru/1.x/?format=json&geocode=foobar&results=5".
+     */
+    public function testGeocodeWithAdaptorFailuresResultInGeocodingException()
+    {
+        $provider = new Yandex($this->getMockAdapterThrows('Ivory\HttpAdapter\HttpAdapterException'));
+        $provider->geocode('foobar');
+    }
+
     public function testGeocodeWithRealAddress()
     {
         $provider = new Yandex($this->getAdapter());

--- a/tests/Geocoder/Tests/TestCase.php
+++ b/tests/Geocoder/Tests/TestCase.php
@@ -70,6 +70,21 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param string $exception
+     * @return HttpAdapterInterface
+     */
+    protected function getMockAdapterThrows($exception)
+    {
+        $adapter = $this->getMock('Ivory\HttpAdapter\HttpAdapterInterface');
+        $adapter
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->throwException(new $exception));
+
+        return $adapter;
+    }
+
+    /**
      * Because I was bored to fix the test suite because of
      * a change in a third-party API...
      *


### PR DESCRIPTION
Provides use Ivory adapters for executing the requests. Executing such requests may results in failures, which are currently thrown as `Ivory\HttpAdapter\HttpAdapterException`. As those exceptions are not catched, the user may get one of those issues instead of the expected `Geocoder\Exception\Exception`.
- Provide a helper method in `AbstractHttpProvider` to safely execute the query via the adpater and retrieve the content
- Add tests for each concerned adapters

Note: I'm not a big fan of protected methods, but in this case this proves to be the most effective way to deal with this issue.

Closes https://github.com/geocoder-php/Geocoder/issues/497

@willdurand I'm not sure how you want to handle this patch, it could be backported to the previous `3.x` releases but I know this can be a bit of a pain as well.
