### PR TITLE
Split getUrlContents

### DIFF
--- a/src/Http/Provider/AbstractHttpProvider.php
+++ b/src/Http/Provider/AbstractHttpProvider.php
@@ -19,6 +19,7 @@ use Geocoder\Provider\AbstractProvider;
 use Http\Message\MessageFactory;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Client\HttpClient;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -57,7 +58,32 @@ abstract class AbstractHttpProvider extends AbstractProvider
      */
     protected function getUrlContents(string $url): string
     {
-        $request = $this->getMessageFactory()->createRequest('GET', $url);
+        $request = $this->getRequest($url);
+
+        return $this->getRequestContents($request);
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return RequestInterface
+     */
+    protected function getRequest(string $url): RequestInterface
+    {
+        return $this->getMessageFactory()->createRequest('GET', $url);
+    }
+
+    /**
+     * Send request and return contents. If content is empty, an exception will be thrown.
+     *
+     * @param RequestInterface $request
+     *
+     * @return string
+     *
+     * @throws InvalidServerResponse
+     */
+    protected function getRequestContents(RequestInterface $request): string
+    {
         $response = $this->getHttpClient()->sendRequest($request);
 
         $statusCode = $response->getStatusCode();
@@ -66,12 +92,12 @@ abstract class AbstractHttpProvider extends AbstractProvider
         } elseif (429 === $statusCode) {
             throw new QuotaExceeded();
         } elseif ($statusCode >= 300) {
-            throw InvalidServerResponse::create($url, $statusCode);
+            throw InvalidServerResponse::create((string) $request->getUri(), $statusCode);
         }
 
         $body = (string) $response->getBody();
         if (empty($body)) {
-            throw InvalidServerResponse::emptyResponse($url);
+            throw InvalidServerResponse::emptyResponse((string) $request->getUri());
         }
 
         return $body;

--- a/src/Http/Provider/AbstractHttpProvider.php
+++ b/src/Http/Provider/AbstractHttpProvider.php
@@ -60,7 +60,7 @@ abstract class AbstractHttpProvider extends AbstractProvider
     {
         $request = $this->getRequest($url);
 
-        return $this->getRequestContents($request);
+        return $this->getParsedResponse($request);
     }
 
     /**
@@ -82,7 +82,7 @@ abstract class AbstractHttpProvider extends AbstractProvider
      *
      * @throws InvalidServerResponse
      */
-    protected function getRequestContents(RequestInterface $request): string
+    protected function getParsedResponse(RequestInterface $request): string
     {
         $response = $this->getHttpClient()->sendRequest($request);
 


### PR DESCRIPTION
As requested in https://github.com/geocoder-php/Geocoder/pull/829. Since `getUrlContents()` takes the url as a string argument, it is not possible to set headers, such as `Accept-Language`, for the request. Therefore I created `getRequest()` to generate the request based on the url string, but without fetching the contents. Then headers can be added to the request, before the request is passed to `getRequestContents()` which fetches the content.