### PR TITLE
[Google maps] Removed return types

### DIFF
--- a/src/Provider/GoogleMaps/Model/GoogleAddress.php
+++ b/src/Provider/GoogleMaps/Model/GoogleAddress.php
@@ -473,7 +473,7 @@ final class GoogleAddress extends Address
     /**
      * @return AdminLevelCollection
      */
-    public function getSubLocalityLevels(): AdminLevelCollection
+    public function getSubLocalityLevels()
     {
         return $this->subLocalityLevels;
     }


### PR DESCRIPTION
This return type is a BC break