### PR TITLE
[Google Maps] do not use duplicate sub locality levels

### DIFF
--- a/src/Provider/GoogleMaps/Model/GoogleAddress.php
+++ b/src/Provider/GoogleMaps/Model/GoogleAddress.php
@@ -499,11 +499,11 @@ final class GoogleAddress extends Address
             $subLocalityLevels[] = new AdminLevel($level['level'], $name, $level['code'] ?? null);
         }
 
-        $subLocalityLevels = array_filter($subLocalityLevels, function($adminLevel) use ($subLocalityLevels) {
+        $subLocalityLevels = array_filter($subLocalityLevels, function ($adminLevel) use ($subLocalityLevels) {
             foreach ($subLocalityLevels as $localityLevel) {
-                if ($adminLevel->getLevel() === $localityLevel->getLevel() 
-                 && $adminLevel->getName()  === $localityLevel->getName() 
-                 && $adminLevel->getCode()  === $localityLevel->getCode()) {
+                if ($adminLevel->getLevel() === $localityLevel->getLevel()
+                 && $adminLevel->getName() === $localityLevel->getName()
+                 && $adminLevel->getCode() === $localityLevel->getCode()) {
                     return false;
                 }
             }

--- a/src/Provider/GoogleMaps/Model/GoogleAddress.php
+++ b/src/Provider/GoogleMaps/Model/GoogleAddress.php
@@ -507,6 +507,7 @@ final class GoogleAddress extends Address
                     return false;
                 }
             }
+
             return true;
         });
 

--- a/src/Provider/GoogleMaps/Model/GoogleAddress.php
+++ b/src/Provider/GoogleMaps/Model/GoogleAddress.php
@@ -499,6 +499,17 @@ final class GoogleAddress extends Address
             $subLocalityLevels[] = new AdminLevel($level['level'], $name, $level['code'] ?? null);
         }
 
+        $subLocalityLevels = array_filter($subLocalityLevels, function($adminLevel) use ($subLocalityLevels) {
+            foreach ($subLocalityLevels as $localityLevel) {
+                if ($adminLevel->getLevel() === $localityLevel->getLevel() 
+                 && $adminLevel->getName()  === $localityLevel->getName() 
+                 && $adminLevel->getCode()  === $localityLevel->getCode()) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
         $new = clone $this;
         $new->subLocalityLevels = new AdminLevelCollection($subLocalityLevels);
 


### PR DESCRIPTION
Fix for #793

If an `AdminLevel` has the exact same code, name and level, it will lead to an 
```
Administrative level x is defined twice
``` 
exception in willdurand\geocoder. This PR filters such `AdminLevel`s. It also works with
```php
$subLocalityLevels = array_filter($subLocalityLevels, function($adminLevel) use ($subLocalityLevels) {
    foreach ($subLocalityLevels as $localityLevel) {
        if ($adminLevel == $localityLevel) {
            return false;
        }
    }
    return true;
});
```
of course, but I am not sure what the best practise for object comparison is.

