### PR TITLE
Adding Plugin support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
         "php-http/mock-client": "^1.0",
         "nyholm/psr7": "^0.2.2",
         "nyholm/nsa": "^1.1",
-        "cache/simple-cache-bridge": "^0.1.1",
-        "cache/array-adapter": "^0.5.0",
-        "cache/void-adapter": "^0.4.1"
+        "cache/simple-cache-bridge": "^1.0",
+        "cache/array-adapter": "^1.0",
+        "cache/void-adapter": "^1.0"
     },
     "suggest": {
         "ext-geoip": "Enabling the geoip extension allows you to use the MaxMindProvider.",
@@ -55,6 +55,7 @@
         "test": "vendor/bin/phpunit"
     },
     "minimum-stability": "dev",
+    "prefer-dist": true,
     "extra": {
         "branch-alias": {
             "dev-master": "4.0-dev"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
         "php-http/client-implementation": "^1.0",
         "php-http/message-factory": "^1.0.2",
         "php-http/httplug": "^1.0",
-        "php-http/discovery": "^1.0"
+        "php-http/discovery": "^1.0",
+        "psr/simple-cache": "^1.0",
+        "php-http/promise": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.1",
@@ -32,7 +34,8 @@
         "nyholm/psr7": "^0.2.2",
         "nyholm/nsa": "^1.1",
         "cache/simple-cache-bridge": "^0.1.1",
-        "cache/array-adapter": "^0.5.0"
+        "cache/array-adapter": "^0.5.0",
+        "cache/void-adapter": "^0.4.1"
     },
     "suggest": {
         "ext-geoip": "Enabling the geoip extension allows you to use the MaxMindProvider.",

--- a/src/Plugin/.gitattributes
+++ b/src/Plugin/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes   export-ignore
+.travis.yml      export-ignore
+phpunit.xml.dist export-ignore
+Tests/           export-ignore

--- a/src/Plugin/.travis.yml
+++ b/src/Plugin/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+sudo: false
+
+php: 7.0
+
+install:
+  - composer update --prefer-stable --prefer-dist
+
+script:
+    - composer test-ci
+
+after_success:
+    - wget https://scrutinizer-ci.com/ocular.phar
+    - php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml
+

--- a/src/Plugin/CHANGELOG.md
+++ b/src/Plugin/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
-## 4.0.0-beta2
-
-- Removed `AbstractHttpProvider::setMessageFactory`.
-- Removed `AbstractHttpProvider::getHttpClient`.
-- Make sure we have a `MessageFactory` in the constructor of `AbstractHttpProvider`. 
-
-## 4.0.0-beta1
+## 1.0.0
 
 First release of this library. 

--- a/src/Plugin/CHANGELOG.md
+++ b/src/Plugin/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
+
+## 4.0.0-beta2
+
+- Removed `AbstractHttpProvider::setMessageFactory`.
+- Removed `AbstractHttpProvider::getHttpClient`.
+- Make sure we have a `MessageFactory` in the constructor of `AbstractHttpProvider`. 
+
+## 4.0.0-beta1
+
+First release of this library. 

--- a/src/Plugin/Exception/LoopException.php
+++ b/src/Plugin/Exception/LoopException.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Exception;
+
+use Geocoder\Exception\Exception;
+use Geocoder\Query\Query;
+
+/**
+ * Thrown when the Plugin Client detects an endless loop.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+class LoopException extends \RuntimeException implements Exception
+{
+    /**
+     * @var Query
+     */
+    private $query;
+
+    public static function create($message, Query $query)
+    {
+        $ex = new self($message);
+        $ex->query = $query;
+
+        return $ex;
+    }
+
+    /**
+     * @return Query
+     */
+    public function getQuery(): Query
+    {
+        return $this->query;
+    }
+}

--- a/src/Plugin/Exception/LoopException.php
+++ b/src/Plugin/Exception/LoopException.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Exception;
 
 use Geocoder\Exception\Exception;

--- a/src/Plugin/LICENSE
+++ b/src/Plugin/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2011 — William Durand <william.durand1@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin;
+
+use Geocoder\Query\Query;
+use Http\Promise\Promise;
+
+/**
+ * A plugin is a middleware to transform the Query and/or the Collection.
+ *
+ * The plugin can:
+ *  - break the chain and return a Collection
+ *  - dispatch the Query to the next middleware
+ *  - restart the Query
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface Plugin
+{
+    /**
+     * Handle the Query and return the Collection coming from the next callable.
+     *
+     * @param Query    $query
+     * @param callable $next    Next middleware in the chain, the query is passed as the first argument
+     * @param callable $first   First middleware in the chain, used to to restart a request
+     *
+     * @return Promise Resolves a Collection or fails with an Geocoder\Exception\Exception
+     */
+    public function handleQuery(Query $query, callable $next, callable $first);
+}

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin;
 
 use Geocoder\Query\Query;
@@ -24,8 +32,8 @@ interface Plugin
      * Handle the Query and return the Collection coming from the next callable.
      *
      * @param Query    $query
-     * @param callable $next    Next middleware in the chain, the query is passed as the first argument
-     * @param callable $first   First middleware in the chain, used to to restart a request
+     * @param callable $next  Next middleware in the chain, the query is passed as the first argument
+     * @param callable $first First middleware in the chain, used to to restart a request
      *
      * @return Promise Resolves a Collection or fails with an Geocoder\Exception\Exception
      */

--- a/src/Plugin/Plugin/BoundsPlugin.php
+++ b/src/Plugin/Plugin/BoundsPlugin.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Plugin;
 
 use Geocoder\Model\Bounds;

--- a/src/Plugin/Plugin/BoundsPlugin.php
+++ b/src/Plugin/Plugin/BoundsPlugin.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Plugin;
+
+use Geocoder\Model\Bounds;
+use Geocoder\Plugin\Plugin;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\Query;
+
+/**
+ * Add bounds to each GeocoderQuery
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class BoundsPlugin implements Plugin
+{
+    /**
+     * @var Bounds
+     */
+    private $bounds;
+
+    /**
+     * @param Bounds $bounds
+     */
+    public function __construct(Bounds $bounds)
+    {
+        $this->bounds = $bounds;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleQuery(Query $query, callable $next, callable $first)
+    {
+        if (!$query instanceof GeocodeQuery) {
+            return $next($query);
+        }
+
+        if (empty($query->getBounds())) {
+            $query = $query->withBounds($this->bounds);
+        }
+
+        return $next($query);
+    }
+}

