### PR TITLE
Bug with the country name in MapQuest

### DIFF
--- a/src/Geocoder/Provider/MapQuest.php
+++ b/src/Geocoder/Provider/MapQuest.php
@@ -159,7 +159,7 @@ class MapQuest extends AbstractHttpProvider implements Provider
                     'locality'    => $location['adminArea5'] ?: null,
                     'postalCode'  => $location['postalCode'] ?: null,
                     'adminLevels' => $admins,
-                    'country'     => $location['adminArea1'] ?: null,
+                    'country'     => $location['adminArea2'] ?: null,
                     'countryCode' => $location['adminArea1'] ?: null,
                 ));
             }


### PR DESCRIPTION
It has been used the same keys for country name and country code, so there was two-letter country code instead of the name.