### PR TITLE
Add GoogleMaps Missing Fields

### DIFF
--- a/src/Geocoder/Provider/GoogleMaps.php
+++ b/src/Geocoder/Provider/GoogleMaps.php
@@ -250,6 +250,8 @@ class GoogleMaps extends AbstractHttpProvider implements LocaleAwareProvider
                 $resultSet['countryCode'] = $values->short_name;
                 break;
 
+            case 'establishment':
+            case 'point_of_interest':
             case 'street_number':
                 $resultSet['streetNumber'] = $values->long_name;
                 break;


### PR DESCRIPTION
This adds `establishment` and `point_of_interest` which are useful as the `streetNumber` when the address is not a numbered address (such as Disney World).