### PR TITLE
Mark GeoJson dumper as Dumper implementation

### DIFF
--- a/src/Common/Dumper/GeoJson.php
+++ b/src/Common/Dumper/GeoJson.php
@@ -17,7 +17,7 @@ use Geocoder\Location;
 /**
  * @author Jan Sorgalla <jsorgalla@googlemail.com>
  */
-final class GeoJson extends AbstractArrayDumper
+final class GeoJson extends AbstractArrayDumper implements Dumper
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
It implements the method, as expected, but won't satisfy checks for the interface, without this change.