--- a/src/Plugin/Plugin/CachePlugin.php
+++ b/src/Plugin/Plugin/CachePlugin.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Plugin;
 
 use Geocoder\Plugin\Plugin;

--- a/src/Plugin/Plugin/CachePlugin.php
+++ b/src/Plugin/Plugin/CachePlugin.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Plugin;
+
+use Geocoder\Plugin\Plugin;
+use Geocoder\Query\Query;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Cache the result of a query.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class CachePlugin implements Plugin
+{
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
+     * How log a result is going to be cached.
+     *
+     * @var int|null
+     */
+    private $lifetime;
+
+    /**
+     * @param CacheInterface $cache
+     * @param int            $lifetime
+     */
+    public function __construct(CacheInterface $cache, int $lifetime = null)
+    {
+        $this->cache = $cache;
+        $this->lifetime = $lifetime;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleQuery(Query $query, callable $next, callable $first)
+    {
+        $cacheKey = $this->getCacheKey($query);
+        if (null !== $cachedResult = $this->cache->get($cacheKey)) {
+            return $cachedResult;
+        }
+
+        $result = $next($query);
+        $this->cache->set($cacheKey, $result, $this->lifetime);
+
+        return $result;
+    }
+
+    /**
+     * @param Query $query
+     *
+     * @return string
+     */
+    private function getCacheKey(Query $query): string
+    {
+        // Include the major version number of the geocoder to avoid issues unserializing.
+        return 'v4'.sha1((string) $query);
+    }
+}

--- a/src/Plugin/Plugin/LimitPlugin.php
+++ b/src/Plugin/Plugin/LimitPlugin.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Plugin;
+
+use Geocoder\Plugin\Plugin;
+use Geocoder\Query\Query;
+
+/**
+ * Add limit on the query
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class LimitPlugin implements Plugin
+{
+    /**
+     * @var int
+     */
+    private $limit;
+
+    /**
+     * @param int $limit
+     */
+    public function __construct(int $limit)
+    {
+        $this->limit = $limit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleQuery(Query $query, callable $next, callable $first)
+    {
+        if (empty($query->getLocale())) {
+            $query = $query->withLimit($this->limit);
+        }
+
+        return $next($query);
+    }
+}

--- a/src/Plugin/Plugin/LimitPlugin.php
+++ b/src/Plugin/Plugin/LimitPlugin.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Plugin;
 
 use Geocoder\Plugin\Plugin;

--- a/src/Plugin/Plugin/LocalePlugin.php
+++ b/src/Plugin/Plugin/LocalePlugin.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Plugin;
 
 use Geocoder\Plugin\Plugin;

--- a/src/Plugin/Plugin/LocalePlugin.php
+++ b/src/Plugin/Plugin/LocalePlugin.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Plugin;
+
+use Geocoder\Plugin\Plugin;
+use Geocoder\Query\Query;
+
+/**
+ * Add locale on the query
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class LocalePlugin implements Plugin
+{
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @param string $locale
+     */
+    public function __construct(string $locale)
+    {
+        $this->locale = $locale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleQuery(Query $query, callable $next, callable $first)
+    {
+        if (empty($query->getLocale())) {
+            $query = $query->withLocale($this->locale);
+        }
+
+        return $next($query);
+    }
+}

--- a/src/Plugin/Plugin/LoggerPlugin.php
+++ b/src/Plugin/Plugin/LoggerPlugin.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Plugin;
+
+use Geocoder\Collection;
+use Geocoder\Exception\Exception;
+use Geocoder\Plugin\Plugin;
+use Geocoder\Query\Query;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Log all queries and the result/failure
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class LoggerPlugin
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function handleQuery(Query $query, callable $next, callable $first)
+    {
+        $startTime = microtime(true);
+        $logger = $this->logger;
+
+        return $next($query)->then(function (Collection $result) use ($logger, $query, $startTime) {
+            $duration = (microtime(true) - $startTime) * 1000;
+            $this->logger->info(sprintf('[Geocoder] Got %d results in %0.2f ms for query %s', count($result), $duration, $query->__toString()));
+
+            return $result;
+        }, function (Exception $exception) use ($logger, $query, $startTime) {
+            $duration = (microtime(true) - $startTime) * 1000;
+            $this->logger->error(sprintf('[Geocoder] Failed with %s after %0.2f ms for query %s', get_class($exception), $duration, $query->__toString()));
+
+            throw $exception;
+        });
+    }
+}

--- a/src/Plugin/Plugin/LoggerPlugin.php
+++ b/src/Plugin/Plugin/LoggerPlugin.php
@@ -2,11 +2,18 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Plugin;
 
 use Geocoder\Collection;
 use Geocoder\Exception\Exception;
-use Geocoder\Plugin\Plugin;
 use Geocoder\Query\Query;
 use Psr\Log\LoggerInterface;
 

--- a/src/Plugin/Plugin/QueryDataPlugin.php
+++ b/src/Plugin/Plugin/QueryDataPlugin.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Plugin;
 
 use Geocoder\Plugin\Plugin;

--- a/src/Plugin/Plugin/QueryDataPlugin.php
+++ b/src/Plugin/Plugin/QueryDataPlugin.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Plugin;
+
+use Geocoder\Plugin\Plugin;
+use Geocoder\Query\Query;
+
+/**
+ * Add arbitrary data to a query
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class QueryDataPlugin implements Plugin
+{
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * @var bool
+     */
+    private $force;
+
+    /**
+     * @param array $data
+     * @param bool  $force If true we overwrite existing values
+     */
+    public function __construct(array $data, $force = false)
+    {
+        $this->data = $data;
+        $this->force = $force;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleQuery(Query $query, callable $next, callable $first)
+    {
+        $queryData = $query->getAllData();
+        foreach ($this->data as $key => $value) {
+            if ($this->force || !array_key_exists($key, $queryData)) {
+                $query = $query->withData($key, $value);
+            }
+        }
+
+        return $next($query);
+    }
+}

--- a/src/Plugin/PluginProvider.php
+++ b/src/Plugin/PluginProvider.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin;
 
 use Geocoder\Collection;
