### PR TITLE
Add countrySet support for TomTom

### DIFF
--- a/src/Provider/TomTom/TomTom.php
+++ b/src/Provider/TomTom/TomTom.php
@@ -74,7 +74,7 @@ final class TomTom extends AbstractHttpProvider implements Provider
         if (null !== $query->getLocale()) {
             $url = sprintf('%s&language=%s', $url, $query->getLocale());
         }
-        
+
         if (null !== $query->getData('countrySet')) {
             $url = sprintf('%s&countrySet=%s', $url, $query->getData('countrySet'));
         }

--- a/src/Provider/TomTom/TomTom.php
+++ b/src/Provider/TomTom/TomTom.php
@@ -74,6 +74,10 @@ final class TomTom extends AbstractHttpProvider implements Provider
         if (null !== $query->getLocale()) {
             $url = sprintf('%s&language=%s', $url, $query->getLocale());
         }
+        
+        if (null !== $query->getData('countrySet')) {
+            $url = sprintf('%s&countrySet=%s', $url, $query->getData('countrySet'));
+        }
 
         $content = $this->getUrlContents($url);
         if (false !== stripos($content, 'Developer Inactive')) {


### PR DESCRIPTION
Instead of bounds like in GoogleMaps, TomTom allows to pass a list of countries to the query to limit the results to specific country. Since the `Query` class already supports adding custom fields through the `setData` and `getData` methods, this feature can easily supported by just adding three lines of code to the `TomTom` provider class.