### PR TITLE
GeoPlugin: Return empty collection if address was not found

### DIFF
--- a/src/Provider/GeoPlugin/GeoPlugin.php
+++ b/src/Provider/GeoPlugin/GeoPlugin.php
@@ -85,6 +85,17 @@ final class GeoPlugin extends AbstractHttpProvider implements Provider
             return new AddressCollection([]);
         }
 
+        // Return empty collection if address was not found
+        if ($json['geoplugin_regionName'] === ''
+        &&  $json['geoplugin_regionCode'] === ''
+        &&  $json['geoplugin_city'] === ''
+        &&  $json['geoplugin_countryName'] === ''
+        &&  $json['geoplugin_countryCode'] === ''
+        &&  $json['geoplugin_latitude'] === '0'
+        &&  $json['geoplugin_longitude'] === '0') {
+            return new AddressCollection([]);
+        }
+
         $data = array_filter($json);
 
         $adminLevels = [];

--- a/src/Provider/GeoPlugin/GeoPlugin.php
+++ b/src/Provider/GeoPlugin/GeoPlugin.php
@@ -86,13 +86,13 @@ final class GeoPlugin extends AbstractHttpProvider implements Provider
         }
 
         // Return empty collection if address was not found
-        if ($json['geoplugin_regionName'] === ''
-        &&  $json['geoplugin_regionCode'] === ''
-        &&  $json['geoplugin_city'] === ''
-        &&  $json['geoplugin_countryName'] === ''
-        &&  $json['geoplugin_countryCode'] === ''
-        &&  $json['geoplugin_latitude'] === '0'
-        &&  $json['geoplugin_longitude'] === '0') {
+        if ('' === $json['geoplugin_regionName']
+        && '' === $json['geoplugin_regionCode']
+        && '' === $json['geoplugin_city']
+        && '' === $json['geoplugin_countryName']
+        && '' === $json['geoplugin_countryCode']
+        && '0' === $json['geoplugin_latitude']
+        && '0' === $json['geoplugin_longitude']) {
             return new AddressCollection([]);
         }
 


### PR DESCRIPTION
If the location of the ip address cannot be determined by GeoPlugin, return an empty AddressCollection instead of dummy data. This is particularly useful when using the Chain provider.