### PR TITLE
Add AddressCollection::fromCache

### DIFF
--- a/src/Common/Model/AddressCollection.php
+++ b/src/Common/Model/AddressCollection.php
@@ -25,11 +25,17 @@ final class AddressCollection implements Collection
     private $locations;
 
     /**
+     * @var bool
+     */
+    private $fromCache = false;
+
+    /**
      * @param Location[] $locations
      */
-    public function __construct(array $locations = [])
+    public function __construct(array $locations = [], bool $fromCache = false)
     {
         $this->locations = array_values($locations);
+        $this->fromCache = $fromCache;
     }
 
     /**
@@ -102,5 +108,25 @@ final class AddressCollection implements Collection
     public function all(): array
     {
         return $this->locations;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFromCache(): bool
+    {
+        return $this->fromCache;
+    }
+
+    /**
+     * @param bool $fromCache
+     *
+     * @return self
+     */
+    public function setFromCache(bool $fromCache)
+    {
+        $this->fromCache = $fromCache;
+
+        return $this;
     }
 }

--- a/src/Provider/Cache/ProviderCache.php
+++ b/src/Provider/Cache/ProviderCache.php
@@ -59,6 +59,8 @@ class ProviderCache implements Provider
     {
         $cacheKey = $this->getCacheKey($query);
         if (null !== $result = $this->cache->get($cacheKey)) {
+            $result->setFromCache(true);
+
             return $result;
         }
 


### PR DESCRIPTION
Actually when results are coming from cache, there is no way to know it

It could be useful sometimes, for cache-invalidation purposes.

What do you think?