### PR TITLE
Added a callable to decide what provider that should be used.

### DIFF
--- a/src/Common/CHANGELOG.md
+++ b/src/Common/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## Unreleased
+
+### Added 
+
+- The constructor of `ProvierAggregator` will accept a callable that can decide what providers should be used for a specific query. 
+
+### Changed
+
+- `ProvierAggregator::getProvider` is now private
+
 ## 4.0.0 - Beta 2
 
 ### Added

--- a/src/Common/ProviderAggregator.php
+++ b/src/Common/ProviderAggregator.php
@@ -39,11 +39,18 @@ class ProviderAggregator implements Geocoder
     private $limit;
 
     /**
+     * A callable that decided what provider to use.
+     * @var callable
+     */
+    private $decider;
+
+    /**
      * @param int $limit
      */
-    public function __construct(int $limit = Geocoder::DEFAULT_RESULT_LIMIT)
+    public function __construct(int $limit = Geocoder::DEFAULT_RESULT_LIMIT, callable $decider = null)
     {
         $this->limit($limit);
+        $this->decider = $decider ?? __CLASS__.'::getProvider';
     }
 
     /**
@@ -51,7 +58,11 @@ class ProviderAggregator implements Geocoder
      */
     public function geocodeQuery(GeocodeQuery $query): Collection
     {
-        return $this->getProvider()->geocodeQuery($query);
+        if (null === $query->getLimit()) {
+            $query = $query->withLimit($this->limit);
+        }
+
+        return call_user_func($this->decider, $query, $this->providers, $this->provider)->geocodeQuery($query);
     }
 
     /**
@@ -59,7 +70,11 @@ class ProviderAggregator implements Geocoder
      */
     public function reverseQuery(ReverseQuery $query): Collection
     {
-        return $this->getProvider()->reverseQuery($query);
+        if (null === $query->getLimit()) {
+            $query = $query->withLimit($this->limit);
+        }
+
+        return call_user_func($this->decider, $query, $this->providers, $this->provider)->reverseQuery($query);
     }
 
     /**
@@ -167,22 +182,29 @@ class ProviderAggregator implements Geocoder
     }
 
     /**
-     * Returns the current provider in use.
+     * Get a provider to use for this query.
+     *
+     * @param GeocodeQuery|ReverseQuery $query
+     * @param Provider[] $providers
+     * @param Provider $currentProvider
      *
      * @return Provider
      *
-     * @throws \RuntimeException
+     * @throws ProviderNotRegistered
      */
-    protected function getProvider(): Provider
+    private static function getProvider($query, array $providers, Provider $currentProvider = null): Provider
     {
-        if (null === $this->provider) {
-            if (0 === count($this->providers)) {
-                throw ProviderNotRegistered::noProviderRegistered();
-            }
-
-            $this->using(key($this->providers));
+        if (null !== $currentProvider) {
+            return $currentProvider;
         }
 
-        return $this->provider;
+        if (0 === count($providers)) {
+            throw ProviderNotRegistered::noProviderRegistered();
+        }
+
+        // Take first
+        $key = key($providers);
+
+        return $providers[$key];
     }
 }

--- a/src/Common/ProviderAggregator.php
+++ b/src/Common/ProviderAggregator.php
@@ -40,6 +40,7 @@ class ProviderAggregator implements Geocoder
 
     /**
      * A callable that decided what provider to use.
+     *
      * @var callable
      */
     private $decider;
@@ -185,8 +186,8 @@ class ProviderAggregator implements Geocoder
      * Get a provider to use for this query.
      *
      * @param GeocodeQuery|ReverseQuery $query
-     * @param Provider[] $providers
-     * @param Provider $currentProvider
+     * @param Provider[]                $providers
+     * @param Provider                  $currentProvider
      *
      * @return Provider
      *

--- a/src/Common/Tests/ProviderAggregatorTest.php
+++ b/src/Common/Tests/ProviderAggregatorTest.php
@@ -14,6 +14,8 @@ namespace Geocoder\Tests;
 
 use Geocoder\Collection;
 use Geocoder\Geocoder;
