### PR TITLE
HostIp: Return empty collection if address was not found

### DIFF
--- a/src/Provider/HostIp/HostIp.php
+++ b/src/Provider/HostIp/HostIp.php
@@ -85,6 +85,24 @@ final class HostIp extends AbstractHttpProvider implements Provider
             return new AddressCollection([]);
         }
 
+		// Return empty collection if address was not found
+        if ($data['lat'] === null
+        &&  $data['lng'] === null
+        &&  $data['city'] === '(Unknown City?)'
+        &&  $data['country_name'] === '(Unknown Country?)'
+        &&  $data['country_code'] === 'XX') {
+            return new AddressCollection([]);
+        }
+
+		// Return empty collection if address was not found
+        if ($data['lat'] === null
+        &&  $data['lng'] === null
+        &&  $data['city'] === '(Private Address)'
+        &&  $data['country_name'] === '(Private Address)'
+        &&  $data['country_code'] === 'XX') {
+            return new AddressCollection([]);
+        }
+
         return new AddressCollection([
             Address::createFromArray([
                 'providedBy' => $this->getName(),

--- a/src/Provider/HostIp/HostIp.php
+++ b/src/Provider/HostIp/HostIp.php
@@ -85,21 +85,21 @@ final class HostIp extends AbstractHttpProvider implements Provider
             return new AddressCollection([]);
         }
 
-		// Return empty collection if address was not found
-        if ($data['lat'] === null
-        &&  $data['lng'] === null
-        &&  $data['city'] === '(Unknown City?)'
-        &&  $data['country_name'] === '(Unknown Country?)'
-        &&  $data['country_code'] === 'XX') {
+        // Return empty collection if address was not found
+        if (null === $data['lat']
+        && null === $data['lng']
+        && '(Unknown City?)' === $data['city']
+        && '(Unknown Country?)' === $data['country_name']
+        && 'XX' === $data['country_code']) {
             return new AddressCollection([]);
         }
 
-		// Return empty collection if address was not found
-        if ($data['lat'] === null
-        &&  $data['lng'] === null
-        &&  $data['city'] === '(Private Address)'
-        &&  $data['country_name'] === '(Private Address)'
-        &&  $data['country_code'] === 'XX') {
+        // Return empty collection if address was not found
+        if (null === $data['lat']
+        && null === $data['lng']
+        && '(Private Address)' === $data['city']
+        && '(Private Address)' === $data['country_name']
+        && 'XX' === $data['country_code']) {
             return new AddressCollection([]);
         }
 


### PR DESCRIPTION
If the location of the ip address cannot be determined by HostIp, return an empty AddressCollection instead of dummy data. This is particularly useful when using the Chain provider.