### PR TITLE
Added locale aware support for FreeGeoIp provider

### DIFF
--- a/src/Http/Provider/AbstractHttpProvider.php
+++ b/src/Http/Provider/AbstractHttpProvider.php
@@ -19,6 +19,7 @@ use Geocoder\Provider\AbstractProvider;
 use Http\Message\MessageFactory;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Client\HttpClient;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -57,7 +58,7 @@ abstract class AbstractHttpProvider extends AbstractProvider
      */
     protected function getUrlContents(string $url): string
     {
-        $request = $this->getMessageFactory()->createRequest('GET', $url);
+        $request = $this->getRequest($url);
         $response = $this->getHttpClient()->sendRequest($request);
 
         $statusCode = $response->getStatusCode();
@@ -93,5 +94,15 @@ abstract class AbstractHttpProvider extends AbstractProvider
     protected function getMessageFactory(): MessageFactory
     {
         return $this->messageFactory;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return RequestInterface
+     */
+    protected function getRequest(string $url): RequestInterface
+    {
+        return $this->getMessageFactory()->createRequest('GET', $url);
     }
 }

--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -14,12 +14,12 @@ namespace Geocoder\Provider\FreeGeoIp;
 
 use Geocoder\Collection;
 use Geocoder\Exception\UnsupportedOperation;
-use Geocoder\Http\Provider\AbstractHttpProvider;
 use Geocoder\Model\AddressBuilder;
 use Geocoder\Model\AddressCollection;
-use Geocoder\Provider\Provider;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
+use Geocoder\Http\Provider\AbstractHttpProvider;
+use Geocoder\Provider\Provider;
 use Http\Client\HttpClient;
 use Psr\Http\Message\RequestInterface;
 
@@ -43,11 +43,7 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
      * @param string     $locale
      * @param string     $baseUrl
      */
-    public function __construct(
-        HttpClient $client,
-        string $locale = '',
-        string $baseUrl = 'https://freegeoip.net/json/%s'
-    )
+    public function __construct(HttpClient $client, string $locale = '', string $baseUrl = 'https://freegeoip.net/json/%s')
     {
         parent::__construct($client);
 

--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -114,7 +114,7 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
     /**
      * @return string|null
      */
-    public function getLocale(): ?string
+    public function getLocale()
     {
         return $this->locale;
     }

--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -14,12 +14,12 @@ namespace Geocoder\Provider\FreeGeoIp;
 
 use Geocoder\Collection;
 use Geocoder\Exception\UnsupportedOperation;
+use Geocoder\Http\Provider\AbstractHttpProvider;
 use Geocoder\Model\AddressBuilder;
 use Geocoder\Model\AddressCollection;
+use Geocoder\Provider\Provider;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
-use Geocoder\Http\Provider\AbstractHttpProvider;
-use Geocoder\Provider\Provider;
 use Http\Client\HttpClient;
 use Psr\Http\Message\RequestInterface;
 
@@ -43,7 +43,11 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
      * @param string     $locale
      * @param string     $baseUrl
      */
-    public function __construct(HttpClient $client, string $locale = 'en', string $baseUrl = 'https://freegeoip.net/json/%s')
+    public function __construct(
+        HttpClient $client,
+        string $locale = '',
+        string $baseUrl = 'https://freegeoip.net/json/%s'
+    )
     {
         parent::__construct($client);
 
@@ -110,7 +114,7 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
     {
         $request = parent::getRequest($url);
 
-        if ($this->locale !== null) {
+        if (!empty($this->locale)) {
             $request = $request->withHeader('Accept-Language', $this->locale);
         }
 

--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -121,6 +121,7 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
 
     /**
      * {@inheritdoc}
+     *
      * @throws \InvalidArgumentException
      */
     protected function getRequest(string $url): RequestInterface

--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -22,6 +22,7 @@ use Geocoder\Http\Provider\AbstractHttpProvider;
 use Geocoder\Provider\Provider;
 use Http\Client\HttpClient;
 use Psr\Http\Message\RequestInterface;
+use Http\Client\HttpClient;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -51,6 +52,18 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
 
     /**
      * {@inheritdoc}
+     * @param string|null $locale
+     */
+    public function __construct(HttpClient $client, $locale = null)
+    {
+        parent::__construct($client);
+
+        $this->locale = $locale;
+    }
+
+
+    /**
+     * {@inheritdoc}
      */
     public function geocodeQuery(GeocodeQuery $query): Collection
     {
@@ -64,7 +77,7 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
         }
 
         if ($locale = $query->getLocale()) {
-            $this->setLocale($locale);
+            $this->locale = $locale;
         }
 
         $content = $this->getUrlContents(sprintf($this->baseUrl, $address));
@@ -103,13 +116,6 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
         return 'free_geo_ip';
     }
 
-    /**
-     * @param string $locale
-     */
-    public function setLocale(string $locale)
-    {
-        $this->locale = $locale;
-    }
 
     /**
      * @return string|null

--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -22,7 +22,6 @@ use Geocoder\Http\Provider\AbstractHttpProvider;
 use Geocoder\Provider\Provider;
 use Http\Client\HttpClient;
 use Psr\Http\Message\RequestInterface;
-use Http\Client\HttpClient;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -35,32 +34,23 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
     private $baseUrl;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $locale;
 
     /**
      * @param HttpClient $client
+     * @param string     $locale
      * @param string     $baseUrl
      */
-    public function __construct(HttpClient $client, string $baseUrl = 'https://freegeoip.net/json/%s')
-    {
-        parent::__construct($client);
-
-        $this->baseUrl = $baseUrl;
-    }
-
-    /**
-     * {@inheritdoc}
-     * @param string|null $locale
-     */
-    public function __construct(HttpClient $client, $locale = null)
+    public function __construct(HttpClient $client, string $locale = 'en', string $baseUrl = 'https://freegeoip.net/json/%s')
     {
         parent::__construct($client);
 
         $this->locale = $locale;
-    }
 
+        $this->baseUrl = $baseUrl;
+    }
 
     /**
      * {@inheritdoc}
@@ -115,7 +105,6 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
     {
         return 'free_geo_ip';
     }
-
 
     /**
      * @return string|null

--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -48,7 +48,6 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
         parent::__construct($client);
 
         $this->locale = $locale;
-
         $this->baseUrl = $baseUrl;
     }
 
@@ -64,10 +63,6 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
 
         if (in_array($address, ['127.0.0.1', '::1'])) {
             return new AddressCollection([$this->getLocationForLocalhost()]);
-        }
-
-        if ($locale = $query->getLocale()) {
-            $this->locale = $locale;
         }
 
         $content = $this->getUrlContents(sprintf($this->baseUrl, $address));
@@ -104,14 +99,6 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
     public function getName(): string
     {
         return 'free_geo_ip';
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getLocale()
-    {
-        return $this->locale;
     }
 
     /**

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_56adadaf03f9037e7cae3a464b6dc9617f814883
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_56adadaf03f9037e7cae3a464b6dc9617f814883
@@ -1,0 +1,2 @@
+s:270:"{"ip":"81.27.51.253","country_code":"RU","country_name":"Россия","region_code":"VLA","region_name":"Владимирская область","city":"Владимир","zip_code":"","time_zone":"Europe/Moscow","latitude":56.1365,"longitude":40.3966,"metro_code":0}
+";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_66299fd8d42b096fa031b8d1832fc8eb50277552
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_66299fd8d42b096fa031b8d1832fc8eb50277552
@@ -1,0 +1,2 @@
+s:235:"{"ip":"81.27.51.252","country_code":"RU","country_name":"Russie","region_code":"VLA","region_name":"Oblast de Vladimir","city":"Vladimir","zip_code":"","time_zone":"Europe/Moscow","latitude":56.1365,"longitude":40.3966,"metro_code":0}
+";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_8aaa58eef1ef2a53923da060d6a9de0db75bf96d
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_8aaa58eef1ef2a53923da060d6a9de0db75bf96d
@@ -1,0 +1,2 @@
+s:238:"{"ip":"81.27.51.251","country_code":"RU","country_name":"Russia","region_code":"VLA","region_name":"Vladimirskaya Oblast'","city":"Vladimir","zip_code":"","time_zone":"Europe/Moscow","latitude":56.1365,"longitude":40.3966,"metro_code":0}
+";

--- a/src/Provider/FreeGeoIp/Tests/FreeGeoIpTest.php
+++ b/src/Provider/FreeGeoIp/Tests/FreeGeoIpTest.php
@@ -160,6 +160,42 @@ class FreeGeoIpTest extends BaseTestCase
         $this->assertEquals('GB', $results->first()->getCountry()->getCode());
     }
 
+    public function testGeocodeWithRuLocale()
+    {
+        $provider = new FreeGeoIp($this->getHttpClient());
+        $results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.253')->withLocale('ru'));
+
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
+        $this->assertCount(1, $results);
+        $this->assertEquals('Владимирская область', $results->first()->getAdminLevels()->first()->getName());
+        $this->assertEquals('Владимир', $results->first()->getLocality());
+        $this->assertEquals('Россия', $results->first()->getCountry()->getName());
+    }
+
+    public function testGeocodeWithFrLocale()
+    {
+        $provider = new FreeGeoIp($this->getHttpClient());
+        $results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.252')->withLocale('fr'));
+
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
+        $this->assertCount(1, $results);
+        $this->assertEquals('Oblast de Vladimir', $results->first()->getAdminLevels()->first()->getName());
+        $this->assertEquals('Vladimir', $results->first()->getLocality());
+        $this->assertEquals('Russie', $results->first()->getCountry()->getName());
+    }
+
+    public function testGeocodeWithIncorrectLocale()
+    {
+        $provider = new FreeGeoIp($this->getHttpClient());
+        $results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.251')->withLocale('wrong_locale'));
+
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
+        $this->assertCount(1, $results);
+        $this->assertEquals('Vladimirskaya Oblast\'', $results->first()->getAdminLevels()->first()->getName());
+        $this->assertEquals('Vladimir', $results->first()->getLocality());
+        $this->assertEquals('Russia', $results->first()->getCountry()->getName());
+    }
+
     /**
      * @expectedException \Geocoder\Exception\UnsupportedOperation
      * @expectedExceptionMessage The FreeGeoIp provider is not able to do reverse geocoding.

--- a/src/Provider/FreeGeoIp/Tests/FreeGeoIpTest.php
+++ b/src/Provider/FreeGeoIp/Tests/FreeGeoIpTest.php
@@ -174,8 +174,8 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithFrLocale()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
-        $results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.252')->withLocale('fr'));
+        $provider = new FreeGeoIp($this->getHttpClient(), 'fr');
+        $results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.252'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
         $this->assertCount(1, $results);
@@ -186,7 +186,7 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithIncorrectLocale()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $provider = new FreeGeoIp($this->getHttpClient(), 'ru');
         $results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.251')->withLocale('wrong_locale'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);


### PR DESCRIPTION
Make support of locale aware for FreeGeoIp provider

The beginning of discussion is [here](https://github.com/geocoder-php/Geocoder/pull/479).

```php
$provider = new FreeGeoIp($adapter);

$provider->setLocale('fr');
$results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.251'));
/* or */
$results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.251')->withLocale('fr'));
```