### PR TITLE
Fix building ProviderNotRegistered exception message

### DIFF
--- a/src/Common/ProviderAggregator.php
+++ b/src/Common/ProviderAggregator.php
@@ -145,7 +145,7 @@ class ProviderAggregator implements Geocoder
     public function using(string $name): self
     {
         if (!isset($this->providers[$name])) {
-            throw ProviderNotRegistered::create($name ?? '', $this->providers);
+            throw ProviderNotRegistered::create($name, array_keys($this->providers));
         }
 
         $this->provider = $this->providers[$name];

--- a/src/Common/Tests/ProviderAggregatorTest.php
+++ b/src/Common/Tests/ProviderAggregatorTest.php
@@ -85,9 +85,12 @@ class ProviderAggregatorTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\ProviderNotRegistered
+     * @expectedExceptionMessage Provider "non_existant" is not registered, so you cannot use it. Did you forget to register it or made a typo? Registered providers are: test1.
      */
     public function testUsingNonExistantProviderShouldThrowAnException()
     {
+        $this->geocoder->registerProvider(new MockProvider('test1'));
+
         $this->geocoder->using('non_existant');
     }
 


### PR DESCRIPTION
Exception tries to implode the providers list, but providers doesn't have `__toString` implementations  and so it fails.

```
PHP Warning:  Uncaught ErrorException: Catchable Fatal Error: Object of class Geocoder\Plugin\PluginProvider could not be converted to string in ~/www/sf/vendor/willdurand/geocoder/Exception/ProviderNotRegistered.php:29
Stack trace:
#0 ~/www/sf/vendor/willdurand/geocoder/ProviderAggregator.php(148): Geocoder\Exception\ProviderNotRegistered::create('address', Array)
#1 ~/www/sf/vendor/willdurand/geocoder-bundle/Command/GeocodeCommand.php(69): Geocoder\ProviderAggregator->using('address')
#2 ~/www/sf/vendor/symfony/console/Command/Command.php(255): Bazinga\GeocoderBundle\Command\GeocodeCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 ~/www/sf/vendor/symfony/console/Application.php(933): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 ~/www/sf in ~/www/sf/vendor/willdurand/geocoder/Exception/ProviderNotRegistered.php on line 29
```