### PR TITLE
Update unittest passage

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,13 +561,12 @@ $ composer install --dev
 Then, run the following command:
 
 ```
-$ phpunit
+$ ./vendor/bin/phpunit
 ```
 
 You'll obtain some _skipped_ unit tests due to the need of API keys.
 
-Rename the `phpunit.xml.dist` file to `phpunit.xml`, then uncomment the
-following lines and add your own API keys:
+Uncomment the following lines in `phpunit.xml.dist` and add your own API keys:
 
 ``` xml
 <php>

--- a/README.md
+++ b/README.md
@@ -561,12 +561,13 @@ $ composer install --dev
 Then, run the following command:
 
 ```
-$ ./vendor/bin/phpunit
+$ composer test
 ```
 
 You'll obtain some _skipped_ unit tests due to the need of API keys.
 
-Uncomment the following lines in `phpunit.xml.dist` and add your own API keys:
+Rename the `phpunit.xml.dist` file to `phpunit.xml`, then uncomment the
+following lines and add your own API keys:
 
 ``` xml
 <php>

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
     "autoload": {
         "psr-0": { "Geocoder": "src/" }
     },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.3-dev"


### PR DESCRIPTION
Use phpunit from vendor to prevent issues
don't suggest to rename `phpunit.xml.dist` 
https://phpunit.de/manual/current/en/organizing-tests.html#organizing-tests.xml-configuration
If there is no `phpunit.xml` then phpunit will use `phpunit.xml.dist` , so whats the point in renaming it?