### PR TITLE
Test on trusty

### DIFF
--- a/src/Provider/Geoip/.travis.yml
+++ b/src/Provider/Geoip/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 sudo: false
-
+dist: trusty
 php: 7.0
 
 addons:

--- a/src/Provider/MaxMindBinary/.travis.yml
+++ b/src/Provider/MaxMindBinary/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 sudo: false
-
+dist: trusty
 php: 7.0
 
 addons:


### PR DESCRIPTION
The providers that need php extension geoip must be tested on trusty