### PR TITLE
Google Maps component filtering

### DIFF
--- a/src/Provider/GoogleMaps/GoogleMaps.php
+++ b/src/Provider/GoogleMaps/GoogleMaps.php
@@ -115,6 +115,11 @@ final class GoogleMaps extends AbstractHttpProvider implements Provider
             $url .= sprintf('&bounds=%s,%s|%s,%s', $bounds->getSouth(), $bounds->getWest(), $bounds->getNorth(), $bounds->getEast());
         }
 
+        if (null !== $components = $query->getData('components')) {
+            $serializedComponents = is_string($components) ? $components : $this->serializeComponents($components);
+            $url .= sprintf('&components=%s', urlencode($serializedComponents));
+        }
+
         return $this->fetchUrl($url, $query->getLocale(), $query->getLimit(), $query->getData('region', $this->region));
     }
 
@@ -364,6 +369,20 @@ final class GoogleMaps extends AbstractHttpProvider implements Provider
         $encodedSignature = str_replace(['+', '/'], ['-', '_'], base64_encode($signature));
 
         return sprintf('%s&signature=%s', $query, $encodedSignature);
+    }
+
+    /**
+     * Serialize the component query parameter.
+     *
+     * @param array $components
+     *
+     * @return string
+     */
+    private function serializeComponents(array $components): string
+    {
+        return implode('|', array_map(function ($name, $value) {
+            return sprintf('%s:%s', $name, $value);
+        }, array_keys($components), $components));
     }
 
     /**

--- a/src/Provider/GoogleMaps/Tests/.cached_responses/maps.googleapis.com_52985ec7762d4de3d6f1e0b41b881be875413899
+++ b/src/Provider/GoogleMaps/Tests/.cached_responses/maps.googleapis.com_52985ec7762d4de3d6f1e0b41b881be875413899
@@ -1,0 +1,69 @@
+s:2115:"{
+   "results" : [
+      {
+         "address_components" : [
+            {
+               "long_name" : "4",
+               "short_name" : "4",
+               "types" : [ "street_number" ]
+            },
+            {
+               "long_name" : "Göran Olsgatan",
+               "short_name" : "Göran Olsgatan",
+               "types" : [ "route" ]
+            },
+            {
+               "long_name" : "Gamla Staden",
+               "short_name" : "Gamla Staden",
+               "types" : [ "political", "sublocality", "sublocality_level_1" ]
+            },
+            {
+               "long_name" : "Malmö",
+               "short_name" : "Malmö",
+               "types" : [ "postal_town" ]
+            },
+            {
+               "long_name" : "Skåne län",
+               "short_name" : "Skåne län",
+               "types" : [ "administrative_area_level_1", "political" ]
+            },
+            {
+               "long_name" : "Sweden",
+               "short_name" : "SE",
+               "types" : [ "country", "political" ]
+            },
+            {
+               "long_name" : "211 22",
+               "short_name" : "211 22",
+               "types" : [ "postal_code" ]
+            }
+         ],
+         "formatted_address" : "Göran Olsgatan 4, 211 22 Malmö, Sweden",
+         "geometry" : {
+            "location" : {
+               "lat" : 55.6069245,
+               "lng" : 13.0033279
+            },
+            "location_type" : "ROOFTOP",
+            "viewport" : {
+               "northeast" : {
+                  "lat" : 55.60827348029149,
+                  "lng" : 13.0046768802915
+               },
+               "southwest" : {
+                  "lat" : 55.60557551970849,
+                  "lng" : 13.0019789197085
+               }
+            }
+         },
+         "place_id" : "ChIJuSSfYfyjU0YRK-5BbDS1mzw",
+         "plus_code" : {
+            "compound_code" : "J243+Q8 Malmö, Sweden",
+            "global_code" : "9F7MJ243+Q8"
+         },
+         "types" : [ "church", "establishment", "place_of_worship", "point_of_interest" ]
+      }
+   ],
+   "status" : "OK"
+}
+";


### PR DESCRIPTION
Hi!

First of all, thanks for a great library.

I noticed that [component filtering](https://developers.google.com/maps/documentation/geocoding/intro#ComponentFiltering) was missing for the Google Maps provider, so i took the liberty of implementing it. Not sure if this can cause any issues with backwards compatibility.