+use Geocoder\Model\Address;
+use Geocoder\Model\AddressCollection;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
 use Geocoder\ProviderAggregator;
@@ -36,12 +38,42 @@ class ProviderAggregatorTest extends TestCase
         $this->geocoder = new ProviderAggregator();
     }
 
+    public function testGeocode()
+    {
+        $provider1 = new MockProvider('test1');
+        $provider1->result = [Address::createFromArray(['providedBy'=>'p1'])];
+        $provider2 = new MockProvider('test2');
+        $provider2->result = [Address::createFromArray(['providedBy'=>'p2'])];
+
+        $this->geocoder->registerProvider($provider1);
+        $this->geocoder->registerProvider($provider2);
+
+
+        $result = $this->geocoder->geocode('foo');
+        $this->assertEquals('p1', $result->first()->getProvidedBy());
+    }
+
+    public function testReverse()
+    {
+        $provider1 = new MockProvider('test1');
+        $provider1->result = [Address::createFromArray(['providedBy'=>'p1'])];
+        $provider2 = new MockProvider('test2');
+        $provider2->result = [Address::createFromArray(['providedBy'=>'p2'])];
+
+        $this->geocoder->registerProvider($provider1);
+        $this->geocoder->registerProvider($provider2);
+        $this->geocoder->using('test2');
+
+        $result = $this->geocoder->reverse(0.1, 0.2);
+        $this->assertEquals('p2', $result->first()->getProvidedBy());
+    }
+
     public function testRegisterProvider()
     {
         $provider = new MockProvider('test');
         $this->geocoder->registerProvider($provider);
 
-        $this->assertSame($provider, NSA::invokeMethod($this->geocoder, 'getProvider'));
+        $this->assertSame(['test'=>$provider], NSA::getProperty($this->geocoder, 'providers'));
     }
 
     public function testRegisterProviders()
@@ -49,25 +81,7 @@ class ProviderAggregatorTest extends TestCase
         $provider = new MockProvider('test');
         $this->geocoder->registerProviders([$provider]);
 
-        $this->assertSame($provider, NSA::invokeMethod($this->geocoder, 'getProvider'));
-    }
-
-    public function testUsing()
-    {
-        $provider1 = new MockProvider('test1');
-        $provider2 = new MockProvider('test2');
-        $this->geocoder->registerProviders([$provider1, $provider2]);
-
-        $this->assertSame($provider1, NSA::invokeMethod($this->geocoder, 'getProvider'));
-
-        $this->geocoder->using('test1');
-        $this->assertSame($provider1, NSA::invokeMethod($this->geocoder, 'getProvider'));
-
-        $this->geocoder->using('test2');
-        $this->assertSame($provider2, NSA::invokeMethod($this->geocoder, 'getProvider'));
-
-        $this->geocoder->using('test1');
-        $this->assertSame($provider1, NSA::invokeMethod($this->geocoder, 'getProvider'));
+        $this->assertSame(['test'=>$provider], NSA::getProperty($this->geocoder, 'providers'));
     }
 
     /**
@@ -109,19 +123,21 @@ class ProviderAggregatorTest extends TestCase
      */
     public function testGetProvider()
     {
-        NSA::invokeMethod($this->geocoder, 'getProvider');
+        NSA::invokeMethod($this->geocoder, 'getProvider', GeocodeQuery::create('foo'), [], null);
         $this->fail('getProvider() should throw an exception');
     }
 
     public function testGetProviderWithMultipleProvidersReturnsTheFirstOne()
     {
-        $this->geocoder->registerProviders([
+        $providers = [
             $provider1 = new MockProvider('test1'),
             $provider2 = new MockProvider('test2'),
             $provider3 = new MockProvider('test3'),
-        ]);
+        ];
 
-        $this->assertSame($provider1, NSA::invokeMethod($this->geocoder, 'getProvider'));
+        $query = GeocodeQuery::create('foo');
+        $this->assertSame($provider1, NSA::invokeMethod($this->geocoder, 'getProvider', $query, $providers, null));
+        $this->assertSame($provider2, NSA::invokeMethod($this->geocoder, 'getProvider', $query, $providers, $provider2));
     }
 
     public function testDefaultMaxResults()
