### PR TITLE
add adminLevels to reverse geocoder

### DIFF
--- a/src/Provider/ArcGISOnline/ArcGISOnline.php
+++ b/src/Provider/ArcGISOnline/ArcGISOnline.php
@@ -136,6 +136,13 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
         $region = !empty($data->Region) ? $data->Region : null;
         $county = !empty($data->Subregion) ? $data->Subregion : null;
         $countryCode = !empty($data->CountryCode) ? $data->CountryCode : null;
+        
+        $adminLevels = [];
+        foreach (['Region', 'Subregion'] as $i => $property) {
+            if (!empty($data->{$property})) {
+                $adminLevels[] = ['name' => $data->{$property}, 'level' => $i + 1];
+            }
+        }
 
         return new AddressCollection([
             Address::createFromArray([
@@ -148,6 +155,7 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
                 'region' => $region,
                 'countryCode' => $countryCode,
                 'county' => $county,
+                'adminLevels' => $adminLevels,
             ]),
         ]);
     }

--- a/src/Provider/ArcGISOnline/ArcGISOnline.php
+++ b/src/Provider/ArcGISOnline/ArcGISOnline.php
@@ -136,7 +136,7 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
         $region = !empty($data->Region) ? $data->Region : null;
         $county = !empty($data->Subregion) ? $data->Subregion : null;
         $countryCode = !empty($data->CountryCode) ? $data->CountryCode : null;
-        
+
         $adminLevels = [];
         foreach (['Region', 'Subregion'] as $i => $property) {
             if (!empty($data->{$property})) {


### PR DESCRIPTION
I was wondering why when using ArcGIS Online as a reverse geocoder would not return the United States state and the county. It turns out that the provider wasn't even returning an "adminLevels" array, which is what every other reverse geocode provider returns. I have added `adminLevels` to the returned object of a reverse geocode.