### PR TITLE
chore: run tests on php 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,14 @@ env:
 matrix:
     fast_finish: true
     include:
-        - php: 7.2
+        - php: 7.3
           env: deps="low"
-        - php: 7.2
+        - php: 7.3
           env: deps="high"
         - php: 7.0
         - php: 7.1
         - php: 7.2
+        - php: 7.3
 
 before_install:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ env:
     global:
         - MIN_PHP=7.0
 
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
 matrix:
     fast_finish: true
     include:


### PR DESCRIPTION
Since PHP 7.3 was released in December last year I think we should switch the CI to test it.

I ran the suite locally and had no errors, but a PR is needed to trigger a CI build.
Also added in a composer cache to speed things up a little bit :)