### PR TITLE
Fix bug where cached unit test responses aren't serialised

### DIFF
--- a/tests/Geocoder/Tests/CachedResponseClient.php
+++ b/tests/Geocoder/Tests/CachedResponseClient.php
@@ -44,7 +44,7 @@ class CachedResponseClient implements HttpClient
         $response = $this->delegate->sendRequest($request);
 
         if ($this->useCache) {
-            file_put_contents($file, $response->getBody()->getContents());
+            file_put_contents($file, serialize($response->getBody()->getContents()));
         }
 
         return $response;


### PR DESCRIPTION
Although the cached unit test responses are serialised, the unit test code framework doesn't actually serialise any new responses that are added to the cache directory. This fixes that.