### PR TITLE
Remove deprecated `sudo` key in Travis CI config files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 addons:
     apt_packages:

--- a/src/Common/.travis.yml
+++ b/src/Common/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Http/.travis.yml
+++ b/src/Http/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Plugin/.travis.yml
+++ b/src/Plugin/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/AlgoliaPlaces/.travis.yml
+++ b/src/Provider/AlgoliaPlaces/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/ArcGISOnline/.travis.yml
+++ b/src/Provider/ArcGISOnline/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/BingMaps/.travis.yml
+++ b/src/Provider/BingMaps/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Cache/.travis.yml
+++ b/src/Provider/Cache/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Chain/.travis.yml
+++ b/src/Provider/Chain/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/FreeGeoIp/.travis.yml
+++ b/src/Provider/FreeGeoIp/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/GeoIP2/.travis.yml
+++ b/src/Provider/GeoIP2/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/GeoIPs/.travis.yml
+++ b/src/Provider/GeoIPs/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/GeoPlugin/.travis.yml
+++ b/src/Provider/GeoPlugin/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/GeocodeEarth/.travis.yml
+++ b/src/Provider/GeocodeEarth/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Geoip/.travis.yml
+++ b/src/Provider/Geoip/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Geonames/.travis.yml
+++ b/src/Provider/Geonames/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/GoogleMaps/.travis.yml
+++ b/src/Provider/GoogleMaps/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/GoogleMapsPlaces/.travis.yml
+++ b/src/Provider/GoogleMapsPlaces/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/GraphHopper/.travis.yml
+++ b/src/Provider/GraphHopper/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Here/.travis.yml
+++ b/src/Provider/Here/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/HostIp/.travis.yml
+++ b/src/Provider/HostIp/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/IP2Location/.travis.yml
+++ b/src/Provider/IP2Location/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/IP2LocationBinary/.travis.yml
+++ b/src/Provider/IP2LocationBinary/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/IpInfo/.travis.yml
+++ b/src/Provider/IpInfo/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/IpInfoDb/.travis.yml
+++ b/src/Provider/IpInfoDb/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Ipstack/.travis.yml
+++ b/src/Provider/Ipstack/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/LocationIQ/.travis.yml
+++ b/src/Provider/LocationIQ/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/MapQuest/.travis.yml
+++ b/src/Provider/MapQuest/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Mapbox/.travis.yml
+++ b/src/Provider/Mapbox/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Mapzen/.travis.yml
+++ b/src/Provider/Mapzen/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/MaxMind/.travis.yml
+++ b/src/Provider/MaxMind/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/MaxMindBinary/.travis.yml
+++ b/src/Provider/MaxMindBinary/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Nominatim/.travis.yml
+++ b/src/Provider/Nominatim/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/OpenCage/.travis.yml
+++ b/src/Provider/OpenCage/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/OpenRouteService/.travis.yml
+++ b/src/Provider/OpenRouteService/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Pelias/.travis.yml
+++ b/src/Provider/Pelias/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Photon/.travis.yml
+++ b/src/Provider/Photon/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/PickPoint/.travis.yml
+++ b/src/Provider/PickPoint/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/TomTom/.travis.yml
+++ b/src/Provider/TomTom/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 

--- a/src/Provider/Yandex/.travis.yml
+++ b/src/Provider/Yandex/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php: 7.2
 


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

![image](https://user-images.githubusercontent.com/1150563/86508711-8c295900-bde2-11ea-9d1d-b565fb7c9905.png)
