### PR TITLE
[Google Maps] Fix "Administrative level X is defined twice"

### DIFF
--- a/src/Provider/GoogleMaps/Model/GoogleAddress.php
+++ b/src/Provider/GoogleMaps/Model/GoogleAddress.php
@@ -499,6 +499,8 @@ final class GoogleAddress extends Address
             $subLocalityLevels[] = new AdminLevel($level['level'], $name, $level['code'] ?? null);
         }
 
+        $subLocalityLevels = array_unique($subLocalityLevels);
+
         $new = clone $this;
         $new->subLocalityLevels = new AdminLevelCollection($subLocalityLevels);
 


### PR DESCRIPTION
This should fix the "Administrative level X is defined twice" error (see #793).

@benwrigley @geodeveloper @fritzmg Could one of you test it and confirm ? Thanks