### PR TITLE
[Fix] NominatimProvider: do not throw error when countryCode is missing

### DIFF
--- a/src/Provider/Nominatim/Nominatim.php
+++ b/src/Provider/Nominatim/Nominatim.php
@@ -144,7 +144,12 @@ final class Nominatim extends AbstractHttpProvider implements Provider
         $builder->setLocality($this->getNodeValue($addressNode->getElementsByTagName('city')));
         $builder->setSubLocality($this->getNodeValue($addressNode->getElementsByTagName('suburb')));
         $builder->setCountry($this->getNodeValue($addressNode->getElementsByTagName('country')));
-        $builder->setCountryCode(strtoupper($this->getNodeValue($addressNode->getElementsByTagName('country_code'))));
+
+        $countryCode = $this->getNodeValue($addressNode->getElementsByTagName('country_code'));
+        if (!empty($countryCode)) {
+            $countryCode = strtoupper($countryCode);
+        }
+        $builder->setCountryCode($countryCode);
         $builder->setCoordinates($resultNode->getAttribute('lat'), $resultNode->getAttribute('lon'));
 
         $boundsAttr = $resultNode->getAttribute('boundingbox');


### PR DESCRIPTION
On this URL for example: https://nominatim.openstreetmap.org/search?q=Italia&format=xml&addressdetails=1&limit=5

We receive locations without countryCode:

    <place place_id="85100707" osm_type="way" osm_id="62194429" place_rank="17" boundingbox="-62.1766268,-62.1725491,-58.51788,-58.5084623" lat="-62.1750648" lon="-58.5135405" display_name="Italia, Antarctica" class="waterway" type="stream" importance="0.435">
        <stream>Italia</stream>
        <continent>Antarctica</continent>
    </place>

In that case, the following error happens: **Type error: strtoupper() expects parameter 1 to be string, null given**.

This PR fixes this by not uppercasing the countrycode if it does not exist.