### PR TITLE
Mark ProviderAggregator as NOT final.

### DIFF
--- a/src/Common/ProviderAggregator.php
+++ b/src/Common/ProviderAggregator.php
@@ -21,7 +21,7 @@ use Geocoder\Provider\Provider;
 /**
  * @author William Durand <william.durand1@gmail.com>
  */
-final class ProviderAggregator implements Geocoder
+class ProviderAggregator implements Geocoder
 {
     /**
      * @var Provider[]


### PR DESCRIPTION
Marking classes as `final` does have benefits in certain situations but many sources recommend doing so only when:
* There is an abstraction (interface) that the final class implements
* All of the public API of the final class is part of that interface

The particular thing that broke in my case was that it's not possible to mock `ProviderAggregator` anymore (and I'm testing the thin wrapper I wrote around it) as mocking final classes in `phpunit-mock-objects` (the default mocking library for phpunit) is not possible.

I would be happy (and could open a PR with such change) if we extract an inteface from the `ProviderAggregator` and leave it final.

Addresses #727 