### PR TITLE
[Mapbox] Fix Mapbox Query builder when there is Bound

### DIFF
--- a/src/Common/Model/Bounds.php
+++ b/src/Common/Model/Bounds.php
@@ -40,10 +40,10 @@ final class Bounds
     private $east;
 
     /**
-     * @param float $south
-     * @param float $west
-     * @param float $north
-     * @param float $east
+     * @param float $south South bound, also min latitude
+     * @param float $west  West bound, also min longitude
+     * @param float $north North bound, also max latitude
+     * @param float $east  East bound, also max longitude
      */
     public function __construct($south, $west, $north, $east)
     {

--- a/src/Provider/Mapbox/CHANGELOG.md
+++ b/src/Provider/Mapbox/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## To be release
+
+### Fixed
+
+- Fix the Bounds query builder format
+
 ## 1.0.0
 
 First release of this library. 

--- a/src/Provider/Mapbox/Mapbox.php
+++ b/src/Provider/Mapbox/Mapbox.php
@@ -179,8 +179,9 @@ final class Mapbox extends AbstractHttpProvider implements Provider
 
         $urlParameters = [];
         if ($query->getBounds()) {
+            // Format is "minLon,minLat,maxLon,maxLat"
             $urlParameters['bbox'] = sprintf(
-                '%s,%s|%s,%s',
+                '%s,%s,%s,%s',
                 $query->getBounds()->getWest(),
                 $query->getBounds()->getSouth(),
                 $query->getBounds()->getEast(),


### PR DESCRIPTION
When using Bound, the query was malformed in two ways:

- the format was wrong (`|` is not allowed);
- ~~the order was wrong (`minLon,minLat,maxLon,maxLat` was not respected).~~

I also added some documentation to the "Bound" object because it may not be clear to everyone what the min latitude can be when reading compass points.