### PR TITLE
Improve error message in case a provider can NOT geocode an address / query

### DIFF
--- a/src/Provider/Chain/Chain.php
+++ b/src/Provider/Chain/Chain.php
@@ -55,8 +55,12 @@ final class Chain implements Provider, LoggerAwareInterface
             } catch (\Throwable $e) {
                 $this->log(
                     'alert',
-                    sprintf('Provider "%s" could geocode address: "%s".', $provider->getName(), $query->getText()),
-                    ['exception' => $e]
+                    'Provider "{providerName}" could not geocode address: "{address}".',
+                    [
+                        'exception' => $e,
+                        'providerName' => $provider->getName(),
+                        'address' => $query->getText(),
+                    ]
                 );
             }
         }


### PR DESCRIPTION
in case a provider can NOT geocode an address / query