### PR TITLE
In Nominatim provider, use city, then town, then village, then hamlet

### DIFF
--- a/src/Provider/GoogleMaps/Model/GoogleAddress.php
+++ b/src/Provider/GoogleMaps/Model/GoogleAddress.php
@@ -116,7 +116,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withId(string $id = null): GoogleAddress
+    public function withId(string $id = null): self
     {
         $new = clone $this;
         $new->id = $id;
@@ -139,7 +139,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withLocationType(string $locationType = null): GoogleAddress
+    public function withLocationType(string $locationType = null): self
     {
         $new = clone $this;
         $new->locationType = $locationType;
@@ -168,7 +168,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withResultType(array $resultType): GoogleAddress
+    public function withResultType(array $resultType): self
     {
         $new = clone $this;
         $new->resultType = $resultType;
@@ -189,7 +189,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withFormattedAddress(string $formattedAddress = null): GoogleAddress
+    public function withFormattedAddress(string $formattedAddress = null): self
     {
         $new = clone $this;
         $new->formattedAddress = $formattedAddress;
@@ -210,7 +210,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withAirport(string $airport = null): GoogleAddress
+    public function withAirport(string $airport = null): self
     {
         $new = clone $this;
         $new->airport = $airport;
@@ -231,7 +231,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withColloquialArea(string $colloquialArea = null): GoogleAddress
+    public function withColloquialArea(string $colloquialArea = null): self
     {
         $new = clone $this;
         $new->colloquialArea = $colloquialArea;
@@ -252,7 +252,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withIntersection(string $intersection = null): GoogleAddress
+    public function withIntersection(string $intersection = null): self
     {
         $new = clone $this;
         $new->intersection = $intersection;
@@ -273,7 +273,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withNaturalFeature(string $naturalFeature = null): GoogleAddress
+    public function withNaturalFeature(string $naturalFeature = null): self
     {
         $new = clone $this;
         $new->naturalFeature = $naturalFeature;
@@ -294,7 +294,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withNeighborhood(string $neighborhood = null): GoogleAddress
+    public function withNeighborhood(string $neighborhood = null): self
     {
         $new = clone $this;
         $new->neighborhood = $neighborhood;
@@ -315,7 +315,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withPark(string $park = null): GoogleAddress
+    public function withPark(string $park = null): self
     {
         $new = clone $this;
         $new->park = $park;
@@ -357,7 +357,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withPolitical(string $political = null): GoogleAddress
+    public function withPolitical(string $political = null): self
     {
         $new = clone $this;
         $new->political = $political;
@@ -378,7 +378,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withPremise(string $premise = null): GoogleAddress
+    public function withPremise(string $premise = null): self
     {
         $new = clone $this;
         $new->premise = $premise;
@@ -399,7 +399,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withStreetAddress(string $streetAddress = null): GoogleAddress
+    public function withStreetAddress(string $streetAddress = null): self
     {
         $new = clone $this;
         $new->streetAddress = $streetAddress;
@@ -420,7 +420,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withSubpremise(string $subpremise = null): GoogleAddress
+    public function withSubpremise(string $subpremise = null): self
     {
         $new = clone $this;
         $new->subpremise = $subpremise;
@@ -441,7 +441,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withWard(string $ward = null): GoogleAddress
+    public function withWard(string $ward = null): self
     {
         $new = clone $this;
         $new->ward = $ward;
@@ -462,7 +462,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withEstablishment(string $establishment = null): GoogleAddress
+    public function withEstablishment(string $establishment = null): self
     {
         $new = clone $this;
         $new->establishment = $establishment;
@@ -483,7 +483,7 @@ final class GoogleAddress extends Address
      *
      * @return $this
      */
-    public function withSubLocalityLevels(array $subLocalityLevel): GoogleAddress
+    public function withSubLocalityLevels(array $subLocalityLevel): self
     {
         $subLocalityLevels = [];
         foreach ($subLocalityLevel as $level) {

--- a/src/Provider/Nominatim/Nominatim.php
+++ b/src/Provider/Nominatim/Nominatim.php
@@ -138,10 +138,20 @@ final class Nominatim extends AbstractHttpProvider implements Provider
         if (!empty($postalCode)) {
             $postalCode = current(explode(';', $postalCode));
         }
+
+        $localityFields = ['city', 'town', 'village', 'hamlet'];
+        foreach ($localityFields as $localityField) {
+            $localityFieldContent = $this->getNodeValue($addressNode->getElementsByTagName($localityField));
+            if (!empty($localityFieldContent)) {
+                $builder->setLocality($localityFieldContent);
+
+                break;
+            }
+        }
+
         $builder->setPostalCode($postalCode);
         $builder->setStreetName($this->getNodeValue($addressNode->getElementsByTagName('road')) ?: $this->getNodeValue($addressNode->getElementsByTagName('pedestrian')));
         $builder->setStreetNumber($this->getNodeValue($addressNode->getElementsByTagName('house_number')));
-        $builder->setLocality($this->getNodeValue($addressNode->getElementsByTagName('city')));
         $builder->setSubLocality($this->getNodeValue($addressNode->getElementsByTagName('suburb')));
         $builder->setCountry($this->getNodeValue($addressNode->getElementsByTagName('country')));
 


### PR DESCRIPTION
When using Nominatim provider, the API can return several kinds of responses for "city" for the same kind of query.
For example:

**75004, France**
https://nominatim.openstreetmap.org/search?q=75004,France&format=xml&addressdetails=1&limit=5

    <suburb>Quartier Saint-Merri</suburb>
    <city_district>4th Arrondissement</city_district>
    <city>Paris</city>
    <county>Paris</county>
    <state>Ile-de-France</state>
    <country>France</country>
    <postcode>75004</postcode>

=> we receive the city in a "city" field

**98000, Monaco**
https://nominatim.openstreetmap.org/search?q=98000%2C+Monaco&format=xml&addressdetails=1&limit=5

    <suburb>La Condamine</suburb>
    <town>Monaco</town>
    <postcode>98000</postcode>
    <country>Monaco</country>

=> we receive the city field in a "town" field

Here is the wiki for Nominatim structure: http://wiki.openstreetmap.org/wiki/Nominatim

**My proposition is that if the "city" field is absent from the response, we use the "town" field instead to define the city of the response.**