### PR TITLE
Update dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "egeloen/http-adapter": "~0.8",
+        "egeloen/http-adapter": ">=0.8",
         "igorw/get-in": "~1.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.0",
         "geoip2/geoip2": "~2.0",
         "symfony/stopwatch": "~2.5"
     },


### PR DESCRIPTION
While `egeloen/http-adapter` is deprecated and this dependency is removed in 4.0, ~0.8 version currently blocks me to use geocoder-php ~3.3 as another library (florianv/swap) requires `egeloen/http-adapter ~1.0`. At the same time `egeloen/http-adater ~1.0` does not seem to be backward incompatible with `0.8`. Currently `geocoder-php 4.0-dev` does not have frozen API so it feels risky to couple with it until at least we got a release candidate.