@@ -16,7 +24,6 @@ use Geocoder\Query\ReverseQuery;
 use Geocoder\Plugin\Exception\LoopException;
 
 /**
- *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
@@ -41,8 +48,8 @@ class PluginProvider implements Provider
 
     /**
      * @param Provider $provider
-     * @param Plugin[]                   $plugins
-     * @param array                      $options {
+     * @param Plugin[] $plugins
+     * @param array    $options  {
      *
      *     @var int      $max_restarts
      * }
@@ -55,7 +62,7 @@ class PluginProvider implements Provider
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function geocodeQuery(GeocodeQuery $query): Collection
     {
@@ -71,7 +78,7 @@ class PluginProvider implements Provider
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function reverseQuery(ReverseQuery $query): Collection
     {
@@ -87,7 +94,7 @@ class PluginProvider implements Provider
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getName(): string
     {

--- a/src/Plugin/PluginProvider.php
+++ b/src/Plugin/PluginProvider.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin;
+
+use Geocoder\Collection;
+use Geocoder\Exception\Exception;
+use Geocoder\Exception\LogicException;
+use Geocoder\Plugin\Promise\GeocoderFulfilledPromise;
+use Geocoder\Plugin\Promise\GeocoderRejectedPromise;
+use Geocoder\Provider\Provider;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\Query;
+use Geocoder\Query\ReverseQuery;
+use Geocoder\Plugin\Exception\LoopException;
+
+/**
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class PluginProvider implements Provider
+{
+    /**
+     * @var Provider
+     */
+    private $provider;
+
+    /**
+     * @var Plugin[]
+     */
+    private $plugins;
+
+    /**
+     * A list of options.
+     *
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @param Provider $provider
+     * @param Plugin[]                   $plugins
+     * @param array                      $options {
+     *
+     *     @var int      $max_restarts
+     * }
+     */
+    public function __construct(Provider $provider, array $plugins = [], array $options = [])
+    {
+        $this->provider = $provider;
+        $this->plugins = $plugins;
+        $this->options = $this->configure($options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function geocodeQuery(GeocodeQuery $query): Collection
+    {
+        $pluginChain = $this->createPluginChain($this->plugins, function (GeocodeQuery $query) {
+            try {
+                return new GeocoderFulfilledPromise($this->provider->geocodeQuery($query));
+            } catch (Exception $exception) {
+                return new GeocoderRejectedPromise($exception);
+            }
+        });
+
+        return $pluginChain($query)->wait();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function reverseQuery(ReverseQuery $query): Collection
+    {
+        $pluginChain = $this->createPluginChain($this->plugins, function (ReverseQuery $query) {
+            try {
+                return new GeocoderFulfilledPromise($this->provider->reverseQuery($query));
+            } catch (Exception $exception) {
+                return new GeocoderRejectedPromise($exception);
+            }
+        });
+
+        return $pluginChain($query)->wait();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getName(): string
+    {
+        return $this->provider->getName();
+    }
+
+    /**
+     * Configure the plugin provider.
+     *
+     * @param array $options
+     *
+     * @return array
+     */
+    private function configure(array $options = []): array
+    {
+        $defaults = [
+            'max_restarts' => 10,
+        ];
+
+        $config = array_merge($defaults, $options);
+
+        // Make sure no invalid values are provided
+        if (count($config) !== count($defaults)) {
+            throw new LogicException(sprintf('Valid options to the PluginProviders are: %s', implode(', ', array_values($defaults))));
+        }
+
+        return $config;
+    }
+
+    /**
+     * Create the plugin chain.
+     *
+     * @param Plugin[] $pluginList     A list of plugins
+     * @param callable $clientCallable Callable making the HTTP call
+     *
+     * @return callable
+     */
+    private function createPluginChain(array $pluginList, callable $clientCallable)
+    {
+        $firstCallable = $lastCallable = $clientCallable;
+
+        while ($plugin = array_pop($pluginList)) {
+            $lastCallable = function (Query $query) use ($plugin, $lastCallable, &$firstCallable) {
+                return $plugin->handleQuery($query, $lastCallable, $firstCallable);
+            };
+
+            $firstCallable = $lastCallable;
+        }
+
+        $firstCalls = 0;
+        $firstCallable = function (Query $query) use ($lastCallable, &$firstCalls) {
+            if ($firstCalls > $this->options['max_restarts']) {
+                throw LoopException::create('Too many restarts in plugin provider', $query);
+            }
+
+            ++$firstCalls;
+
+            return $lastCallable($query);
+        };
+
+        return $firstCallable;
+    }
+}

--- a/src/Plugin/Promise/GeocoderFulfilledPromise.php
+++ b/src/Plugin/Promise/GeocoderFulfilledPromise.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Promise;
 
 use Geocoder\Collection;
@@ -7,7 +15,6 @@ use Geocoder\Exception\Exception;
 use Http\Promise\Promise;
 
 /**
- *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */

--- a/src/Plugin/Promise/GeocoderFulfilledPromise.php
+++ b/src/Plugin/Promise/GeocoderFulfilledPromise.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Geocoder\Plugin\Promise;
+
+use Geocoder\Collection;
+use Geocoder\Exception\Exception;
+use Http\Promise\Promise;
+
+/**
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class GeocoderFulfilledPromise implements Promise
+{
+    /**
+     * @var Collection
+     */
+    private $collection;
+
+    /**
+     * @param Collection $collection
+     */
+    public function __construct(Collection $collection)
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    {
+        if (null === $onFulfilled) {
+            return $this;
+        }
+
+        try {
+            return new self($onFulfilled($this->collection));
+        } catch (Exception $e) {
+            return new GeocoderRejectedPromise($e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getState()
+    {
+        return Promise::FULFILLED;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function wait($unwrap = true)
+    {
+        if ($unwrap) {
+            return $this->collection;
+        }
+    }
+}

--- a/src/Plugin/Promise/GeocoderRejectedPromise.php
+++ b/src/Plugin/Promise/GeocoderRejectedPromise.php
@@ -1,12 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Promise;
 
 use Geocoder\Exception\Exception;
 use Http\Promise\Promise;
 
 /**
- *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */

--- a/src/Plugin/Promise/GeocoderRejectedPromise.php
+++ b/src/Plugin/Promise/GeocoderRejectedPromise.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Geocoder\Plugin\Promise;
+
+use Geocoder\Exception\Exception;
+use Http\Promise\Promise;
+
+/**
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class GeocoderRejectedPromise implements Promise
+{
+    /**
+     * @var Exception
+     */
+    private $exception;
+
+    /**
+     * @param Exception $exception
+     */
+    public function __construct(Exception $exception)
+    {
+        $this->exception = $exception;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    {
+        if (null === $onRejected) {
+            return $this;
+        }
+
+        try {
+            return new GeocoderFulfilledPromise($onRejected($this->exception));
+        } catch (Exception $e) {
+            return new self($e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getState()
+    {
+        return Promise::REJECTED;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function wait($unwrap = true)
+    {
+        if ($unwrap) {
+            throw $this->exception;
+        }
+    }
+}

--- a/src/Plugin/Readme.md
+++ b/src/Plugin/Readme.md
@@ -1,0 +1,21 @@
+# Geocoder plugin
+
+[![Build Status](https://travis-ci.org/geocoder-php/plugin.svg?branch=master)](http://travis-ci.org/geocoder-php/plugin)
+[![Latest Stable Version](https://poser.pugx.org/geocoder-php/plugin/v/stable)](https://packagist.org/packages/geocoder-php/plugin)
+[![Total Downloads](https://poser.pugx.org/geocoder-php/plugin/downloads)](https://packagist.org/packages/geocoder-php/plugin)
+[![Monthly Downloads](https://poser.pugx.org/geocoder-php/plugin/d/monthly.png)](https://packagist.org/packages/geocoder-php/plugin)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/geocoder-php/plugin.svg?style=flat-square)](https://scrutinizer-ci.com/g/geocoder-php/plugin)
+[![Quality Score](https://img.shields.io/scrutinizer/g/geocoder-php/plugin.svg?style=flat-square)](https://scrutinizer-ci.com/g/geocoder-php/plugin)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
+
+
+### Install
+
+```bash
+composer require geocoder-php/plugin
+```
+
+### Contribute
+
+Contributions are very welcome! Send a pull request to the [main repository](https://github.com/geocoder-php/Geocoder) or 
+report any issues you find on the [issue tracker](https://github.com/geocoder-php/Geocoder/issues).

--- a/src/Plugin/Tests/Plugin/BoundsPluginTest.php
+++ b/src/Plugin/Tests/Plugin/BoundsPluginTest.php
@@ -2,28 +2,33 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Tests\Plugin;
 
 use Geocoder\Model\Bounds;
 use Geocoder\Plugin\Plugin\BoundsPlugin;
-use Geocoder\Plugin\Plugin\LimitPlugin;
-use Geocoder\Plugin\Plugin\LocalePlugin;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\Query;
 use Geocoder\Query\ReverseQuery;
-use League\Flysystem\Adapter\Local;
 use PHPUnit\Framework\TestCase;
 
 class BoundsPluginTest extends TestCase
 {
     public function testGeocode()
     {
-        $bounds = new Bounds(4,7,1,1);
+        $bounds = new Bounds(4, 7, 1, 1);
         $query = GeocodeQuery::create('foo');
-        $first = function(Query $query) {
+        $first = function (Query $query) {
             $this->fail('Plugin should not restart the chain');
         };
-        $next = function(GeocodeQuery $query) use ($bounds) {
+        $next = function (GeocodeQuery $query) use ($bounds) {
             $this->assertEquals($bounds, $query->getBounds());
         };
 
@@ -33,12 +38,12 @@ class BoundsPluginTest extends TestCase
 
     public function testReverse()
     {
-        $bounds = new Bounds(4,7,1,1);
-        $query = ReverseQuery::fromCoordinates(71,11);
-        $first = function(Query $query) {
+        $bounds = new Bounds(4, 7, 1, 1);
+        $query = ReverseQuery::fromCoordinates(71, 11);
+        $first = function (Query $query) {
             $this->fail('Plugin should not restart the chain');
         };
-        $next = function(Query $query) use ($bounds) {
+        $next = function (Query $query) use ($bounds) {
             $this->assertTrue(true, 'We should not fail on ReverseQuery');
         };
 

--- a/src/Plugin/Tests/Plugin/BoundsPluginTest.php
+++ b/src/Plugin/Tests/Plugin/BoundsPluginTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Tests\Plugin;
+
+use Geocoder\Model\Bounds;
+use Geocoder\Plugin\Plugin\BoundsPlugin;
+use Geocoder\Plugin\Plugin\LimitPlugin;
+use Geocoder\Plugin\Plugin\LocalePlugin;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\Query;
+use Geocoder\Query\ReverseQuery;
+use League\Flysystem\Adapter\Local;
+use PHPUnit\Framework\TestCase;
+
+class BoundsPluginTest extends TestCase
+{
+    public function testGeocode()
+    {
+        $bounds = new Bounds(4,7,1,1);
+        $query = GeocodeQuery::create('foo');
+        $first = function(Query $query) {
+            $this->fail('Plugin should not restart the chain');
+        };
+        $next = function(GeocodeQuery $query) use ($bounds) {
+            $this->assertEquals($bounds, $query->getBounds());
+        };
+
+        $plugin = new BoundsPlugin($bounds);
+        $plugin->handleQuery($query, $next, $first);
+    }
+
+    public function testReverse()
+    {
+        $bounds = new Bounds(4,7,1,1);
+        $query = ReverseQuery::fromCoordinates(71,11);
+        $first = function(Query $query) {
+            $this->fail('Plugin should not restart the chain');
+        };
+        $next = function(Query $query) use ($bounds) {
+            $this->assertTrue(true, 'We should not fail on ReverseQuery');
+        };
+
+        $plugin = new BoundsPlugin($bounds);
+        $plugin->handleQuery($query, $next, $first);
+    }
+}

--- a/src/Plugin/Tests/Plugin/CachePluginTest.php
+++ b/src/Plugin/Tests/Plugin/CachePluginTest.php
@@ -24,7 +24,7 @@ class CachePluginTest extends TestCase
     {
         $ttl = 4711;
         $query = GeocodeQuery::create('foo');
-        $queryString = $query->__toString();
+        $queryString = sha1($query->__toString());
         $cache = $this->getMockBuilder(VoidCachePool::class)
             ->disableOriginalConstructor()
             ->setMethods(['get', 'set'])
@@ -53,7 +53,7 @@ class CachePluginTest extends TestCase
     public function testPluginHit()
     {
         $query = GeocodeQuery::create('foo');
-        $queryString = $query->__toString();
+        $queryString = sha1($query->__toString());
         $cache = $this->getMockBuilder(VoidCachePool::class)
             ->disableOriginalConstructor()
             ->setMethods(['get', 'set'])

--- a/src/Plugin/Tests/Plugin/CachePluginTest.php
+++ b/src/Plugin/Tests/Plugin/CachePluginTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Tests\Plugin;
+
+use Cache\Adapter\Void\VoidCachePool;
+use Geocoder\Plugin\Plugin\CachePlugin;
+use Geocoder\Plugin\Plugin\LimitPlugin;
+use Geocoder\Plugin\Plugin\LocalePlugin;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\Query;
+use League\Flysystem\Adapter\Local;
+use PHPUnit\Framework\TestCase;
+
+class CachePluginTest extends TestCase
+{
+    public function testPluginMiss()
+    {
+        $ttl = 4711;
+        $query = GeocodeQuery::create('foo');
+        $queryString = $query->__toString();
+        $cache = $this->getMockBuilder(VoidCachePool::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get', 'set'])
+            ->getMock();
+
+        $cache->expects($this->once())
+            ->method('get')
+            ->with('v4'.$queryString)
+            ->willReturn(null);
+        $cache->expects($this->once())
+            ->method('set')
+            ->with('v4'.$queryString, 'result', $ttl)
+            ->willReturn(true);
+
+        $first = function(Query $query) {
+            $this->fail('Plugin should not restart the chain');
+        };
+        $next = function(Query $query) {
+            return 'result';
+        };
+
+        $plugin = new CachePlugin($cache, $ttl);
+        $this->assertEquals('result', $plugin->handleQuery($query, $next, $first));
+    }
+    public function testPluginHit()
+    {
+        $query = GeocodeQuery::create('foo');
+        $queryString = $query->__toString();
+        $cache = $this->getMockBuilder(VoidCachePool::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get', 'set'])
+            ->getMock();
+
+        $cache->expects($this->once())
+            ->method('get')
+            ->with('v4'.$queryString)
+            ->willReturn('result');
+        $cache->expects($this->never())->method('set');
+
+        $first = function(Query $query) {
+            $this->fail('Plugin should not restart the chain');
+        };
+        $next = function(Query $query) {
+            $this->fail('Plugin not call $next on cache hit');
+        };
+
+        $plugin = new CachePlugin($cache);
+        $this->assertEquals('result', $plugin->handleQuery($query, $next, $first));
+    }
+}

--- a/src/Plugin/Tests/Plugin/CachePluginTest.php
+++ b/src/Plugin/Tests/Plugin/CachePluginTest.php
@@ -2,15 +2,20 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Tests\Plugin;
 
 use Cache\Adapter\Void\VoidCachePool;
 use Geocoder\Plugin\Plugin\CachePlugin;
-use Geocoder\Plugin\Plugin\LimitPlugin;
-use Geocoder\Plugin\Plugin\LocalePlugin;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\Query;
-use League\Flysystem\Adapter\Local;
 use PHPUnit\Framework\TestCase;
 
 class CachePluginTest extends TestCase
@@ -34,16 +39,17 @@ class CachePluginTest extends TestCase
             ->with('v4'.$queryString, 'result', $ttl)
             ->willReturn(true);
 
-        $first = function(Query $query) {
+        $first = function (Query $query) {
             $this->fail('Plugin should not restart the chain');
         };
-        $next = function(Query $query) {
+        $next = function (Query $query) {
             return 'result';
         };
 
         $plugin = new CachePlugin($cache, $ttl);
         $this->assertEquals('result', $plugin->handleQuery($query, $next, $first));
     }
+
     public function testPluginHit()
     {
         $query = GeocodeQuery::create('foo');
@@ -59,10 +65,10 @@ class CachePluginTest extends TestCase
             ->willReturn('result');
         $cache->expects($this->never())->method('set');
 
-        $first = function(Query $query) {
+        $first = function (Query $query) {
             $this->fail('Plugin should not restart the chain');
         };
-        $next = function(Query $query) {
+        $next = function (Query $query) {
             $this->fail('Plugin not call $next on cache hit');
         };
 

--- a/src/Plugin/Tests/Plugin/LimitPluginTest.php
+++ b/src/Plugin/Tests/Plugin/LimitPluginTest.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Tests\Plugin;
 
 use Geocoder\Plugin\Plugin\LimitPlugin;
@@ -14,10 +22,10 @@ class LimitPluginTest extends TestCase
     public function testPlugin()
     {
         $query = GeocodeQuery::create('foo');
-        $first = function(Query $query) {
+        $first = function (Query $query) {
             $this->fail('Plugin should not restart the chain');
         };
-        $next = function(Query $query) {
+        $next = function (Query $query) {
             $this->assertEquals(4711, $query->getLimit());
         };
 

--- a/src/Plugin/Tests/Plugin/LimitPluginTest.php
+++ b/src/Plugin/Tests/Plugin/LimitPluginTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Tests\Plugin;
+
+use Geocoder\Plugin\Plugin\LimitPlugin;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\Query;
+use PHPUnit\Framework\TestCase;
+
+class LimitPluginTest extends TestCase
+{
+    public function testPlugin()
+    {
+        $query = GeocodeQuery::create('foo');
+        $first = function(Query $query) {
+            $this->fail('Plugin should not restart the chain');
+        };
+        $next = function(Query $query) {
+            $this->assertEquals(4711, $query->getLimit());
+        };
+
+        $plugin = new LimitPlugin(4711);
+        $plugin->handleQuery($query, $next, $first);
+    }
+}

--- a/src/Plugin/Tests/Plugin/LocalePluginTest.php
+++ b/src/Plugin/Tests/Plugin/LocalePluginTest.php
@@ -2,13 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Tests\Plugin;
 
-use Geocoder\Plugin\Plugin\LimitPlugin;
 use Geocoder\Plugin\Plugin\LocalePlugin;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\Query;
-use League\Flysystem\Adapter\Local;
 use PHPUnit\Framework\TestCase;
 
 class LocalePluginTest extends TestCase
@@ -16,10 +22,10 @@ class LocalePluginTest extends TestCase
     public function testPlugin()
     {
         $query = GeocodeQuery::create('foo');
-        $first = function(Query $query) {
+        $first = function (Query $query) {
             $this->fail('Plugin should not restart the chain');
         };
-        $next = function(Query $query) {
+        $next = function (Query $query) {
             $this->assertEquals('sv', $query->getLocale());
         };
 

--- a/src/Plugin/Tests/Plugin/LocalePluginTest.php
+++ b/src/Plugin/Tests/Plugin/LocalePluginTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Tests\Plugin;
+
+use Geocoder\Plugin\Plugin\LimitPlugin;
+use Geocoder\Plugin\Plugin\LocalePlugin;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\Query;
+use League\Flysystem\Adapter\Local;
+use PHPUnit\Framework\TestCase;
+
+class LocalePluginTest extends TestCase
+{
+    public function testPlugin()
+    {
+        $query = GeocodeQuery::create('foo');
+        $first = function(Query $query) {
+            $this->fail('Plugin should not restart the chain');
+        };
+        $next = function(Query $query) {
+            $this->assertEquals('sv', $query->getLocale());
+        };
+
+        $plugin = new LocalePlugin('sv');
+        $plugin->handleQuery($query, $next, $first);
+    }
+}

--- a/src/Plugin/Tests/Plugin/LoggerPluginTest.php
+++ b/src/Plugin/Tests/Plugin/LoggerPluginTest.php
@@ -2,21 +2,24 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Tests\Plugin;
 
 use Geocoder\Exception\QuotaExceeded;
 use Geocoder\Model\AddressCollection;
-use Geocoder\Plugin\Plugin\LimitPlugin;
-use Geocoder\Plugin\Plugin\LocalePlugin;
 use Geocoder\Plugin\Plugin\LoggerPlugin;
 use Geocoder\Plugin\PluginProvider;
 use Geocoder\Provider\Provider;
 use Geocoder\Query\GeocodeQuery;
-use Geocoder\Query\Query;
-use League\Flysystem\Adapter\Local;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
-use Psr\Log\LoggerInterface;
 
 class LoggerPluginTest extends TestCase
 {
@@ -28,7 +31,7 @@ class LoggerPluginTest extends TestCase
             ->getMock();
         $logger->expects($this->once())
             ->method('log')
-            ->with('info', $this->callback(function($message) {
+            ->with('info', $this->callback(function ($message) {
                 return false !== strstr($message, 'Got 0 results');
             }));
 
@@ -59,7 +62,7 @@ class LoggerPluginTest extends TestCase
             ->getMock();
         $logger->expects($this->once())
             ->method('log')
-            ->with('error', $this->callback(function($message) {
+            ->with('error', $this->callback(function ($message) {
                 return false !== strstr($message, 'QuotaExceeded');
             }));
 

--- a/src/Plugin/Tests/Plugin/LoggerPluginTest.php
+++ b/src/Plugin/Tests/Plugin/LoggerPluginTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Tests\Plugin;
+
+use Geocoder\Exception\QuotaExceeded;
+use Geocoder\Model\AddressCollection;
+use Geocoder\Plugin\Plugin\LimitPlugin;
+use Geocoder\Plugin\Plugin\LocalePlugin;
+use Geocoder\Plugin\Plugin\LoggerPlugin;
+use Geocoder\Plugin\PluginProvider;
+use Geocoder\Provider\Provider;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\Query;
+use League\Flysystem\Adapter\Local;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+class LoggerPluginTest extends TestCase
+{
+    public function testPlugin()
+    {
+        $logger = $this->getMockBuilder(AbstractLogger::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['log'])
+            ->getMock();
+        $logger->expects($this->once())
+            ->method('log')
+            ->with('info', $this->callback(function($message) {
+                return false !== strstr($message, 'Got 0 results');
+            }));
+
+        $geocodeQuery = GeocodeQuery::create('foo');
+        $collection = new AddressCollection([]);
+
+        $provider = $this->getMockBuilder(Provider::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
+            ->getMock();
+        $provider->expects($this->once())
+            ->method('geocodeQuery')
+            ->with($geocodeQuery)
+            ->willReturn($collection);
+        $provider->expects($this->never())->method('reverseQuery');
+        $provider->expects($this->never())->method('getName');
+
+        $pluginProvider = new PluginProvider($provider, [new LoggerPlugin($logger)]);
+        $this->assertSame($collection, $pluginProvider->geocodeQuery($geocodeQuery));
+    }
+
+    public function testPluginException()
+    {
+        $this->expectException(QuotaExceeded::class);
+        $logger = $this->getMockBuilder(AbstractLogger::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['log'])
+            ->getMock();
+        $logger->expects($this->once())
+            ->method('log')
+            ->with('error', $this->callback(function($message) {
+                return false !== strstr($message, 'QuotaExceeded');
+            }));
+
+        $geocodeQuery = GeocodeQuery::create('foo');
+        $provider = $this->getMockBuilder(Provider::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
+            ->getMock();
+        $provider->expects($this->once())
+            ->method('geocodeQuery')
+            ->willThrowException(new QuotaExceeded());
+        $provider->expects($this->never())->method('reverseQuery');
+        $provider->expects($this->never())->method('getName');
+
+        $pluginProvider = new PluginProvider($provider, [new LoggerPlugin($logger)]);
+        $pluginProvider->geocodeQuery($geocodeQuery);
+    }
+}

--- a/src/Plugin/Tests/Plugin/QueryDataPluginTest.php
+++ b/src/Plugin/Tests/Plugin/QueryDataPluginTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Tests\Plugin;
+
+use Geocoder\Plugin\Plugin\LimitPlugin;
+use Geocoder\Plugin\Plugin\LocalePlugin;
+use Geocoder\Plugin\Plugin\QueryDataPlugin;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\Query;
+use League\Flysystem\Adapter\Local;
+use PHPUnit\Framework\TestCase;
+
+class QueryDataPluginTest extends TestCase
+{
+    public function testPlugin()
+    {
+        $query = GeocodeQuery::create('xxx');
+        $query = $query->withData('default', 'value');
+        $first = function(Query $query) {
+            $this->fail('Plugin should not restart the chain');
+        };
+        $next = function(Query $query) {
+            $this->assertEquals('bar', $query->getData('foo'));
+            $this->assertEquals('value', $query->getData('default'));
+        };
+
+        $plugin = new QueryDataPlugin(['foo'=>'bar', 'default'=>'new value']);
+        $plugin->handleQuery($query, $next, $first);
+    }
+
+    public function testPluginForce()
+    {
+        $query = GeocodeQuery::create('xxx');
+        $query = $query->withData('default', 'value');
+        $first = function(Query $query) {
+            $this->fail('Plugin should not restart the chain');
+        };
+        $next = function(Query $query) {
+            $this->assertEquals('bar', $query->getData('foo'));
+            $this->assertEquals('new value', $query->getData('default'));
+        };
+
+        $plugin = new QueryDataPlugin(['foo'=>'bar', 'default'=>'new value'], true);
+        $plugin->handleQuery($query, $next, $first);
+    }
+}

--- a/src/Plugin/Tests/Plugin/QueryDataPluginTest.php
+++ b/src/Plugin/Tests/Plugin/QueryDataPluginTest.php
@@ -2,14 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Tests\Plugin;
 
-use Geocoder\Plugin\Plugin\LimitPlugin;
-use Geocoder\Plugin\Plugin\LocalePlugin;
 use Geocoder\Plugin\Plugin\QueryDataPlugin;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\Query;
-use League\Flysystem\Adapter\Local;
 use PHPUnit\Framework\TestCase;
 
 class QueryDataPluginTest extends TestCase
@@ -18,15 +23,15 @@ class QueryDataPluginTest extends TestCase
     {
         $query = GeocodeQuery::create('xxx');
         $query = $query->withData('default', 'value');
-        $first = function(Query $query) {
+        $first = function (Query $query) {
             $this->fail('Plugin should not restart the chain');
         };
-        $next = function(Query $query) {
+        $next = function (Query $query) {
             $this->assertEquals('bar', $query->getData('foo'));
             $this->assertEquals('value', $query->getData('default'));
         };
 
-        $plugin = new QueryDataPlugin(['foo'=>'bar', 'default'=>'new value']);
+        $plugin = new QueryDataPlugin(['foo' => 'bar', 'default' => 'new value']);
         $plugin->handleQuery($query, $next, $first);
     }
 
@@ -34,15 +39,15 @@ class QueryDataPluginTest extends TestCase
     {
         $query = GeocodeQuery::create('xxx');
         $query = $query->withData('default', 'value');
-        $first = function(Query $query) {
+        $first = function (Query $query) {
             $this->fail('Plugin should not restart the chain');
         };
-        $next = function(Query $query) {
+        $next = function (Query $query) {
             $this->assertEquals('bar', $query->getData('foo'));
             $this->assertEquals('new value', $query->getData('default'));
         };
 
-        $plugin = new QueryDataPlugin(['foo'=>'bar', 'default'=>'new value'], true);
+        $plugin = new QueryDataPlugin(['foo' => 'bar', 'default' => 'new value'], true);
         $plugin->handleQuery($query, $next, $first);
     }
 }

--- a/src/Plugin/Tests/PluginProviderTest.php
+++ b/src/Plugin/Tests/PluginProviderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Geocoder\Plugin\Tests;
+
+use Geocoder\Model\AddressCollection;
+use Geocoder\Plugin\Exception\LoopException;
+use Geocoder\Plugin\Plugin;
+use Geocoder\Plugin\PluginProvider;
+use Geocoder\Provider\Provider;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\Query;
+use Geocoder\Query\ReverseQuery;
+use PHPUnit\Framework\TestCase;
+
+class PluginProviderTest extends TestCase
+{
+    public function testDispatchQueries()
+    {
+        $geocodeQuery = GeocodeQuery::create('foo');
+        $reverseQuery = ReverseQuery::fromCoordinates(47,11);
+        $collection = new AddressCollection([]);
+
+        $provider = $this->getMockBuilder(Provider::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
+            ->getMock();
+        $provider->expects($this->once())
+            ->method('geocodeQuery')
+            ->with($geocodeQuery)
+            ->willReturn($collection);
+        $provider->expects($this->once())
+            ->method('reverseQuery')
+            ->with($reverseQuery)
+            ->willReturn($collection);
+        $provider->expects($this->never())->method('getName');
+
+        $pluginProvider = new PluginProvider($provider);
+        $this->assertSame($collection, $pluginProvider->geocodeQuery($geocodeQuery));
+        $this->assertSame($collection, $pluginProvider->reverseQuery($reverseQuery));
+    }
+
+    public function testPluginsIsBeingUsedWhenGeocoding()
+    {
+        $geocodeQuery = GeocodeQuery::create('foo');
+        $collection = new AddressCollection([]);
+
+        $provider = $this->getMockBuilder(Provider::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
+            ->getMock();
+        $provider->expects($this->once())
+            ->method('geocodeQuery')
+            ->with($geocodeQuery)
+            ->willReturn($collection);
+        $provider->expects($this->never())->method('reverseQuery');
+        $provider->expects($this->never())->method('getName');
+
+        $pluginA = $this->getMockBuilder(Plugin::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['handleQuery'])
+            ->getMock();
+        $pluginA->expects($this->once())
+            ->method('handleQuery')
+            ->with($geocodeQuery, $this->isType('callable'), $this->isType('callable'))
+            ->willReturnCallback(function(Query $query, callable $next, callable $first) {
+                return $next($query);
+            });
+
+        $pluginProvider = new PluginProvider($provider, [$pluginA]);
+        $this->assertSame($collection, $pluginProvider->geocodeQuery($geocodeQuery));
+    }
+
+
+    public function testPluginsIsBeingUsedWhenReverse()
+    {
+        $reverseQuery = ReverseQuery::fromCoordinates(47,11);
+        $collection = new AddressCollection([]);
+
+        $provider = $this->getMockBuilder(Provider::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
+            ->getMock();
+        $provider->expects($this->never())->method('geocodeQuery');
+        $provider->expects($this->never())->method('getName');
+        $provider->expects($this->once())
+            ->method('reverseQuery')
+            ->with($reverseQuery)
+            ->willReturn($collection);
+
+        $pluginA = $this->getMockBuilder(Plugin::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['handleQuery'])
+            ->getMock();
+        $pluginA->expects($this->once())
+            ->method('handleQuery')
+            ->with($reverseQuery, $this->isType('callable'), $this->isType('callable'))
+            ->willReturnCallback(function(Query $query, callable $next, callable $first) {
+                return $next($query);
+            });
+
+        $pluginProvider = new PluginProvider($provider, [$pluginA]);
+        $this->assertSame($collection, $pluginProvider->reverseQuery($reverseQuery));
+    }
+
+    public function testLoopException()
+    {
+        $this->expectException(LoopException::class);
+        $geocodeQuery = GeocodeQuery::create('foo');
+        $collection = new AddressCollection([]);
+
+        $provider = $this->getMockBuilder(Provider::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
+            ->getMock();
+        $provider->expects($this->once())
+            ->method('geocodeQuery')
+            ->with($geocodeQuery)
+            ->willReturn($collection);
+        $provider->expects($this->never())->method('reverseQuery');
+        $provider->expects($this->never())->method('getName');
+
+        $pluginA = $this->getMockBuilder(Plugin::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['handleQuery'])
+            ->getMock();
+        $pluginA->expects($this->any())
+            ->method('handleQuery')
+            ->with($geocodeQuery, $this->isType('callable'), $this->isType('callable'))
+            ->willReturnCallback(function(Query $query, callable $next, callable $first) {
+                return $first($query);
+            });
+
+        $pluginProvider = new PluginProvider($provider, [$pluginA]);
+        $pluginProvider->geocodeQuery($geocodeQuery);
+    }
+}

--- a/src/Plugin/Tests/PluginProviderTest.php
+++ b/src/Plugin/Tests/PluginProviderTest.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
 namespace Geocoder\Plugin\Tests;
 
 use Geocoder\Model\AddressCollection;
@@ -19,7 +27,7 @@ class PluginProviderTest extends TestCase
     public function testDispatchQueries()
     {
         $geocodeQuery = GeocodeQuery::create('foo');
-        $reverseQuery = ReverseQuery::fromCoordinates(47,11);
+        $reverseQuery = ReverseQuery::fromCoordinates(47, 11);
         $collection = new AddressCollection([]);
 
         $provider = $this->getMockBuilder(Provider::class)
@@ -64,7 +72,7 @@ class PluginProviderTest extends TestCase
         $pluginA->expects($this->once())
             ->method('handleQuery')
             ->with($geocodeQuery, $this->isType('callable'), $this->isType('callable'))
-            ->willReturnCallback(function(Query $query, callable $next, callable $first) {
+            ->willReturnCallback(function (Query $query, callable $next, callable $first) {
                 return $next($query);
             });
 
@@ -72,10 +80,9 @@ class PluginProviderTest extends TestCase
         $this->assertSame($collection, $pluginProvider->geocodeQuery($geocodeQuery));
     }
 
-
     public function testPluginsIsBeingUsedWhenReverse()
     {
-        $reverseQuery = ReverseQuery::fromCoordinates(47,11);
+        $reverseQuery = ReverseQuery::fromCoordinates(47, 11);
         $collection = new AddressCollection([]);
 
         $provider = $this->getMockBuilder(Provider::class)
@@ -96,7 +103,7 @@ class PluginProviderTest extends TestCase
         $pluginA->expects($this->once())
             ->method('handleQuery')
             ->with($reverseQuery, $this->isType('callable'), $this->isType('callable'))
-            ->willReturnCallback(function(Query $query, callable $next, callable $first) {
+            ->willReturnCallback(function (Query $query, callable $next, callable $first) {
                 return $next($query);
             });
 
@@ -128,7 +135,7 @@ class PluginProviderTest extends TestCase
         $pluginA->expects($this->any())
             ->method('handleQuery')
             ->with($geocodeQuery, $this->isType('callable'), $this->isType('callable'))
-            ->willReturnCallback(function(Query $query, callable $next, callable $first) {
+            ->willReturnCallback(function (Query $query, callable $next, callable $first) {
                 return $first($query);
             });
 

--- a/src/Plugin/composer.json
+++ b/src/Plugin/composer.json
@@ -1,0 +1,43 @@
+{
+    "name": "geocoder-php/plugin",
+    "type": "library",
+    "description": "Plugins to Geocoder providers",
+    "keywords": ["http geocoder"],
+    "homepage": "http://geocoder-php.org",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Tobias Nyholm",
+            "email": "tobias.nyholm@gmail.com"
+        }
+    ],
+    "require": {
+        "php": "^7.0",
+        "willdurand/geocoder": "^4.0",
+        "psr/log": "^1.0",
+        "psr/simple-cache": "^1.0",
+        "php-http/promise": "^1.0"
+
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1",
+        "cache/void-adapter": "^0.4.1"
+    },
+    "autoload": {
+        "psr-4": { "Geocoder\\Plugin\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
+    },
+    "minimum-stability": "dev",
+    "prefer": "dist",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "4.0-dev"
+        }
+    }
+}

--- a/src/Plugin/composer.json
+++ b/src/Plugin/composer.json
@@ -17,7 +17,6 @@
         "psr/log": "^1.0",
         "psr/simple-cache": "^1.0",
         "php-http/promise": "^1.0"
-
     },
     "require-dev": {
         "phpunit/phpunit": "^6.1",

--- a/src/Plugin/composer.json
+++ b/src/Plugin/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.1",
-        "cache/void-adapter": "^0.4.1"
+        "cache/void-adapter": "^1.0"
     },
     "autoload": {
         "psr-4": { "Geocoder\\Plugin\\": "" },

--- a/src/Plugin/phpunit.xml.dist
+++ b/src/Plugin/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Geocoder Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
When creating the BazingaBundle we could either decorate all providers with a CacheProvider, LoggerProvider, ProfilingProvider etc... or we could use a PluginProfiler. This basically rips all nice plugin classes created by php-http and modify them to our needs. 

I put these plugin files in a new package, `geocoder-php/plugin`, because they have a few external dependencies. 

I've added 6 plugins to modify or log the queries. 

FYI @joelwurtz, @sagikazarmark

(Blocked by #741)


### Usage

```php
$provider = new GoogleMapsProvider();
$pluginProvider = new PluginProvider($provider, [
  new LocalePlugin('sv'),
  new CachePlugin($cacheService),
  new LoggerPlugin($logger),
]);

$query = GeocodeQuery::create('foobar');
$result = $pluginProvider->geocodeQuery($query);

// $result is in Swedish
// $result is cached
// $result is logged

// Try again
$result = $pluginProvider->geocodeQuery($query);

// $result is fetched from cache and not log were written. 

```