### PR TITLE
[Google Maps] Added missing nullable return type

### DIFF
--- a/src/Provider/GoogleMapsPlaces/Model/GooglePlace.php
+++ b/src/Provider/GoogleMapsPlaces/Model/GooglePlace.php
@@ -194,7 +194,7 @@ final class GooglePlace extends Address
     /**
      * @return PlusCode|null
      */
-    public function getPlusCode(): PlusCode
+    public function getPlusCode(): ?PlusCode
     {
         return $this->plusCode;
     }


### PR DESCRIPTION
Sometimes Google Maps does not return a Plus Code.
PoC:
{"query":"[object] (Geocoder\\Query\\GeocodeQuery: GeocodeQuery: {\"text\":\"Port of Ijmuiden, North Holland, Netherlands, Port Ijmuiden Port\",\"bounds\":\"null\",\"locale\":null,\"limit\":5,\"data\":{\"mode\":\"search\",\"fields\":\"formatted_address, geometry, icon, name, place_id, plus_code, types\"}})"} 

The first 2 results have a PlusCode but the rest do not, which generates an exception.