### PR TITLE
Return empty collection if address was not found

### DIFF
--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -61,15 +61,15 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
         $data = json_decode($content, true);
 
         // Return empty collection if address was not found
-        if ($data['region_name'] === ''
-        &&  $data['region_code'] === ''
-        &&  $data['latitude'] === 0
-        &&  $data['longitude'] === 0
-        &&  $data['city'] === ''
-        &&  $data['zip_code'] === ''
-        &&  $data['country_name'] === ''
-        &&  $data['country_code'] === ''
-        &&  $data['time_zone'] === '') {
+        if ('' === $data['region_name']
+        && '' === $data['region_code']
+        && 0 === $data['latitude']
+        && 0 === $data['longitude']
+        && '' === $data['city']
+        && '' === $data['zip_code']
+        && '' === $data['country_name']
+        && '' === $data['country_code']
+        && '' === $data['time_zone']) {
             return new AddressCollection([]);
         }
 

--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -59,6 +59,20 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
 
         $content = $this->getUrlContents(sprintf($this->baseUrl, $address));
         $data = json_decode($content, true);
+
+        // Return empty collection if address was not found
+        if ($data['region_name'] === ''
+        &&  $data['region_code'] === ''
+        &&  $data['latitude'] === 0
+        &&  $data['longitude'] === 0
+        &&  $data['city'] === ''
+        &&  $data['zip_code'] === ''
+        &&  $data['country_name'] === ''
+        &&  $data['country_code'] === ''
+        &&  $data['time_zone'] === '') {
+            return new AddressCollection([]);
+        }
+
         $builder = new AddressBuilder($this->getName());
 
         if (!empty($data['region_name'])) {


### PR DESCRIPTION
If the location of the ip address cannot be determined by FreeGeoIp, return an empty AddressCollection instead of dummy data. This is particularly useful when using the Chain provider.