### PR TITLE
Fixing order of coordinates passed to AddressBuilder::setBound 

### DIFF
--- a/src/Provider/Nominatim/Nominatim.php
+++ b/src/Provider/Nominatim/Nominatim.php
@@ -156,7 +156,7 @@ final class Nominatim extends AbstractHttpProvider implements Provider
         if ($boundsAttr) {
             $bounds = [];
             list($bounds['south'], $bounds['north'], $bounds['west'], $bounds['east']) = explode(',', $boundsAttr);
-            $builder->setBounds($bounds['south'], $bounds['north'], $bounds['west'], $bounds['east']);
+            $builder->setBounds($bounds['south'], $bounds['west'], $bounds['north'], $bounds['east']);
         }
 
         return $builder->build();


### PR DESCRIPTION
Hi,

Tiny fix here, coordinates weren't passed in the right order to AddressBuilder::setBound in the Nominatim provider, north and west was inverted, made Bounds attributes inconsistent.