### PR TITLE
fix: add postal_code_suffix to google maps provider

### DIFF
--- a/src/Provider/GoogleMaps/Model/GoogleAddress.php
+++ b/src/Provider/GoogleMaps/Model/GoogleAddress.php
@@ -54,6 +54,11 @@ final class GoogleAddress extends Address
     /**
      * @var string|null
      */
+    private $postalCodeSuffix;
+
+    /**
+     * @var string|null
+     */
     private $political;
 
     /**
@@ -261,6 +266,27 @@ final class GoogleAddress extends Address
     {
         $new = clone $this;
         $new->intersection = $intersection;
+
+        return $new;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getPostalCodeSuffix()
+    {
+        return $this->postalCodeSuffix;
+    }
+
+    /**
+     * @param string|null $postalCodeSuffix
+     *
+     * @return GoogleAddress
+     */
+    public function withPostalCodeSuffix(string $postalCodeSuffix = null)
+    {
+        $new = clone $this;
+        $new->postalCodeSuffix = $postalCodeSuffix;
 
         return $new;
     }

--- a/src/Provider/GoogleMaps/Tests/.cached_responses/maps.googleapis.com_db9847acc1c9be42852ac89be82c87e3cecdd7c2
+++ b/src/Provider/GoogleMaps/Tests/.cached_responses/maps.googleapis.com_db9847acc1c9be42852ac89be82c87e3cecdd7c2
@@ -1,0 +1,79 @@
+s:2474:"{
+   "results" : [
+      {
+         "address_components" : [
+            {
+               "long_name" : "900",
+               "short_name" : "900",
+               "types" : [ "street_number" ]
+            },
+            {
+               "long_name" : "South Oak Park Avenue",
+               "short_name" : "S Oak Park Ave",
+               "types" : [ "route" ]
+            },
+            {
+               "long_name" : "Oak Park",
+               "short_name" : "Oak Park",
+               "types" : [ "locality", "political" ]
+            },
+            {
+               "long_name" : "Oak Park Township",
+               "short_name" : "Oak Park Township",
+               "types" : [ "administrative_area_level_3", "political" ]
+            },
+            {
+               "long_name" : "Cook County",
+               "short_name" : "Cook County",
+               "types" : [ "administrative_area_level_2", "political" ]
+            },
+            {
+               "long_name" : "Illinois",
+               "short_name" : "IL",
+               "types" : [ "administrative_area_level_1", "political" ]
+            },
+            {
+               "long_name" : "United States",
+               "short_name" : "US",
+               "types" : [ "country", "political" ]
+            },
+            {
+               "long_name" : "60304",
+               "short_name" : "60304",
+               "types" : [ "postal_code" ]
+            },
+            {
+               "long_name" : "1936",
+               "short_name" : "1936",
+               "types" : [ "postal_code_suffix" ]
+            }
+         ],
+         "formatted_address" : "900 S Oak Park Ave, Oak Park, IL 60304, USA",
+         "geometry" : {
+            "location" : {
+               "lat" : 41.8718539,
+               "lng" : -87.79375659999999
+            },
+            "location_type" : "ROOFTOP",
+            "viewport" : {
+               "northeast" : {
+                  "lat" : 41.87320288029149,
+                  "lng" : -87.7924076197085
+               },
+               "southwest" : {
+                  "lat" : 41.87050491970849,
+                  "lng" : -87.79510558029151
+               }
+            }
+         },
+         "place_id" : "ChIJK6OxB5M0DogRla1PTqvu7gk",
+         "plus_code" : {
+            "compound_code" : "V6C4+PF Oak Park, Oak Park Township, IL, United States",
+            "global_code" : "86HJV6C4+PF"
+         },
+         "types" : [ "street_address" ]
+      }
+   ],
+   "status" : "OK"
+}
+";

--- a/src/Provider/GoogleMaps/Tests/GoogleMapsTest.php
+++ b/src/Provider/GoogleMaps/Tests/GoogleMapsTest.php
@@ -120,6 +120,7 @@ class GoogleMapsTest extends BaseTestCase
 
         // not provided
         $this->assertNull($result->getTimezone());
+        $this->assertNull($result->getPostalCodeSuffix());
     }
 
     public function testGeocodeBoundsWithRealAddressForNonRooftopLocation()
@@ -534,6 +535,22 @@ class GoogleMapsTest extends BaseTestCase
         $this->assertInstanceOf(Address::class, $result);
         $this->assertInstanceOf('\Geocoder\Model\AdminLevelCollection', $result->getSubLocalityLevels());
         $this->assertEquals('Iijima', $result->getSubLocalityLevels()->get(2)->getName());
+        $this->assertEquals(false, $result->isPartialMatch());
+    }
+
+    public function testGeocodeWithPostalCodeSuffixComponent()
+    {
+        $provider = $this->getGoogleMapsProvider();
+        $results = $provider->geocodeQuery(GeocodeQuery::create('900 S Oak Park Ave, Oak Park, IL 60304'));
+
+        $this->assertInstanceOf(AddressCollection::class, $results);
+        $this->assertCount(1, $results);
+
+        /** @var GoogleAddress $result */
+        $result = $results->first();
+        $this->assertInstanceOf(Address::class, $result);
+        $this->assertEquals('900 S Oak Park Ave, Oak Park, IL 60304, USA', $result->getFormattedAddress());
+        $this->assertEquals('1936', $result->getPostalCodeSuffix());
         $this->assertEquals(false, $result->isPartialMatch());
     }
 


### PR DESCRIPTION
The google maps provider is missing the `postal_code_suffix` field as per issue #1006.

This adds the field + test, and fixes some styling issues.

Closes #1006 