### PR TITLE
Allow to extend the ArcGISOnline class

### DIFF
--- a/src/Provider/ArcGISOnline/ArcGISOnline.php
+++ b/src/Provider/ArcGISOnline/ArcGISOnline.php
@@ -27,7 +27,7 @@ use Http\Client\HttpClient;
 /**
  * @author ALKOUM Dorian <baikunz@gmail.com>
  */
-final class ArcGISOnline extends AbstractHttpProvider implements Provider
+class ArcGISOnline extends AbstractHttpProvider implements Provider
 {
     /**
      * @var string
@@ -42,7 +42,7 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
     /**
      * @var string
      */
-    private $sourceCountry;
+    protected $sourceCountry;
 
     /**
      * @param HttpClient $client        An HTTP adapter
@@ -166,7 +166,7 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
      *
      * @return string
      */
-    private function buildQuery(string $query, int $limit): string
+    protected function buildQuery(string $query, int $limit): string
     {
         if (null !== $this->sourceCountry) {
             $query = sprintf('%s&sourceCountry=%s', $query, $this->sourceCountry);
@@ -181,7 +181,7 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
      *
      * @return \stdClass
      */
-    private function executeQuery(string $url, int $limit): \stdClass
+    protected function executeQuery(string $url, int $limit): \stdClass
     {
         $url = $this->buildQuery($url, $limit);
         $content = $this->getUrlContents($url);


### PR DESCRIPTION
I'm working for an organisation that is an ArcGIS Enterprise customer. They are not using the public endpoint (https://geocode.arcgis.com/) but have their own customized endpoint.

Currently I cannot use the ArcGISOnline provider since the endpoint is hardcoded and the class is final so it cannot be overridden.

This PR makes it possible to override the provider so that ArcGIS Enterprise customers can customize the functionality to match their individual needs.