### PR TITLE
fix: update freegeoip post-shutdown

### DIFF
--- a/src/Provider/FreeGeoIp/FreeGeoIp.php
+++ b/src/Provider/FreeGeoIp/FreeGeoIp.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Geocoder\Provider\FreeGeoIp;
 
 use Geocoder\Collection;
+use Geocoder\Exception\InvalidArgument;
 use Geocoder\Exception\UnsupportedOperation;
 use Geocoder\Model\AddressBuilder;
 use Geocoder\Model\AddressCollection;
@@ -28,7 +29,7 @@ use Http\Client\HttpClient;
 final class FreeGeoIp extends AbstractHttpProvider implements Provider
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $baseUrl;
 
@@ -36,7 +37,7 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
      * @param HttpClient $client
      * @param string     $baseUrl
      */
-    public function __construct(HttpClient $client, string $baseUrl = 'https://freegeoip.net/json/%s')
+    public function __construct(HttpClient $client, string $baseUrl = null)
     {
         parent::__construct($client);
 
@@ -48,6 +49,14 @@ final class FreeGeoIp extends AbstractHttpProvider implements Provider
      */
     public function geocodeQuery(GeocodeQuery $query): Collection
     {
+        if (null === $this->baseUrl) {
+            throw new InvalidArgument(sprintf(
+                'The FreeGeoIp.net service no longer operates. See %s and %s for more information.',
+                'http://freegeoip.net/shutdown',
+                'https://github.com/geocoder-php/free-geoip-provider'
+            ));
+        }
+
         $address = $query->getText();
         if (!filter_var($address, FILTER_VALIDATE_IP)) {
             throw new UnsupportedOperation('The FreeGeoIp provider does not support street addresses.');

--- a/src/Provider/FreeGeoIp/Readme.md
+++ b/src/Provider/FreeGeoIp/Readme.md
@@ -10,7 +10,7 @@
 This is the Free GeoIp provider from the PHP Geocoder. This is a **READ ONLY** repository. See the
 [main repo](https://github.com/geocoder-php/Geocoder) for information and documentation. 
 
-# Freegeoip Shutdown
+## Freegeoip Shutdown
 As per the [freegeoip.net](http://freegeoip.net/shutdown) website, the provider has been purchased by [IpStack](https://ipstack.com/).
 As a result, this provider no longer works with the default configuration. It will still work if you use the 
 [self hosted variant](https://github.com/apilayer/freegeoip/) and supply a host when constructing the provider.
@@ -26,15 +26,18 @@ $provider = new Geocoder\Provider\FreeGeoIp\FreeGeoIp($httpClient, 'http://my.in
 ```
 
 ## Alternatives
+We offer an [IpStack provider](https://github.com/geocoder-php/ipstack-provider) which you can use if you wish to continue with the new service owner.
+
+### Full IP Provider List
 https://github.com/geocoder-php/Geocoder#ip
 
-### Install
+## Install
 
 ```bash
 composer require geocoder-php/free-geoip-provider
 ```
 
-### Contribute
+## Contribute
 
 Contributions are very welcome! Send a pull request to the [main repository](https://github.com/geocoder-php/Geocoder) or 
 report any issues you find on the [issue tracker](https://github.com/geocoder-php/Geocoder/issues).

--- a/src/Provider/FreeGeoIp/Readme.md
+++ b/src/Provider/FreeGeoIp/Readme.md
@@ -10,6 +10,24 @@
 This is the Free GeoIp provider from the PHP Geocoder. This is a **READ ONLY** repository. See the
 [main repo](https://github.com/geocoder-php/Geocoder) for information and documentation. 
 
+# Freegeoip Shutdown
+As per the [freegeoip.net](http://freegeoip.net/shutdown) website, the provider has been purchased by [IpStack](https://ipstack.com/).
+As a result, this provider no longer works with the default configuration. It will still work if you use the 
+[self hosted variant](https://github.com/apilayer/freegeoip/) and supply a host when constructing the provider.
+
+## Usage
+```php
+$httpClient = new \Http\Adapter\Guzzle6\Client();
+
+// This will no longer work
+$provider = new Geocoder\Provider\FreeGeoIp\FreeGeoIp($httpClient);
+// You must provide the endpoint of your instance 
+$provider = new Geocoder\Provider\FreeGeoIp\FreeGeoIp($httpClient, 'http://my.internal.geocoder/json/%s');
+```
+
+## Alternatives
+https://github.com/geocoder-php/Geocoder#ip
+
 ### Install
 
 ```bash

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_500b2d9369a4fc679d5ceb9a418cf02bf10d013d
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_500b2d9369a4fc679d5ceb9a418cf02bf10d013d
@@ -1,2 +1,0 @@
-s:234:"{"ip":"74.200.247.59","country_code":"US","country_name":"United States","region_code":"TX","region_name":"Texas","city":"Plano","zip_code":"75093","time_zone":"America/Chicago","latitude":33.035,"longitude":-96.814,"metro_code":623}
-";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_56adadaf03f9037e7cae3a464b6dc9617f814883
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_56adadaf03f9037e7cae3a464b6dc9617f814883
@@ -1,2 +1,0 @@
-s:270:"{"ip":"81.27.51.253","country_code":"RU","country_name":"Россия","region_code":"VLA","region_name":"Владимирская область","city":"Владимир","zip_code":"","time_zone":"Europe/Moscow","latitude":56.1365,"longitude":40.3966,"metro_code":0}
-";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_66299fd8d42b096fa031b8d1832fc8eb50277552
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_66299fd8d42b096fa031b8d1832fc8eb50277552
@@ -1,2 +1,0 @@
-s:235:"{"ip":"81.27.51.252","country_code":"RU","country_name":"Russie","region_code":"VLA","region_name":"Oblast de Vladimir","city":"Vladimir","zip_code":"","time_zone":"Europe/Moscow","latitude":56.1365,"longitude":40.3966,"metro_code":0}
-";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_77986275ed32e32047ac76a39223f623f52033bc
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_77986275ed32e32047ac76a39223f623f52033bc
@@ -1,2 +1,0 @@
-s:234:"{"ip":"74.200.247.59","country_code":"US","country_name":"United States","region_code":"TX","region_name":"Texas","city":"Plano","zip_code":"75093","time_zone":"America/Chicago","latitude":33.035,"longitude":-96.814,"metro_code":623}
-";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_8aaa58eef1ef2a53923da060d6a9de0db75bf96d
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_8aaa58eef1ef2a53923da060d6a9de0db75bf96d
@@ -1,2 +1,0 @@
-s:238:"{"ip":"81.27.51.251","country_code":"RU","country_name":"Russia","region_code":"VLA","region_name":"Vladimirskaya Oblast'","city":"Vladimir","zip_code":"","time_zone":"Europe/Moscow","latitude":56.1365,"longitude":40.3966,"metro_code":0}
-";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_8c694912ce2a0ccbf93c7f24111247dbea9916ad
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_8c694912ce2a0ccbf93c7f24111247dbea9916ad
@@ -1,2 +1,0 @@
-s:230:"{"ip":"83.227.123.8","country_code":"SE","country_name":"Sweden","region_code":"T","region_name":"Örebro","city":"Örebro","zip_code":"703 51","time_zone":"Europe/Stockholm","latitude":59.2741,"longitude":15.2066,"metro_code":0}
-";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_9a5acb5700a246cf22916f12ecea2dd2a58c99bb
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_9a5acb5700a246cf22916f12ecea2dd2a58c99bb
@@ -1,2 +1,0 @@
-s:190:"{"ip":"2001:db8:0:42:0:8a2e:370:7334","country_code":"","country_name":"","region_code":"","region_name":"","city":"","zip_code":"","time_zone":"","latitude":0,"longitude":0,"metro_code":0}
-";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_bcc32e827a944478cb862d570202ef3e941ff8ef
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_bcc32e827a944478cb862d570202ef3e941ff8ef
@@ -1,2 +1,0 @@
-s:235:"{"ip":"129.67.242.154","country_code":"GB","country_name":"United Kingdom","region_code":"ENG","region_name":"England","city":"Oxford","zip_code":"OX1","time_zone":"Europe/London","latitude":51.7158,"longitude":-1.2925,"metro_code":0}
-";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_d1b17a8025172d4e89a00e1386d65cfff66ca0ce
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_d1b17a8025172d4e89a00e1386d65cfff66ca0ce
@@ -1,2 +1,0 @@
-s:247:"{"ip":"8.8.8.8","country_code":"US","country_name":"United States","region_code":"CA","region_name":"California","city":"Mountain View","zip_code":"94035","time_zone":"America/Los_Angeles","latitude":37.386,"longitude":-122.0838,"metro_code":807}
-";

--- a/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_ec36afcdc6f9803d67dedca58c4421f83ecedda5
+++ b/src/Provider/FreeGeoIp/Tests/.cached_responses/freegeoip.net_ec36afcdc6f9803d67dedca58c4421f83ecedda5
@@ -1,2 +1,0 @@
-s:235:"{"ip":"129.67.242.154","country_code":"GB","country_name":"United Kingdom","region_code":"ENG","region_name":"England","city":"Oxford","zip_code":"OX1","time_zone":"Europe/London","latitude":51.7158,"longitude":-1.2925,"metro_code":0}
-";

--- a/src/Provider/FreeGeoIp/Tests/FreeGeoIpTest.php
+++ b/src/Provider/FreeGeoIp/Tests/FreeGeoIpTest.php
@@ -27,7 +27,7 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGetName()
     {
-        $provider = new FreeGeoIp($this->getMockedHttpClient());
+        $provider = $this->getProvider();
         $this->assertEquals('free_geo_ip', $provider->getName());
     }
 
@@ -37,13 +37,13 @@ class FreeGeoIpTest extends BaseTestCase
      */
     public function testGeocodeWithAddress()
     {
-        $provider = new FreeGeoIp($this->getMockedHttpClient());
+        $provider = $this->getProvider();
         $provider->geocodeQuery(GeocodeQuery::create('10 avenue Gambetta, Paris, France'));
     }
 
     public function testGeocodeWithLocalhostIPv4()
     {
-        $provider = new FreeGeoIp($this->getMockedHttpClient());
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('127.0.0.1'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -58,7 +58,7 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithLocalhostIPv6()
     {
-        $provider = new FreeGeoIp($this->getMockedHttpClient());
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('::1'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -73,7 +73,9 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithRealIPv4()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $this->markTestSkipped('Web service no longer operating');
+
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('74.200.247.59'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -94,7 +96,9 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithRealIPv6()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $this->markTestSkipped('Web service no longer operating');
+
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('::ffff:74.200.247.59'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -115,7 +119,9 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithUSIPv4()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $this->markTestSkipped('Web service no longer operating');
+
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('74.200.247.59'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -127,7 +133,9 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithUSIPv6()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $this->markTestSkipped('Web service no longer operating');
+
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('::ffff:74.200.247.59'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -139,7 +147,9 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithUKIPv4()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $this->markTestSkipped('Web service no longer operating');
+
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('129.67.242.154'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -152,7 +162,9 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithUKIPv6()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $this->markTestSkipped('Web service no longer operating');
+
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('::ffff:129.67.242.154'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -162,7 +174,9 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithRuLocale()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $this->markTestSkipped('Web service no longer operating');
+
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.253')->withLocale('ru'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -174,7 +188,9 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithFrLocale()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $this->markTestSkipped('Web service no longer operating');
+
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.252')->withLocale('fr'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -186,7 +202,9 @@ class FreeGeoIpTest extends BaseTestCase
 
     public function testGeocodeWithIncorrectLocale()
     {
-        $provider = new FreeGeoIp($this->getHttpClient());
+        $this->markTestSkipped('Web service no longer operating');
+
+        $provider = $this->getProvider();
         $results = $provider->geocodeQuery(GeocodeQuery::create('81.27.51.251')->withLocale('wrong_locale'));
 
         $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
@@ -202,7 +220,7 @@ class FreeGeoIpTest extends BaseTestCase
      */
     public function testReverse()
     {
-        $provider = new FreeGeoIp($this->getMockedHttpClient());
+        $provider = $this->getProvider();
         $provider->reverseQuery(ReverseQuery::fromCoordinates(1, 2));
     }
 
@@ -211,7 +229,12 @@ class FreeGeoIpTest extends BaseTestCase
      */
     public function testServerEmptyResponse()
     {
-        $provider = new FreeGeoIp($this->getMockedHttpClient());
+        $provider = $this->getProvider();
         $provider->geocodeQuery(GeocodeQuery::create('87.227.124.53'));
+    }
+
+    private function getProvider(): FreeGeoIp
+    {
+        return new FreeGeoIp($this->getMockedHttpClient(), 'https://internal.geocoder/json/%s');
     }
 }

--- a/src/Provider/FreeGeoIp/Tests/IntegrationTest.php
+++ b/src/Provider/FreeGeoIp/Tests/IntegrationTest.php
@@ -27,6 +27,7 @@ class IntegrationTest extends ProviderIntegrationTest
      * @var bool Web service no longer operating
      */
     protected $testIpv4 = false;
+
     /**
      * @var bool Web service no longer operating
      */

--- a/src/Provider/FreeGeoIp/Tests/IntegrationTest.php
+++ b/src/Provider/FreeGeoIp/Tests/IntegrationTest.php
@@ -23,11 +23,20 @@ class IntegrationTest extends ProviderIntegrationTest
 {
     protected $testAddress = false;
 
+    /**
+     * @var bool Web service no longer operating
+     */
+    protected $testIpv4 = false;
+    /**
+     * @var bool Web service no longer operating
+     */
+    protected $testIpv6 = false;
+
     protected $testReverse = false;
 
     protected function createProvider(HttpClient $httpClient)
     {
-        return new FreeGeoIp($httpClient);
+        return new FreeGeoIp($httpClient, 'https://internal.geocoder/json/%s');
     }
 
     protected function getCacheDir()


### PR DESCRIPTION
freegeoip.net shut down > 1 year ago, so I think it makes sense to update the provider.

Since it will still work with the open source, self hosted variant i've just updated the constructor default to `null` and throw an exception when trying to geocode without explicit setting of a host.

cc @jbelien  