### PR TITLE
[Photon] Require PHP 7.1

### DIFF
--- a/src/Provider/Photon/composer.json
+++ b/src/Provider/Photon/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "geocoder-php/common-http": "^4.1",
         "willdurand/geocoder": "^4.0"
     },
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "nyholm/psr7": "^0.2.2",
+        "nyholm/psr7": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "6.3.*"


### PR DESCRIPTION
PHP 7.0 is not longer supported. 

This PR will also trigger a push to https://github.com/geocoder-php/photon-provider