### PR TITLE
Exception interface should extend Throwable interface

### DIFF
--- a/src/Common/Exception/Exception.php
+++ b/src/Common/Exception/Exception.php
@@ -15,6 +15,6 @@ namespace Geocoder\Exception;
 /**
  * @author William Durand <william.durand1@gmail.com>
  */
-interface Exception
+interface Exception extends \Throwable
 {
 }


### PR DESCRIPTION
PhpStan warns of an error about this

```
124    PHPDoc tag @throws with type Geocoder\Exception\Exception is not subtype of Throwable
```


And this has no impact as each exception inherits from \Exception