### PR TITLE
docs: update install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ Read more about HTTPlug in [their docs](http://docs.php-http.org/en/latest/httpl
 To install Google Maps geocoder with Guzzle 6 you may run the following command:
 
 ```
-$ composer require geocoder-php/google-maps-provider php-http/guzzle6-adapter php-http/message
+$ composer require geocoder-php/google-maps-provider php-http/guzzle6-adapter
+```
+
+Or using the curl client (you'll need to provide a PSR7 implementation such as `nyholm/psr7` if not using guzzle)
+
+```
+$ composer geocoder-php/google-maps-provider php-http/curl-client nyholm/psr7
 ```
 
 ### Framework integration


### PR DESCRIPTION
Currently the docs are a little bit unclear in regards to how to use different http drivers.

You don't actually need to install `php-http/message`, guzzle installs their own PSR7 implementation.

I added another example command with the curl client, to demonstrate that a PSR7 implementation is required if not using guzzle.

Closes #1021 