### PR TITLE
Feature/add result type location type to googlemaps

### DIFF
--- a/src/Geocoder/Provider/GoogleMaps.php
+++ b/src/Geocoder/Provider/GoogleMaps.php
@@ -40,6 +40,16 @@ final class GoogleMaps extends AbstractHttpProvider implements LocaleAwareProvid
     private $region;
 
     /**
+     * @var array
+     */
+    private $resultType;
+
+    /**
+     * @var array
+     */
+    private $locationType;
+
+    /**
      * @var bool
      */
     private $useSsl;
@@ -70,11 +80,13 @@ final class GoogleMaps extends AbstractHttpProvider implements LocaleAwareProvid
      * @param string     $region Region biasing (optional)
      * @param bool       $useSsl Whether to use an SSL connection (optional)
      * @param string     $apiKey Google Geocoding API key (optional)
+     * @param array      $resultType One or more address types (optional)
+     * @param array      $locationType One or more location types (optional)
      * @return GoogleMaps
      */
-    public static function business(HttpClient $client, $clientId, $privateKey = null, $locale = null, $region = null, $useSsl = false, $apiKey = null)
+    public static function business(HttpClient $client, $clientId, $privateKey = null, $locale = null, $region = null, $useSsl = false, $apiKey = null, $resultType = [], $locationType = [])
     {
-        $provider = new self($client, $locale, $region, $useSsl, $apiKey);
+        $provider = new self($client, $locale, $region, $useSsl, $apiKey, $resultType, $locationType);
         $provider->clientId = $clientId;
         $provider->privateKey = $privateKey;
 
@@ -87,8 +99,10 @@ final class GoogleMaps extends AbstractHttpProvider implements LocaleAwareProvid
      * @param string     $region Region biasing (optional)
      * @param bool       $useSsl Whether to use an SSL connection (optional)
      * @param string     $apiKey Google Geocoding API key (optional)
+     * @param array      $resultType One or more address types - only for reserve (optional)
+     * @param array      $locationType One or more location types - only for reserve (optional)
      */
-    public function __construct(HttpClient $client, $locale = null, $region = null, $useSsl = false, $apiKey = null)
+    public function __construct(HttpClient $client, $locale = null, $region = null, $useSsl = false, $apiKey = null, $resultType = [], $locationType = [])
     {
         parent::__construct($client);
 
@@ -96,6 +110,8 @@ final class GoogleMaps extends AbstractHttpProvider implements LocaleAwareProvid
         $this->region = $region;
         $this->useSsl = $useSsl;
         $this->apiKey = $apiKey;
+        $this->resultType = $resultType;
+        $this->locationType = $locationType;
     }
 
     /**
@@ -141,6 +157,28 @@ final class GoogleMaps extends AbstractHttpProvider implements LocaleAwareProvid
     }
 
     /**
+     * @param array $resultType One or more address types - only for reserve
+     * @return $this
+     */
+    public function setResultType($resultType)
+    {
+        $this->resultType = $resultType;
+
+        return $this;
+    }
+
+    /**
+     * @param array $locationType One or more location types - only for reserve
+     * @return $this
+     */
+    public function setLocationType($locationType)
+    {
+        $this->locationType = $locationType;
+
+        return $this;
+    }
+
+    /**
      * @param string $query
      *
      * @return string query with extra params
@@ -153,6 +191,14 @@ final class GoogleMaps extends AbstractHttpProvider implements LocaleAwareProvid
 
         if (null !== $this->region) {
             $query = sprintf('%s&region=%s', $query, $this->region);
+        }
+
+        if (!empty($this->resultType) && is_array($this->resultType)) {
+            $query = sprintf('%s&result_type=%s', $query, implode("|", $this->resultType));
+        }
+
+        if (!empty($this->locationType) && is_array($this->locationType)) {
+            $query = sprintf('%s&location_type=%s', $query, implode("|", $this->locationType));
         }
 
         if (null !== $this->apiKey) {
@@ -201,6 +247,11 @@ final class GoogleMaps extends AbstractHttpProvider implements LocaleAwareProvid
 
         if ('REQUEST_DENIED' === $json->status) {
             throw new Exception(sprintf('API access denied. Request: %s - Message: %s',
+                $query, $json->error_message));
+        }
+
+        if ('INVALID_REQUEST' === $json->status) {
+            throw new Exception(sprintf('Sent invalid parameter. Request: %s - Message: %s',
                 $query, $json->error_message));
         }
 


### PR DESCRIPTION
PR for Issue #546

Adds `result_type` and `location_type` params for GoogleMaps reverse query

Please merge PR #551 first, otherwise this PR will be pointless.  `result_type` and `location_type` only work with a correct url reverse geocoding Url

Cheers,
Chris