### PR TITLE
docs: update framework section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ $ composer require geocoder-php/google-maps-provider php-http/curl-client nyholm
 
 ### Framework integration
 
-If you are using a framework then you may be interested in our excellent framework integrations. Check out our
-[Laravel Package](https://github.com/geocoder-php/GeocoderLaravel) and our [Symfony Bundle](https://github.com/geocoder-php/BazingaGeocoderBundle).
+If you are using a framework then you may be interested in our excellent framework integrations.
 
+Framework       | Package  | Stats
+:------------- |:--------- |:-------
+Laravel | [geocoder-php/GeocoderLaravel](https://github.com/geocoder-php/GeocoderLaravel) | [![GitHub release](https://img.shields.io/packagist/v/toin0u/geocoder-laravel.svg)](https://github.com/geocoder-php/GeocoderLaravel/releases) [![Packagist](https://img.shields.io/packagist/dt/toin0u/geocoder-laravel.svg)](https://packagist.org/packages/toin0u/geocoder-laravel)
+Symfony | [geocoder-php/BazingaGeocoderBundle](https://github.com/geocoder-php/BazingaGeocoderBundle) | [![Latest Stable Version](https://img.shields.io/packagist/v/willdurand/geocoder-bundle)](https://packagist.org/packages/willdurand/geocoder-bundle) [![Total Downloads](https://img.shields.io/packagist/dt/willdurand/geocoder-bundle)](https://packagist.org/packages/willdurand/geocoder-bundle)
 
 Cookbook
 --------


### PR DESCRIPTION
I was planning in adding in the other ones that were missing, but these two seem to be the only ones with active support :(

I did find this Zend module, but it's using 3x and hasn't been updated in ages.
https://github.com/geocoder-php/GeocoderModule
There's a fork here that's more up to date however:
https://github.com/mb-tec/GeocoderModule

The silex package is even older, on 2.x and not updated in 3y:
https://github.com/geocoder-php/GeocoderServiceProvider

There's also a cakephp library out there, but it's on 3x as well
https://github.com/dereuromark/cakephp-geo

cc @jbelien 