### PR TITLE
New Pelias provider

### DIFF
--- a/src/Provider/Pelias/CHANGELOG.md
+++ b/src/Provider/Pelias/CHANGELOG.md
@@ -4,4 +4,4 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## 1.0.0
 
-First release of this (abstract) provider.
+First release of this provider.

--- a/src/Provider/Pelias/CHANGELOG.md
+++ b/src/Provider/Pelias/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
+
+## 1.0.0
+
+First release of this (abstract) provider.

--- a/src/Provider/Pelias/LICENSE
+++ b/src/Provider/Pelias/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2011 — William Durand <william.durand1@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Geocoder\Provider\Pelias;
+
+use Geocoder\Collection;
+use Geocoder\Exception\InvalidCredentials;
+use Geocoder\Exception\QuotaExceeded;
+use Geocoder\Exception\UnsupportedOperation;
+use Geocoder\Model\Address;
+use Geocoder\Model\AddressCollection;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\ReverseQuery;
+use Geocoder\Http\Provider\AbstractHttpProvider;
+use Geocoder\Provider\Provider;
+use Http\Client\HttpClient;
+
+abstract class Pelias extends AbstractHttpProvider implements Provider
+{
+    /**
+     * @var string
+     */
+    private $root;
+
+    /**
+     * @var int
+     */
+    private $version;
+
+    /**
+     * @param HttpClient $client  an HTTP adapter
+     * @param string     $root    url of Pelias API
+     * @param int        $version version of Pelias API
+     */
+    public function __construct(HttpClient $client, string $root, int $version = 1)
+    {
+        $this->root = sprintf('%s/v%d', rtrim($root, '/'), $version);
+        $this->version = $version;
+
+        parent::__construct($client);
+    }
+
+    /**
+     * @param GeocodeQuery $query
+     * @param array        $query_data Additional query data (API key for instance).
+     *
+     * @return string
+     *
+     * @throws \Geocoder\Exception\Exception
+     */
+    protected function getGeocodeQueryUrl(GeocodeQuery $query, array $query_data = []): string
+    {
+        $address = $query->getText();
+
+        // This API doesn't handle IPs
+        if (filter_var($address, FILTER_VALIDATE_IP)) {
+            throw new UnsupportedOperation('The GeocodeEarth provider does not support IP addresses, only street addresses.');
+        }
+
+        $data = [
+            'text' => $address,
+            'size' => $query->getLimit(),
+        ];
+
+        return sprintf('%s/search?%s', $this->root, http_build_query(array_merge($data, $query_data)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function geocodeQuery(GeocodeQuery $query): Collection;
+
+    /**
+     * @param ReverseQuery $query
+     * @param array        $query_data Additional query data (API key for instance).
+     *
+     * @return string
+     *
+     * @throws \Geocoder\Exception\Exception
+     */
+    protected function getReverseQueryUrl(ReverseQuery $query, array $query_data = []): string
+    {
+        $coordinates = $query->getCoordinates();
+        $longitude = $coordinates->getLongitude();
+        $latitude = $coordinates->getLatitude();
+
+        $data = [
+            'point.lat' => $latitude,
+            'point.lon' => $longitude,
+            'size' => $query->getLimit(),
+        ];
+
+        return sprintf('%s/reverse?%s', $this->root, http_build_query(array_merge($data, $query_data)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function reverseQuery(ReverseQuery $query): Collection;
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function getName(): string;
+
+    /**
+     * @param $url
+     *
+     * @return Collection
+     */
+    protected function executeQuery(string $url): AddressCollection
+    {
+        $content = $this->getUrlContents($url);
+        $json = json_decode($content, true);
+
+        if (isset($json['meta'])) {
+            switch ($json['meta']['status_code']) {
+                case 401:
+                case 403:
+                    throw new InvalidCredentials('Invalid or missing api key.');
+                case 429:
+                    throw new QuotaExceeded('Valid request but quota exceeded.');
+            }
+        }
+
+        if (!isset($json['type']) || 'FeatureCollection' !== $json['type'] || !isset($json['features']) || 0 === count($json['features'])) {
+            return new AddressCollection([]);
+        }
+
+        $locations = $json['features'];
+
+        if (empty($locations)) {
+            return new AddressCollection([]);
+        }
+
+        $results = [];
+        foreach ($locations as $location) {
+            $bounds = [
+                'south' => null,
+                'west' => null,
+                'north' => null,
+                'east' => null,
+            ];
+            if (isset($location['bbox'])) {
+                $bounds = [
+                    'south' => $location['bbox'][3],
+                    'west' => $location['bbox'][2],
+                    'north' => $location['bbox'][1],
+                    'east' => $location['bbox'][0],
+                ];
+            }
+
+            $props = $location['properties'];
+
+            $adminLevels = [];
+            foreach (['region', 'county', 'locality', 'macroregion', 'country'] as $i => $component) {
+                if (isset($props[$component])) {
+                    $adminLevels[] = ['name' => $props[$component], 'level' => $i + 1];
+                }
+            }
+
+            $results[] = Address::createFromArray([
+                'providedBy' => $this->getName(),
+                'latitude' => $location['geometry']['coordinates'][1],
+                'longitude' => $location['geometry']['coordinates'][0],
+                'bounds' => $bounds,
+                'streetNumber' => isset($props['housenumber']) ? $props['housenumber'] : null,
+                'streetName' => isset($props['street']) ? $props['street'] : null,
+                'subLocality' => isset($props['neighbourhood']) ? $props['neighbourhood'] : null,
+                'locality' => isset($props['locality']) ? $props['locality'] : null,
+                'postalCode' => isset($props['postalcode']) ? $props['postalcode'] : null,
+                'adminLevels' => $adminLevels,
+                'country' => isset($props['country']) ? $props['country'] : null,
+                'countryCode' => isset($props['country_a']) ? strtoupper($props['country_a']) : null,
+            ]);
+        }
+
+        return new AddressCollection($results);
+    }
+
+    /**
+     * @param array $components
+     *
+     * @return null|string
+     */
+    protected function guessLocality(array $components)
+    {
+        $localityKeys = ['city', 'town', 'village', 'hamlet'];
+
+        return $this->guessBestComponent($components, $localityKeys);
+    }
+
+    /**
+     * @param array $components
+     *
+     * @return null|string
+     */
+    protected function guessStreetName(array $components)
+    {
+        $streetNameKeys = ['road', 'street', 'street_name', 'residential'];
+
+        return $this->guessBestComponent($components, $streetNameKeys);
+    }
+
+    /**
+     * @param array $components
+     *
+     * @return null|string
+     */
+    protected function guessSubLocality(array $components)
+    {
+        $subLocalityKeys = ['neighbourhood', 'city_district'];
+
+        return $this->guessBestComponent($components, $subLocalityKeys);
+    }
+
+    /**
+     * @param array $components
+     * @param array $keys
+     *
+     * @return null|string
+     */
+    protected function guessBestComponent(array $components, array $keys)
+    {
+        foreach ($keys as $key) {
+            if (isset($components[$key]) && !empty($components[$key])) {
+                return $components[$key];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -158,12 +158,6 @@ class Pelias extends AbstractHttpProvider implements Provider
 
         $results = [];
         foreach ($locations as $location) {
-            $bounds = [
-                'south' => null,
-                'west' => null,
-                'north' => null,
-                'east' => null,
-            ];
             if (isset($location['bbox'])) {
                 $bounds = [
                     'south' => $location['bbox'][3],
@@ -171,6 +165,8 @@ class Pelias extends AbstractHttpProvider implements Provider
                     'north' => $location['bbox'][1],
                     'east' => $location['bbox'][0],
                 ];
+            } else {
+                $bounds = null;
             }
 
             $props = $location['properties'];

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -146,7 +146,12 @@ class Pelias extends AbstractHttpProvider implements Provider
             }
         }
 
-        if (!isset($json['type']) || 'FeatureCollection' !== $json['type'] || !isset($json['features']) || 0 === count($json['features'])) {
+        if (
+            !isset($json['type'])
+            || 'FeatureCollection' !== $json['type']
+            || !isset($json['features'])
+            || 0 === count($json['features'])
+        ) {
             return new AddressCollection([]);
         }
 

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -63,7 +63,7 @@ abstract class Pelias extends AbstractHttpProvider implements Provider
 
         // This API doesn't handle IPs
         if (filter_var($address, FILTER_VALIDATE_IP)) {
-            throw new UnsupportedOperation('The GeocodeEarth provider does not support IP addresses, only street addresses.');
+            throw new UnsupportedOperation('The Pelias provider does not support IP addresses, only street addresses.');
         }
 
         $data = [

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -63,7 +63,12 @@ class Pelias extends AbstractHttpProvider implements Provider
 
         // This API doesn't handle IPs
         if (filter_var($address, FILTER_VALIDATE_IP)) {
-            throw new UnsupportedOperation('The Pelias provider does not support IP addresses, only street addresses.');
+            throw new UnsupportedOperation(
+                sprintf(
+                    'The %s provider does not support IP addresses, only street addresses.',
+                    $this->getName()
+                )
+            );
         }
 
         $data = [

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -24,7 +24,7 @@ use Geocoder\Http\Provider\AbstractHttpProvider;
 use Geocoder\Provider\Provider;
 use Http\Client\HttpClient;
 
-abstract class Pelias extends AbstractHttpProvider implements Provider
+class Pelias extends AbstractHttpProvider implements Provider
 {
     /**
      * @var string
@@ -77,7 +77,10 @@ abstract class Pelias extends AbstractHttpProvider implements Provider
     /**
      * {@inheritdoc}
      */
-    abstract public function geocodeQuery(GeocodeQuery $query): Collection;
+    public function geocodeQuery(GeocodeQuery $query): Collection
+    {
+        return $this->executeQuery($this->getGeocodeQueryUrl($query));
+    }
 
     /**
      * @param ReverseQuery $query
@@ -105,12 +108,18 @@ abstract class Pelias extends AbstractHttpProvider implements Provider
     /**
      * {@inheritdoc}
      */
-    abstract public function reverseQuery(ReverseQuery $query): Collection;
+    public function reverseQuery(ReverseQuery $query): Collection
+    {
+        return $this->executeQuery($this->getReverseQueryUrl($query));
+    }
 
     /**
      * {@inheritdoc}
      */
-    abstract public function getName(): string;
+    public function getName(): string
+    {
+        return 'pelias';
+    }
 
     /**
      * @param $url

--- a/src/Provider/Pelias/README.md
+++ b/src/Provider/Pelias/README.md
@@ -1,0 +1,26 @@
+# Pelias Geocoder (abstract) provider
+
+[![Build Status](https://travis-ci.org/geocoder-php/pelias-provider.svg?branch=master)](http://travis-ci.org/geocoder-php/pelias-provider)
+[![Latest Stable Version](https://poser.pugx.org/geocoder-php/pelias-provider/v/stable)](https://packagist.org/packages/geocoder-php/pelias-provider)
+[![Total Downloads](https://poser.pugx.org/geocoder-php/pelias-provider/downloads)](https://packagist.org/packages/geocoder-php/pelias-provider)
+[![Monthly Downloads](https://poser.pugx.org/geocoder-php/pelias-provider/d/monthly.png)](https://packagist.org/packages/geocoder-php/pelias-provider)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/geocoder-php/pelias-provider.svg?style=flat-square)](https://scrutinizer-ci.com/g/geocoder-php/pelias-provider)
+[![Quality Score](https://img.shields.io/scrutinizer/g/geocoder-php/pelias-provider.svg?style=flat-square)](https://scrutinizer-ci.com/g/geocoder-php/pelias-provider)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
+
+This is the Pelias **abstract** provider from the PHP Geocoder. This is a **READ ONLY** repository. See the
+[main repo](https://github.com/geocoder-php/Geocoder) for information and documentation.
+
+## Pelias
+
+Pelias is an open-source geocoder. You can find its [documentation here](https://github.com/pelias/documentation).
+
+Pelias does not provide an API per se but other API (and providers) are based on Pelias and extend this provider.
+
+For instance:
+- Geocode Earth ([Website](https://geocode.earth/) & [Provider](https://github.com/geocoder-php/geocode-earth-provider))
+
+## Contribute
+
+Contributions are very welcome! Send a pull request to the [main repository](https://github.com/geocoder-php/Geocoder) or
+report any issues you find on the [issue tracker](https://github.com/geocoder-php/Geocoder/issues).

--- a/src/Provider/Pelias/README.md
+++ b/src/Provider/Pelias/README.md
@@ -15,7 +15,8 @@ This is the Pelias provider from the PHP Geocoder. This is a **READ ONLY** repos
 
 Pelias is an open-source geocoder. You can find its [documentation here](https://github.com/pelias/documentation).
 
-Pelias does not provide an API per se but other API (and providers) are based on Pelias and extend this provider.
+Pelias does not provide an API per se but other API (and providers) are based on Pelias and extend this provider.  
+You can run your own Pelias instance on your server, see [documentation](https://github.com/pelias/documentation/blob/master/getting_started_install.md) to install it.
 
 For instance:
 

--- a/src/Provider/Pelias/README.md
+++ b/src/Provider/Pelias/README.md
@@ -1,4 +1,4 @@
-# Pelias Geocoder (abstract) provider
+# Pelias Geocoder provider
 
 [![Build Status](https://travis-ci.org/geocoder-php/pelias-provider.svg?branch=master)](http://travis-ci.org/geocoder-php/pelias-provider)
 [![Latest Stable Version](https://poser.pugx.org/geocoder-php/pelias-provider/v/stable)](https://packagist.org/packages/geocoder-php/pelias-provider)
@@ -8,7 +8,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/geocoder-php/pelias-provider.svg?style=flat-square)](https://scrutinizer-ci.com/g/geocoder-php/pelias-provider)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 
-This is the Pelias **abstract** provider from the PHP Geocoder. This is a **READ ONLY** repository. See the
+This is the Pelias provider from the PHP Geocoder. This is a **READ ONLY** repository. See the
 [main repo](https://github.com/geocoder-php/Geocoder) for information and documentation.
 
 ## Pelias
@@ -18,7 +18,14 @@ Pelias is an open-source geocoder. You can find its [documentation here](https:/
 Pelias does not provide an API per se but other API (and providers) are based on Pelias and extend this provider.
 
 For instance:
+
 - Geocode Earth ([Website](https://geocode.earth/) & [Provider](https://github.com/geocoder-php/geocode-earth-provider))
+
+## Install
+
+```bash
+composer require geocoder-php/pelias-provider
+```
 
 ## Contribute
 

--- a/src/Provider/Pelias/Tests/IntegrationTest.php
+++ b/src/Provider/Pelias/Tests/IntegrationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Geocoder\Provider\Pelias\Tests;
+
+use Geocoder\IntegrationTest\ProviderIntegrationTest;
+use Geocoder\Provider\Pelias\Pelias;
+use Http\Client\HttpClient;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class IntegrationTest extends ProviderIntegrationTest
+{
+    protected $skippedTests = [
+        'testGeocodeQuery'              => 'No Pelias "default" instance.',
+        'testGeocodeQueryWithNoResults' => 'No Pelias "default" instance.',
+        'testReverseQuery'              => 'No Pelias "default" instance.',
+        'testReverseQueryWithNoResults' => 'No Pelias "default" instance.',
+    ];
+
+    protected $testIpv4 = false;
+
+    protected $testIpv6 = false;
+
+    protected function createProvider(HttpClient $httpClient)
+    {
+        return new Pelias($httpClient, 'http://localhost/');
+    }
+
+    protected function getCacheDir()
+    {
+        return __DIR__ . '/.cached_responses';
+    }
+
+    protected function getApiKey()
+    {
+        return null;
+    }
+}

--- a/src/Provider/Pelias/Tests/IntegrationTest.php
+++ b/src/Provider/Pelias/Tests/IntegrationTest.php
@@ -22,9 +22,9 @@ use Http\Client\HttpClient;
 class IntegrationTest extends ProviderIntegrationTest
 {
     protected $skippedTests = [
-        'testGeocodeQuery'              => 'No Pelias "default" instance.',
+        'testGeocodeQuery' => 'No Pelias "default" instance.',
         'testGeocodeQueryWithNoResults' => 'No Pelias "default" instance.',
-        'testReverseQuery'              => 'No Pelias "default" instance.',
+        'testReverseQuery' => 'No Pelias "default" instance.',
         'testReverseQueryWithNoResults' => 'No Pelias "default" instance.',
     ];
 
@@ -39,7 +39,7 @@ class IntegrationTest extends ProviderIntegrationTest
 
     protected function getCacheDir()
     {
-        return __DIR__ . '/.cached_responses';
+        return __DIR__.'/.cached_responses';
     }
 
     protected function getApiKey()

--- a/src/Provider/Pelias/Tests/PeliasTest.php
+++ b/src/Provider/Pelias/Tests/PeliasTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Geocoder\Provider\Pelias\Tests;
+
+use Geocoder\Collection;
+use Geocoder\IntegrationTest\BaseTestCase;
+use Geocoder\Provider\Pelias\Pelias;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\ReverseQuery;
+
+class PeliasTest extends BaseTestCase
+{
+    protected function getCacheDir()
+    {
+        return __DIR__ . '/.cached_responses';
+    }
+
+    public function testGetName()
+    {
+        $provider = new Pelias($this->getMockedHttpClient(), 'http://localhost/');
+        $this->assertEquals('pelias', $provider->getName());
+    }
+
+    public function testGeocode()
+    {
+        $provider = new Pelias($this->getMockedHttpClient('{}'), 'http://localhost/');
+        $result = $provider->geocodeQuery(GeocodeQuery::create('foobar'));
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals(0, $result->count());
+    }
+
+    public function testReverse()
+    {
+        $provider = new Pelias($this->getMockedHttpClient('{}'), 'http://localhost/');
+        $result = $provider->reverseQuery(ReverseQuery::fromCoordinates(0, 0));
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals(0, $result->count());
+    }
+
+    /**
+     * @expectedException \Geocoder\Exception\QuotaExceeded
+     * @expectedExceptionMessage Valid request but quota exceeded.
+     */
+    public function testGeocodeQuotaExceeded()
+    {
+        $provider = new Pelias(
+            $this->getMockedHttpClient(
+                '{
+                    "meta": {
+                        "version": 1,
+                        "status_code": 429
+                    },
+                    "results": {
+                        "error": {
+                            "type": "QpsExceededError",
+                            "message": "Queries per second exceeded: Queries exceeded (6 allowed)."
+                        }
+                    }
+                }'
+            ),
+            'http://localhost/'
+        );
+        $provider->geocodeQuery(GeocodeQuery::create('New York'));
+    }
+
+    /**
+     * @expectedException \Geocoder\Exception\InvalidCredentials
+     * @expectedExceptionMessage Invalid or missing api key.
+     */
+    public function testGeocodeInvalidApiKey()
+    {
+        $provider = new Pelias(
+            $this->getMockedHttpClient(
+                '{
+                    "meta": {
+                        "version": 1,
+                        "status_code": 403
+                    },
+                    "results": {
+                        "error": {
+                            "type": "KeyError",
+                            "message": "No api_key specified."
+                        }
+                    }
+                }'
+            ),
+            'http://localhost/'
+        );
+        $provider->geocodeQuery(GeocodeQuery::create('New York'));
+    }
+
+    /**
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The Pelias provider does not support IP addresses, only street addresses.
+     */
+    public function testGeocodeWithLocalhostIPv4()
+    {
+        $provider = new Pelias($this->getMockedHttpClient(), 'http://localhost/');
+        $provider->geocodeQuery(GeocodeQuery::create('127.0.0.1'));
+    }
+
+    /**
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The Pelias provider does not support IP addresses, only street addresses.
+     */
+    public function testGeocodeWithLocalhostIPv6()
+    {
+        $provider = new Pelias($this->getMockedHttpClient(), 'http://localhost/');
+        $provider->geocodeQuery(GeocodeQuery::create('::1'));
+    }
+
+    /**
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The Pelias provider does not support IP addresses, only street addresses.
+     */
+    public function testGeocodeWithRealIPv4()
+    {
+        $provider = new Pelias($this->getMockedHttpClient(), 'http://localhost/');
+        $provider->geocodeQuery(GeocodeQuery::create('74.200.247.59'));
+    }
+
+    /**
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The Pelias provider does not support IP addresses, only street addresses.
+     */
+    public function testGeocodeWithRealIPv6()
+    {
+        $provider = new Pelias($this->getMockedHttpClient(), 'http://localhost/');
+        $provider->geocodeQuery(GeocodeQuery::create('::ffff:74.200.247.59'));
+    }
+}

--- a/src/Provider/Pelias/Tests/PeliasTest.php
+++ b/src/Provider/Pelias/Tests/PeliasTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Geocoder\Provider\Pelias\Tests;
 
 use Geocoder\Collection;
+use Geocoder\Exception\UnsupportedOperation;
 use Geocoder\IntegrationTest\BaseTestCase;
 use Geocoder\Provider\Pelias\Pelias;
 use Geocoder\Query\GeocodeQuery;
@@ -49,94 +50,38 @@ class PeliasTest extends BaseTestCase
         $this->assertEquals(0, $result->count());
     }
 
-    /**
-     * @expectedException \Geocoder\Exception\QuotaExceeded
-     * @expectedExceptionMessage Valid request but quota exceeded.
-     */
-    public function testGeocodeQuotaExceeded()
-    {
-        $provider = new Pelias(
-            $this->getMockedHttpClient(
-                '{
-                    "meta": {
-                        "version": 1,
-                        "status_code": 429
-                    },
-                    "results": {
-                        "error": {
-                            "type": "QpsExceededError",
-                            "message": "Queries per second exceeded: Queries exceeded (6 allowed)."
-                        }
-                    }
-                }'
-            ),
-            'http://localhost/'
-        );
-        $provider->geocodeQuery(GeocodeQuery::create('New York'));
-    }
-
-    /**
-     * @expectedException \Geocoder\Exception\InvalidCredentials
-     * @expectedExceptionMessage Invalid or missing api key.
-     */
-    public function testGeocodeInvalidApiKey()
-    {
-        $provider = new Pelias(
-            $this->getMockedHttpClient(
-                '{
-                    "meta": {
-                        "version": 1,
-                        "status_code": 403
-                    },
-                    "results": {
-                        "error": {
-                            "type": "KeyError",
-                            "message": "No api_key specified."
-                        }
-                    }
-                }'
-            ),
-            'http://localhost/'
-        );
-        $provider->geocodeQuery(GeocodeQuery::create('New York'));
-    }
-
-    /**
-     * @expectedException \Geocoder\Exception\UnsupportedOperation
-     * @expectedExceptionMessage The Pelias provider does not support IP addresses, only street addresses.
-     */
     public function testGeocodeWithLocalhostIPv4()
     {
+        $this->expectException(UnsupportedOperation::class);
+        $this->expectExceptionMessage('The pelias provider does not support IP addresses, only street addresses.');
+
         $provider = new Pelias($this->getMockedHttpClient(), 'http://localhost/');
         $provider->geocodeQuery(GeocodeQuery::create('127.0.0.1'));
     }
 
-    /**
-     * @expectedException \Geocoder\Exception\UnsupportedOperation
-     * @expectedExceptionMessage The Pelias provider does not support IP addresses, only street addresses.
-     */
     public function testGeocodeWithLocalhostIPv6()
     {
+        $this->expectException(UnsupportedOperation::class);
+        $this->expectExceptionMessage('The pelias provider does not support IP addresses, only street addresses.');
+
         $provider = new Pelias($this->getMockedHttpClient(), 'http://localhost/');
         $provider->geocodeQuery(GeocodeQuery::create('::1'));
     }
 
-    /**
-     * @expectedException \Geocoder\Exception\UnsupportedOperation
-     * @expectedExceptionMessage The Pelias provider does not support IP addresses, only street addresses.
-     */
     public function testGeocodeWithRealIPv4()
     {
+        $this->expectException(UnsupportedOperation::class);
+        $this->expectExceptionMessage('The pelias provider does not support IP addresses, only street addresses.');
+
         $provider = new Pelias($this->getMockedHttpClient(), 'http://localhost/');
         $provider->geocodeQuery(GeocodeQuery::create('74.200.247.59'));
     }
 
-    /**
-     * @expectedException \Geocoder\Exception\UnsupportedOperation
-     * @expectedExceptionMessage The Pelias provider does not support IP addresses, only street addresses.
-     */
     public function testGeocodeWithRealIPv6()
     {
+        $this->expectException(UnsupportedOperation::class);
+        $this->expectExceptionMessage('The pelias provider does not support IP addresses, only street addresses.');
+
         $provider = new Pelias($this->getMockedHttpClient(), 'http://localhost/');
         $provider->geocodeQuery(GeocodeQuery::create('::ffff:74.200.247.59'));
     }

--- a/src/Provider/Pelias/Tests/PeliasTest.php
+++ b/src/Provider/Pelias/Tests/PeliasTest.php
@@ -22,7 +22,7 @@ class PeliasTest extends BaseTestCase
 {
     protected function getCacheDir()
     {
-        return __DIR__ . '/.cached_responses';
+        return __DIR__.'/.cached_responses';
     }
 
     public function testGetName()

--- a/src/Provider/Pelias/composer.json
+++ b/src/Provider/Pelias/composer.json
@@ -1,0 +1,47 @@
+{
+    "name": "geocoder-php/pelias-provider",
+    "type": "library",
+    "description": "Geocoder Pelias abstract adapter",
+    "keywords": [],
+    "homepage": "http://geocoder-php.org/Geocoder/",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "William Durand",
+            "email": "william.durand1@gmail.com"
+        }
+    ],
+    "require": {
+        "php": "^7.0",
+        "geocoder-php/common-http": "^4.0",
+        "willdurand/geocoder": "^4.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.5 || ^7.5",
+        "geocoder-php/provider-integration-tests": "^1.0",
+        "php-http/message": "^1.0",
+        "php-http/curl-client": "^1.7"
+    },
+    "provide": {
+        "geocoder-php/provider-implementation": "1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Geocoder\\Provider\\Pelias\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    }
+}

--- a/src/Provider/Pelias/phpunit.xml.dist
+++ b/src/Provider/Pelias/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <php>
+        <server name="USE_CACHED_RESPONSES" value="true" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Geocoder Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Pelias is an open-source geocoder. You can find its [documentation here](https://github.com/pelias/documentation).
Pelias does not provide an API per se but other API (and providers) are based on Pelias and extend this provider.

Geocode Earth will be updated to extend this new provider (see #1005).