@@ -134,6 +150,8 @@ class MockProvider implements Provider
 {
     protected $name;
 
+    public $result = [];
+
     public function __construct($name)
     {
         $this->name = $name;
@@ -141,12 +159,12 @@ class MockProvider implements Provider
 
     public function geocodeQuery(GeocodeQuery $query): Collection
     {
-        return $this->returnResult([]);
+        return $this->returnResult();
     }
 
     public function reverseQuery(ReverseQuery $query): Collection
     {
-        return $this->returnResult([]);
+        return $this->returnResult();
     }
 
     public function getName(): string
@@ -163,7 +181,8 @@ class MockProvider implements Provider
         return $this;
     }
 
-    public function returnResult(array $data = [])
+    private function returnResult()
     {
+        return new AddressCollection($this->result);
     }
 }

--- a/src/Common/Tests/ProviderAggregatorTest.php
+++ b/src/Common/Tests/ProviderAggregatorTest.php
@@ -41,13 +41,12 @@ class ProviderAggregatorTest extends TestCase
     public function testGeocode()
     {
         $provider1 = new MockProvider('test1');
-        $provider1->result = [Address::createFromArray(['providedBy'=>'p1'])];
+        $provider1->result = [Address::createFromArray(['providedBy' => 'p1'])];
         $provider2 = new MockProvider('test2');
-        $provider2->result = [Address::createFromArray(['providedBy'=>'p2'])];
+        $provider2->result = [Address::createFromArray(['providedBy' => 'p2'])];
 
         $this->geocoder->registerProvider($provider1);
         $this->geocoder->registerProvider($provider2);
-
 
         $result = $this->geocoder->geocode('foo');
         $this->assertEquals('p1', $result->first()->getProvidedBy());
@@ -56,9 +55,9 @@ class ProviderAggregatorTest extends TestCase
     public function testReverse()
     {
         $provider1 = new MockProvider('test1');
-        $provider1->result = [Address::createFromArray(['providedBy'=>'p1'])];
+        $provider1->result = [Address::createFromArray(['providedBy' => 'p1'])];
         $provider2 = new MockProvider('test2');
-        $provider2->result = [Address::createFromArray(['providedBy'=>'p2'])];
+        $provider2->result = [Address::createFromArray(['providedBy' => 'p2'])];
 
         $this->geocoder->registerProvider($provider1);
         $this->geocoder->registerProvider($provider2);
@@ -73,7 +72,7 @@ class ProviderAggregatorTest extends TestCase
         $provider = new MockProvider('test');
         $this->geocoder->registerProvider($provider);
 
-        $this->assertSame(['test'=>$provider], NSA::getProperty($this->geocoder, 'providers'));
+        $this->assertSame(['test' => $provider], NSA::getProperty($this->geocoder, 'providers'));
     }
 
     public function testRegisterProviders()
@@ -81,7 +80,7 @@ class ProviderAggregatorTest extends TestCase
         $provider = new MockProvider('test');
         $this->geocoder->registerProviders([$provider]);
 
-        $this->assertSame(['test'=>$provider], NSA::getProperty($this->geocoder, 'providers'));
+        $this->assertSame(['test' => $provider], NSA::getProperty($this->geocoder, 'providers'));
     }
 
     /**


### PR DESCRIPTION
From https://github.com/geocoder-php/Geocoder/issues/727#issuecomment-312446873

> One potential case for extending (or providing an alternative implementation of such aggregator) is such where you would have a certain logic to automatically select a provider based on your query. For example -> use geoip2 for valid IP address geocode() calls, use google maps for anything else. Given the popularity of the library, I think more options to extend the library are better.

Ping @ddinchev