### PR TITLE
Use AbstractHttpProvider in FreeGeoIp

### DIFF
--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -60,29 +60,13 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
             return new AddressCollection([$this->getLocationForLocalhost()]);
         }
 
-        $url = sprintf($this->baseUrl, $address);
-        $request = $this->getMessageFactory()->createRequest('GET', $url);
+        $request = $this->getRequest(sprintf($this->baseUrl, $address));
 
         if (null !== $query->getLocale()) {
             $request = $request->withHeader('Accept-Language', $query->getLocale());
         }
 
-        $response = $this->getHttpClient()->sendRequest($request);
-
-        $statusCode = $response->getStatusCode();
-        if (401 === $statusCode || 403 === $statusCode) {
-            throw new InvalidCredentials();
-        } elseif (429 === $statusCode) {
-            throw new QuotaExceeded();
-        } elseif ($statusCode >= 300) {
-            throw InvalidServerResponse::create($url, $statusCode);
-        }
-
-        $body = (string) $response->getBody();
-        if (empty($body)) {
-            throw InvalidServerResponse::emptyResponse($url);
-        }
-
+        $body = $this->getParsedResponse($request);
         $data = json_decode($body, true);
 
         // Return empty collection if address was not found

--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 namespace Geocoder\Provider\FreeGeoIp;
 
 use Geocoder\Collection;
-use Geocoder\Exception\InvalidCredentials;
-use Geocoder\Exception\InvalidServerResponse;
-use Geocoder\Exception\QuotaExceeded;
 use Geocoder\Exception\UnsupportedOperation;
 use Geocoder\Model\AddressBuilder;
 use Geocoder\Model\AddressCollection;

--- a/src/Provider/FreeGeoIp/composer.json
+++ b/src/Provider/FreeGeoIp/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "geocoder-php/common-http": "^4.0",
+        "geocoder-php/common-http": "^4.1",
         "willdurand/geocoder": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Use `getRequest` and `getParsedResponse` from `AbstractHttpProvider` instead of duplicating code in `FreeGeoIp`. See https://github.com/geocoder-php/Geocoder/pull/864.