### PR TITLE
Synchronize construct with nominatim

### DIFF
--- a/src/Http/Provider/AbstractHttpProvider.php
+++ b/src/Http/Provider/AbstractHttpProvider.php
@@ -40,8 +40,10 @@ abstract class AbstractHttpProvider extends AbstractProvider
     /**
      * @param HttpClient          $client
      * @param MessageFactory|null $factory
+     * @param string     $userAgent Value of the User-Agent header
+     * @param string     $referer   Value of the Referer header
      */
-    public function __construct(HttpClient $client, MessageFactory $factory = null)
+    public function __construct(HttpClient $client, MessageFactory $factory = null, string $userAgent = '', string $referer = '')
     {
         $this->client = $client;
         $this->messageFactory = $factory ?: MessageFactoryDiscovery::find();


### PR DESCRIPTION
Per https://github.com/geocoder-php/nominatim-provider/commit/3068e7f692e0d799679adcfd81df6046cfcab8fb 
Nominatim accepts 2 additional parameters - one being 'required' because of Nominatim Terms of service. Really the constructor should be standard between all providers so if this is accepted for Nominim then it makes sense to put it in the parent. The point of a factory like this is for one syntax to work with many providers

Note I don't think it needs to be 'required'