### PR TITLE
ArcGIS provider : street name must use StAddr attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 * Changed: `Location::getBounds` will return null or a `Bounds` object with coordinates data. It will never return `Bounds` without data. 
 * Changed: Support for unsecure transfer protocol was removed. The providers only support HTTPS.
 * Changed: Using PSR-4 instead of PSR-0 for autoloading.  
+* Fixed: ArcGISOnline's street address should not contain city and country. 
 * Removed: `AdminLevel::toString` in favor for `AdminLevel::__toString`.
 * Removed: `Country::toString` in favor for `Country::__toString`.
 * Removed: `Address::getCountryCode` in favor for `Address::getCountry()->getCode()`.

--- a/src/Provider/ArcGISOnline/ArcGISOnline.php
+++ b/src/Provider/ArcGISOnline/ArcGISOnline.php
@@ -79,7 +79,7 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
             $data = $location->feature->attributes;
 
             $coordinates = (array) $location->feature->geometry;
-            $streetName = !empty($data->Match_addr) ? $data->Match_addr : null;
+            $streetName = !empty($data->StAddr) ? $data->StAddr : null;
             $streetNumber = !empty($data->AddNum) ? $data->AddNum : null;
             $city = !empty($data->City) ? $data->City : null;
             $zipcode = !empty($data->Postal) ? $data->Postal : null;

--- a/src/Provider/ArcGISOnline/Tests/ArcGISOnlineTest.php
+++ b/src/Provider/ArcGISOnline/Tests/ArcGISOnlineTest.php
@@ -86,7 +86,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertEquals(48.863279997000461, $result->getCoordinates()->getLatitude(), '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result->getCoordinates()->getLongitude(), '', 0.0001);
         $this->assertEquals(10, $result->getStreetNumber());
-        $this->assertEquals('10 Avenue Gambetta, 75020, 20e Arrondissement, Paris, Île-de-France', $result->getStreetName());
+        $this->assertEquals('10 Avenue Gambetta', $result->getStreetName());
         $this->assertEquals(75020, $result->getPostalCode());
         $this->assertEquals('Paris', $result->getLocality());
         $this->assertCount(2, $result->getAdminLevels());
@@ -116,7 +116,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertEquals(48.863279997000461, $result->getCoordinates()->getLatitude(), '', 0.0001);
         $this->assertEquals(2.3890199980004354, $result->getCoordinates()->getLongitude(), '', 0.0001);
         $this->assertEquals(10, $result->getStreetNumber());
-        $this->assertEquals('10 Avenue Gambetta, 75020, 20e Arrondissement, Paris, Île-de-France', $result->getStreetName());
+        $this->assertEquals('10 Avenue Gambetta', $result->getStreetName());
         $this->assertEquals(75020, $result->getPostalCode());
         $this->assertEquals('Paris', $result->getLocality());
         $this->assertCount(2, $result->getAdminLevels());
@@ -200,7 +200,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertEquals(52.370518568000477, $result->getCoordinates()->getLatitude(), '', 0.0001);
         $this->assertEquals(9.7332166860004463, $result->getCoordinates()->getLongitude(), '', 0.0001);
         $this->assertNull($result->getStreetNumber());
-        $this->assertEquals('Hannover, Niedersachsen, Deutschland', $result->getStreetName());
+        $this->assertNull($result->getStreetName());
         $this->assertNull($result->getPostalCode());
         $this->assertNull($result->getLocality());
         $this->assertCount(1, $result->getAdminLevels());
@@ -217,7 +217,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(47.111386795000499, $result->getCoordinates()->getLatitude(), '', 0.0001);
         $this->assertEquals(-101.4265391569997, $result->getCoordinates()->getLongitude(), '', 0.0001);
-        $this->assertEquals('Hannover, North Dakota, United States', $result->getStreetName());
+        $this->assertNull($result->getStreetName());
         $this->assertNull($result->getLocality());
         $this->assertCount(2, $result->getAdminLevels());
         $this->assertEquals('North Dakota', $result->getAdminLevels()->get(1)->getName());
@@ -228,7 +228,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(39.391768472000479, $result->getCoordinates()->getLatitude(), '', 0.0001);
         $this->assertEquals(-77.440257128999633, $result->getCoordinates()->getLongitude(), '', 0.0001);
-        $this->assertEquals('Hannover, Maryland, United States', $result->getStreetName());
+        $this->assertNull($result->getStreetName());
         $this->assertNull($result->getLocality());
         $this->assertCount(2, $result->getAdminLevels());
         $this->assertEquals('Maryland', $result->getAdminLevels()->get(1)->getName());
@@ -239,7 +239,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(53.174198173, $result->getCoordinates()->getLatitude(), '', 0.0001);
         $this->assertEquals(8.5069383810005, $result->getCoordinates()->getLongitude(), '', 0.0001);
-        $this->assertEquals('Hannöver, Niedersachsen, Deutschland', $result->getStreetName());
+        $this->assertNull($result->getStreetName());
         $this->assertNull($result->getLocality());
         $this->assertCount(1, $result->getAdminLevels());
         $this->assertEquals('Niedersachsen', $result->getAdminLevels()->get(1)->getName());
@@ -250,7 +250,7 @@ class ArcGISOnlineTest extends TestCase
         $this->assertInstanceOf('\Geocoder\Model\Address', $result);
         $this->assertEquals(-26.281805980999593, $result->getCoordinates()->getLatitude(), '', 0.0001);
         $this->assertEquals(-48.849389793999649, $result->getCoordinates()->getLongitude(), '', 0.0001);
-        $this->assertEquals('Hannover', $result->getStreetName());
+        $this->assertEquals('Rua Doutor João Colin', $result->getStreetName());
         $this->assertCount(2, $result->getAdminLevels());
         $this->assertEquals('Sul', $result->getAdminLevels()->get(1)->getName());
         $this->assertEquals('BRA', $result->getCountry()->getCode());


### PR DESCRIPTION
This will replace #566 and fix #489