### PR TITLE
All exceptions should be ours

### DIFF
--- a/src/Common/Assert.php
+++ b/src/Common/Assert.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Geocoder;
 
+use Geocoder\Exception\InvalidArgument;
+
 class Assert
 {
     /**
@@ -21,13 +23,13 @@ class Assert
     public static function latitude($value, $message = '')
     {
         if (!is_float($value)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgument(
                 sprintf($message ?: 'Expected a double. Got: %s', self::typeToString($value))
             );
         }
 
         if ($value < -90 || $value > 90) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgument(
                 sprintf($message ?: 'Latitude should be between -90 and 90. Got: %s', $value)
             );
         }
@@ -40,13 +42,13 @@ class Assert
     public static function longitude($value, $message = '')
     {
         if (!is_float($value)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgument(
                 sprintf($message ?: 'Expected a doable. Got: %s', self::typeToString($value))
             );
         }
 
         if ($value < -180 || $value > 180) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgument(
                 sprintf($message ?: 'Latitude should be between -90 and 90. Got: %s', $value)
             );
         }
@@ -59,7 +61,7 @@ class Assert
     public static function notNull($value, $message = '')
     {
         if (null === $value) {
-            throw new \InvalidArgumentException(sprintf($message ?: 'Value cannot be null'));
+            throw new InvalidArgument(sprintf($message ?: 'Value cannot be null'));
         }
     }
 

--- a/src/Common/Exception/LogicException.php
+++ b/src/Common/Exception/LogicException.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Exception;
 
 /**

--- a/src/Common/Exception/LogicException.php
+++ b/src/Common/Exception/LogicException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Geocoder\Exception;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class LogicException extends \LogicException implements Exception
+{
+}

--- a/src/Common/Exception/OutOfBoundsException.php
+++ b/src/Common/Exception/OutOfBoundsException.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Exception;
 
 /**

--- a/src/Common/Exception/OutOfBoundsException.php
+++ b/src/Common/Exception/OutOfBoundsException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Geocoder\Exception;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class OutOfBoundsException extends \OutOfBoundsException implements Exception
+{
+}

--- a/src/Common/Exception/ProviderNotRegistered.php
+++ b/src/Common/Exception/ProviderNotRegistered.php
@@ -21,12 +21,17 @@ class ProviderNotRegistered extends \RuntimeException implements Exception
      * @param string $providerName
      * @param array  $registeredProviders
      */
-    public function __construct(string $providerName, array $registeredProviders = [])
+    public static function create(string $providerName, array $registeredProviders = [])
     {
-        parent::__construct(sprintf(
+        return new self(sprintf(
             'Provider "%s" is not registered, so you cannot use it. Did you forget to register it or made a typo?%s',
             $providerName,
             0 == count($registeredProviders) ? '' : sprintf(' Registered providers are: %s.', implode(', ', $registeredProviders))
         ));
+    }
+
+    public static function noProviderRegistered()
+    {
+        return new self('No provider registered.');
     }
 }

--- a/src/Common/Model/AddressBuilder.php
+++ b/src/Common/Model/AddressBuilder.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Geocoder\Model;
 
+use Geocoder\Exception\LogicException;
+
 /**
  * A class that builds a Location or any of its subclasses.
  *
@@ -102,7 +104,7 @@ final class AddressBuilder
     public function build(string $class = Address::class)
     {
         if (!is_a($class, Address::class, true)) {
-            throw new \LogicException('First parameter to LocationBuilder::build must be a class name extending Geocoder\Model\Address');
+            throw new LogicException('First parameter to LocationBuilder::build must be a class name extending Geocoder\Model\Address');
         }
 
         $country = null;

--- a/src/Common/Model/AddressCollection.php
+++ b/src/Common/Model/AddressCollection.php
@@ -14,6 +14,7 @@ namespace Geocoder\Model;
 
 use Geocoder\Collection;
 use Geocoder\Exception\CollectionIsEmpty;
+use Geocoder\Exception\OutOfBoundsException;
 use Geocoder\Location;
 
 class AddressCollection implements Collection
@@ -89,7 +90,7 @@ class AddressCollection implements Collection
     public function get($index): Location
     {
         if (!isset($this->locations[$index])) {
-            throw new \OutOfBoundsException(sprintf('The index "%s" does not exist in this collection.', $index));
+            throw new OutOfBoundsException(sprintf('The index "%s" does not exist in this collection.', $index));
         }
 
         return $this->locations[$index];

--- a/src/Common/Model/AdminLevelCollection.php
+++ b/src/Common/Model/AdminLevelCollection.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace Geocoder\Model;
 
+use Geocoder\Exception\CollectionIsEmpty;
 use Geocoder\Exception\InvalidArgument;
+use Geocoder\Exception\OutOfBoundsException;
 
 /**
  * @author Giorgio Premi <giosh94mhz@gmail.com>
@@ -65,21 +67,26 @@ final class AdminLevelCollection implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @return AdminLevel|null
+     * @return AdminLevel
+     *
+     * @throws CollectionIsEmpty
      */
-    public function first()
+    public function first(): AdminLevel
     {
         if (empty($this->adminLevels)) {
-            return null;
+            throw new CollectionIsEmpty();
         }
 
         return reset($this->adminLevels);
     }
 
     /**
+     * @param int $offset
+     * @param int|null $length
+     *
      * @return AdminLevel[]
      */
-    public function slice($offset, $length = null)
+    public function slice(int $offset, int $length = null): array
     {
         return array_slice($this->adminLevels, $offset, $length, true);
     }
@@ -87,7 +94,7 @@ final class AdminLevelCollection implements \IteratorAggregate, \Countable
     /**
      * @return bool
      */
-    public function has($level): bool
+    public function has(int $level): bool
     {
         return isset($this->adminLevels[$level]);
     }
@@ -98,7 +105,7 @@ final class AdminLevelCollection implements \IteratorAggregate, \Countable
      * @throws \OutOfBoundsException
      * @throws InvalidArgument
      */
-    public function get($level): AdminLevel
+    public function get(int $level): AdminLevel
     {
         $this->checkLevel($level);
 
@@ -122,14 +129,12 @@ final class AdminLevelCollection implements \IteratorAggregate, \Countable
      *
      * @throws \OutOfBoundsException
      */
-    private function checkLevel($level)
+    private function checkLevel(int $level)
     {
         if ($level <= 0 || $level > self::MAX_LEVEL_DEPTH) {
-            throw new \OutOfBoundsException(sprintf(
-                'Administrative level should be an integer in [1,%d], %d given',
-                self::MAX_LEVEL_DEPTH,
-                $level
-            ));
+            throw new OutOfBoundsException(
+                sprintf('Administrative level should be an integer in [1,%d], %d given', self::MAX_LEVEL_DEPTH, $level)
+            );
         }
     }
 }

--- a/src/Common/Model/AdminLevelCollection.php
+++ b/src/Common/Model/AdminLevelCollection.php
@@ -81,7 +81,7 @@ final class AdminLevelCollection implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @param int $offset
+     * @param int      $offset
      * @param int|null $length
      *
      * @return AdminLevel[]

--- a/src/Common/ProviderAggregator.php
+++ b/src/Common/ProviderAggregator.php
@@ -146,7 +146,7 @@ class ProviderAggregator implements Geocoder
     public function using($name)
     {
         if (!isset($this->providers[$name])) {
-            throw new ProviderNotRegistered($name ?? '');
+            throw ProviderNotRegistered::create($name ?? '', $this->providers);
         }
 
         $this->provider = $this->providers[$name];
@@ -173,7 +173,7 @@ class ProviderAggregator implements Geocoder
     {
         if (null === $this->provider) {
             if (0 === count($this->providers)) {
-                throw new \RuntimeException('No provider registered.');
+                throw ProviderNotRegistered::noProviderRegistered();
             }
 
             $this->using(key($this->providers));

--- a/src/Provider/GoogleMaps/GoogleMaps.php
+++ b/src/Provider/GoogleMaps/GoogleMaps.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Geocoder\Provider\GoogleMaps;
 
-use Exception;
 use Geocoder\Collection;
 use Geocoder\Exception\InvalidCredentials;
 use Geocoder\Exception\InvalidServerResponse;
@@ -201,8 +200,9 @@ final class GoogleMaps extends AbstractHttpProvider implements LocaleAwareGeocod
         }
 
         if ('REQUEST_DENIED' === $json->status) {
-            throw new Exception(sprintf('API access denied. Request: %s - Message: %s',
-                $url, $json->error_message));
+            throw new InvalidServerResponse(
+                sprintf('API access denied. Request: %s - Message: %s', $url, $json->error_message)
+            );
         }
 
         // you are over your quota


### PR DESCRIPTION
The `\LogicException` in `AddressBuilder` will only be thrown if the provider is doing something strange (ie wrong programming).

How about the `\OutOfBoundsException` in `AddressCollection` and `AdminLevelCollection`. Should we create our own `OutOfBoundsException`?