### PR TITLE
Improve functions signature

### DIFF
--- a/src/Common/Collection.php
+++ b/src/Common/Collection.php
@@ -38,7 +38,7 @@ interface Collection extends \IteratorAggregate, \Countable
     /**
      * @return Location[]
      */
-    public function slice(int $offset, int $length = null);
+    public function slice(int $offset, int $length = null): array;
 
     /**
      * @return bool

--- a/src/Common/Location.php
+++ b/src/Common/Location.php
@@ -30,14 +30,14 @@ interface Location
      *
      * @return Coordinates|null
      */
-    public function getCoordinates();
+    public function getCoordinates(): ?Coordinates;
 
     /**
      * Returns the bounds value object.
      *
      * @return Bounds|null
      */
-    public function getBounds();
+    public function getBounds(): ?Bounds;
 
     /**
      * Returns the street number value.
@@ -51,21 +51,21 @@ interface Location
      *
      * @return string|null
      */
-    public function getStreetName();
+    public function getStreetName(): ?string;
 
     /**
      * Returns the city or locality value.
      *
      * @return string|null
      */
-    public function getLocality();
+    public function getLocality(): ?string;
 
     /**
      * Returns the postal code or zipcode value.
      *
      * @return string|null
      */
-    public function getPostalCode();
+    public function getPostalCode(): ?string;
 
     /**
      * Returns the locality district, or
@@ -73,7 +73,7 @@ interface Location
      *
      * @return string|null
      */
-    public function getSubLocality();
+    public function getSubLocality(): ?string;
 
     /**
      * Returns the administrative levels.
@@ -89,7 +89,7 @@ interface Location
      *
      * @return Country|null
      */
-    public function getCountry();
+    public function getCountry(): ?Country;
 
     /**
      * Returns the timezone for the Location. The timezone MUST be in the list of supported timezones.
@@ -98,7 +98,7 @@ interface Location
      *
      * @return string|null
      */
-    public function getTimezone();
+    public function getTimezone(): ?string;
 
     /**
      * Returns an array with data indexed by name.

--- a/src/Common/Model/Address.php
+++ b/src/Common/Model/Address.php
@@ -90,15 +90,15 @@ class Address implements Location
     public function __construct(
         string $providedBy,
         AdminLevelCollection $adminLevels,
-        Coordinates $coordinates = null,
-        Bounds $bounds = null,
-        string $streetNumber = null,
-        string $streetName = null,
-        string $postalCode = null,
-        string $locality = null,
-        string $subLocality = null,
-        Country $country = null,
-        string $timezone = null
+        ?Coordinates $coordinates = null,
+        ?Bounds $bounds = null,
+        ?string $streetNumber = null,
+        ?string $streetName = null,
+        ?string $postalCode = null,
+        ?string $locality = null,
+        ?string $subLocality = null,
+        ?Country $country = null,
+        ?string $timezone = null
     ) {
         $this->providedBy = $providedBy;
         $this->adminLevels = $adminLevels;
@@ -124,7 +124,7 @@ class Address implements Location
     /**
      * {@inheritdoc}
      */
-    public function getCoordinates()
+    public function getCoordinates(): ?Coordinates
     {
         return $this->coordinates;
     }
@@ -132,7 +132,7 @@ class Address implements Location
     /**
      * {@inheritdoc}
      */
-    public function getBounds()
+    public function getBounds(): ?Bounds
     {
         return $this->bounds;
     }
@@ -148,7 +148,7 @@ class Address implements Location
     /**
      * {@inheritdoc}
      */
-    public function getStreetName()
+    public function getStreetName(): ?string
     {
         return $this->streetName;
     }
@@ -156,7 +156,7 @@ class Address implements Location
     /**
      * {@inheritdoc}
      */
-    public function getLocality()
+    public function getLocality(): ?string
     {
         return $this->locality;
     }
@@ -164,7 +164,7 @@ class Address implements Location
     /**
      * {@inheritdoc}
      */
-    public function getPostalCode()
+    public function getPostalCode(): ?string
     {
         return $this->postalCode;
     }
@@ -172,7 +172,7 @@ class Address implements Location
     /**
      * {@inheritdoc}
      */
-    public function getSubLocality()
+    public function getSubLocality(): ?string
     {
         return $this->subLocality;
     }
@@ -188,7 +188,7 @@ class Address implements Location
     /**
      * {@inheritdoc}
      */
-    public function getCountry()
+    public function getCountry(): ?Country
     {
         return $this->country;
     }
@@ -196,7 +196,7 @@ class Address implements Location
     /**
      * {@inheritdoc}
      */
-    public function getTimezone()
+    public function getTimezone(): ?string
     {
         return $this->timezone;
     }
@@ -271,12 +271,12 @@ class Address implements Location
     }
 
     /**
-     * @param float $latitude
-     * @param float $longitude
+     * @param float|null $latitude
+     * @param float|null $longitude
      *
      * @return Coordinates|null
      */
-    private static function createCoordinates($latitude, $longitude)
+    private static function createCoordinates($latitude, $longitude): ?Coordinates
     {
         if (null === $latitude || null === $longitude) {
             return null;
@@ -291,7 +291,7 @@ class Address implements Location
      *
      * @return Country|null
      */
-    private static function createCountry($name, $code)
+    private static function createCountry(?string $name, ?string $code): ?Country
     {
         if (null === $name && null === $code) {
             return null;
@@ -301,13 +301,14 @@ class Address implements Location
     }
 
     /**
-     * @param float $south
-     * @param float $west
-     * @param float $north
+     * @param float|null $south
+     * @param float|null $west
+     * @param float|null $north
+     * @param float|null $east
      *
      * @return Bounds|null
      */
-    private static function createBounds($south, $west, $north, $east)
+    private static function createBounds(?float $south, ?float $west, ?float $north, ?float $east): ?Bounds
     {
         if (null === $south || null === $west || null === $north || null === $east) {
             return null;

--- a/src/Common/Model/AddressBuilder.php
+++ b/src/Common/Model/AddressBuilder.php
@@ -171,7 +171,7 @@ final class AddressBuilder
      *
      * @return AddressBuilder
      */
-    public function addAdminLevel(int $level, string $name, string $code = null): self
+    public function addAdminLevel(int $level, string $name, ?string $code = null): self
     {
         $this->adminLevels[] = new AdminLevel($level, $name, $code);
 
@@ -183,7 +183,7 @@ final class AddressBuilder
      *
      * @return AddressBuilder
      */
-    public function setStreetNumber($streetNumber): self
+    public function setStreetNumber(?string $streetNumber): self
     {
         $this->streetNumber = $streetNumber;
 
@@ -195,7 +195,7 @@ final class AddressBuilder
      *
      * @return AddressBuilder
      */
-    public function setStreetName($streetName): self
+    public function setStreetName(?string $streetName): self
     {
         $this->streetName = $streetName;
 
@@ -207,7 +207,7 @@ final class AddressBuilder
      *
      * @return AddressBuilder
      */
-    public function setLocality($locality): self
+    public function setLocality(?string $locality): self
     {
         $this->locality = $locality;
 
@@ -219,7 +219,7 @@ final class AddressBuilder
      *
      * @return AddressBuilder
      */
-    public function setPostalCode($postalCode): self
+    public function setPostalCode(?string $postalCode): self
     {
         $this->postalCode = $postalCode;
 
@@ -231,7 +231,7 @@ final class AddressBuilder
      *
      * @return AddressBuilder
      */
-    public function setSubLocality($subLocality): self
+    public function setSubLocality(?string $subLocality): self
     {
         $this->subLocality = $subLocality;
 
@@ -255,7 +255,7 @@ final class AddressBuilder
      *
      * @return AddressBuilder
      */
-    public function setCountry($country): self
+    public function setCountry(?string $country): self
     {
         $this->country = $country;
 
@@ -267,7 +267,7 @@ final class AddressBuilder
      *
      * @return AddressBuilder
      */
-    public function setCountryCode($countryCode): self
+    public function setCountryCode(?string $countryCode): self
     {
         $this->countryCode = $countryCode;
 
@@ -279,7 +279,7 @@ final class AddressBuilder
      *
      * @return AddressBuilder
      */
-    public function setTimezone($timezone): self
+    public function setTimezone(?string $timezone): self
     {
         $this->timezone = $timezone;
 

--- a/src/Common/Model/AddressCollection.php
+++ b/src/Common/Model/AddressCollection.php
@@ -35,7 +35,7 @@ final class AddressCollection implements Collection
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->all());
     }
@@ -43,7 +43,7 @@ final class AddressCollection implements Collection
     /**
      * {@inheritdoc}
      */
-    public function count()
+    public function count(): int
     {
         return count($this->locations);
     }
@@ -71,7 +71,7 @@ final class AddressCollection implements Collection
     /**
      * @return Location[]
      */
-    public function slice(int $offset, int $length = null)
+    public function slice(int $offset, int $length = null): array
     {
         return array_slice($this->locations, $offset, $length);
     }

--- a/src/Common/Model/AdminLevel.php
+++ b/src/Common/Model/AdminLevel.php
@@ -37,7 +37,7 @@ final class AdminLevel
      * @param string      $name
      * @param string|null $code
      */
-    public function __construct(int $level, string $name, string $code = null)
+    public function __construct(int $level, string $name, ?string $code = null)
     {
         $this->level = $level;
         $this->name = $name;
@@ -69,7 +69,7 @@ final class AdminLevel
      *
      * @return string|null
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }

--- a/src/Common/Model/AdminLevelCollection.php
+++ b/src/Common/Model/AdminLevelCollection.php
@@ -86,7 +86,7 @@ final class AdminLevelCollection implements \IteratorAggregate, \Countable
      *
      * @return AdminLevel[]
      */
-    public function slice(int $offset, int $length = null): array
+    public function slice(int $offset, ?int $length = null): array
     {
         return array_slice($this->adminLevels, $offset, $length, true);
     }

--- a/src/Common/Model/Country.php
+++ b/src/Common/Model/Country.php
@@ -35,7 +35,7 @@ final class Country
      * @param string $name
      * @param string $code
      */
-    public function __construct(string $name = null, string $code = null)
+    public function __construct(?string $name = null, ?string $code = null)
     {
         if (null === $name && null === $code) {
             throw new InvalidArgument('A country must have either a name or a code');
@@ -50,7 +50,7 @@ final class Country
      *
      * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -60,7 +60,7 @@ final class Country
      *
      * @return string|null
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }

--- a/src/Common/ProviderAggregator.php
+++ b/src/Common/ProviderAggregator.php
@@ -49,10 +49,10 @@ class ProviderAggregator implements Geocoder
      * @param callable|null $decider
      * @param int           $limit
      */
-    public function __construct(callable $decider = null, int $limit = Geocoder::DEFAULT_RESULT_LIMIT)
+    public function __construct(?callable $decider = null, int $limit = Geocoder::DEFAULT_RESULT_LIMIT)
     {
         $this->limit = $limit;
-        $this->decider = $decider ?? __CLASS__.'::getProvider';
+        $this->decider = $decider ?? __CLASS__ . '::getProvider';
     }
 
     /**

--- a/src/Common/ProviderAggregator.php
+++ b/src/Common/ProviderAggregator.php
@@ -52,7 +52,7 @@ class ProviderAggregator implements Geocoder
     public function __construct(?callable $decider = null, int $limit = Geocoder::DEFAULT_RESULT_LIMIT)
     {
         $this->limit = $limit;
-        $this->decider = $decider ?? __CLASS__ . '::getProvider';
+        $this->decider = $decider ?? __CLASS__.'::getProvider';
     }
 
     /**

--- a/src/Common/Query/GeocodeQuery.php
+++ b/src/Common/Query/GeocodeQuery.php
@@ -147,7 +147,7 @@ final class GeocodeQuery implements Query
     /**
      * @return Bounds|null
      */
-    public function getBounds()
+    public function getBounds(): ?Bounds
     {
         return $this->bounds;
     }
@@ -155,7 +155,7 @@ final class GeocodeQuery implements Query
     /**
      * @return string|null
      */
-    public function getLocale()
+    public function getLocale(): ?string
     {
         return $this->locale;
     }

--- a/src/Common/Query/Query.php
+++ b/src/Common/Query/Query.php
@@ -42,7 +42,7 @@ interface Query
     /**
      * @return string|null
      */
-    public function getLocale();
+    public function getLocale(): ?string;
 
     /**
      * @return int

--- a/src/Common/Query/ReverseQuery.php
+++ b/src/Common/Query/ReverseQuery.php
@@ -53,7 +53,7 @@ final class ReverseQuery implements Query
      *
      * @return ReverseQuery
      */
-    public static function create(Coordinates $coordinates)
+    public static function create(Coordinates $coordinates): self
     {
         return new self($coordinates);
     }
@@ -64,7 +64,7 @@ final class ReverseQuery implements Query
      *
      * @return ReverseQuery
      */
-    public static function fromCoordinates($latitude, $longitude): self
+    public static function fromCoordinates(float $latitude, float $longitude): self
     {
         return new self(new Coordinates($latitude, $longitude));
     }
@@ -139,9 +139,9 @@ final class ReverseQuery implements Query
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getLocale()
+    public function getLocale(): ?string
     {
         return $this->locale;
     }

--- a/src/Common/StatefulGeocoder.php
+++ b/src/Common/StatefulGeocoder.php
@@ -43,10 +43,10 @@ final class StatefulGeocoder implements Geocoder
     private $provider;
 
     /**
-     * @param Provider $provider
-     * @param string   $locale
+     * @param Provider    $provider
+     * @param string|null $locale
      */
-    public function __construct(Provider $provider, string $locale = null)
+    public function __construct(Provider $provider, ?string $locale = null)
     {
         $this->provider = $provider;
         $this->locale = $locale;

--- a/src/Http/Provider/AbstractHttpProvider.php
+++ b/src/Http/Provider/AbstractHttpProvider.php
@@ -41,7 +41,7 @@ abstract class AbstractHttpProvider extends AbstractProvider
      * @param HttpClient          $client
      * @param MessageFactory|null $factory
      */
-    public function __construct(HttpClient $client, MessageFactory $factory = null)
+    public function __construct(HttpClient $client, ?MessageFactory $factory = null)
     {
         $this->client = $client;
         $this->messageFactory = $factory ?: MessageFactoryDiscovery::find();

--- a/src/Plugin/Plugin/CachePlugin.php
+++ b/src/Plugin/Plugin/CachePlugin.php
@@ -85,6 +85,6 @@ class CachePlugin implements Plugin
         }
 
         // Include the major version number of the geocoder to avoid issues unserializing.
-        return 'v4' . sha1((string) $query);
+        return 'v4'.sha1((string) $query);
     }
 }

--- a/src/Plugin/Plugin/CachePlugin.php
+++ b/src/Plugin/Plugin/CachePlugin.php
@@ -47,7 +47,7 @@ class CachePlugin implements Plugin
      * @param int|null       $lifetime
      * @param int|null       $precision
      */
-    public function __construct(CacheInterface $cache, int $lifetime = null, int $precision = null)
+    public function __construct(CacheInterface $cache, ?int $lifetime = null, ?int $precision = null)
     {
         $this->cache = $cache;
         $this->lifetime = $lifetime;
@@ -85,6 +85,6 @@ class CachePlugin implements Plugin
         }
 
         // Include the major version number of the geocoder to avoid issues unserializing.
-        return 'v4'.sha1((string) $query);
+        return 'v4' . sha1((string) $query);
     }
 }

--- a/src/Provider/AlgoliaPlaces/AlgoliaPlaces.php
+++ b/src/Provider/AlgoliaPlaces/AlgoliaPlaces.php
@@ -181,7 +181,7 @@ class AlgoliaPlaces extends AbstractHttpProvider implements Provider
      *
      * @return AddressCollection
      */
-    private function buildResult(array $jsonResponse, string $locale = null): AddressCollection
+    private function buildResult(array $jsonResponse, ?string $locale = null): AddressCollection
     {
         $results = [];
 
@@ -230,7 +230,7 @@ class AlgoliaPlaces extends AbstractHttpProvider implements Provider
      *
      * @return string|int|float
      */
-    private function getResultAttribute(array $result, string $attribute, string $locale = null)
+    private function getResultAttribute(array $result, ?string $attribute, string $locale = null)
     {
         if (!is_array($result[$attribute])) {
             return $result[$attribute];

--- a/src/Provider/ArcGISOnline/ArcGISOnline.php
+++ b/src/Provider/ArcGISOnline/ArcGISOnline.php
@@ -48,7 +48,7 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
      * @param HttpClient $client        An HTTP adapter
      * @param string     $sourceCountry Country biasing (optional)
      */
-    public function __construct(HttpClient $client, string $sourceCountry = null)
+    public function __construct(HttpClient $client, ?string $sourceCountry = null)
     {
         parent::__construct($client);
 

--- a/src/Provider/BingMaps/BingMaps.php
+++ b/src/Provider/BingMaps/BingMaps.php
@@ -98,7 +98,7 @@ final class BingMaps extends AbstractHttpProvider implements Provider
      *
      * @return \Geocoder\Collection
      */
-    private function executeQuery(string $url, string $locale = null, int $limit): Collection
+    private function executeQuery(string $url, ?string $locale = null, int $limit): Collection
     {
         if (null !== $locale) {
             $url = sprintf('%s&culture=%s', $url, str_replace('_', '-', $locale));

--- a/src/Provider/Cache/ProviderCache.php
+++ b/src/Provider/Cache/ProviderCache.php
@@ -105,6 +105,6 @@ class ProviderCache implements Provider
     protected function getCacheKey($query): string
     {
         // Include the major version number of the geocoder to avoid issues unserializing.
-        return 'v4' . sha1((string) $query);
+        return 'v4'.sha1((string) $query);
     }
 }

--- a/src/Provider/Cache/ProviderCache.php
+++ b/src/Provider/Cache/ProviderCache.php
@@ -45,7 +45,7 @@ class ProviderCache implements Provider
      * @param CacheInterface $cache
      * @param int            $lifetime
      */
-    final public function __construct(Provider $realProvider, CacheInterface $cache, int $lifetime = null)
+    final public function __construct(Provider $realProvider, CacheInterface $cache, ?int $lifetime = null)
     {
         $this->realProvider = $realProvider;
         $this->cache = $cache;
@@ -105,6 +105,6 @@ class ProviderCache implements Provider
     protected function getCacheKey($query): string
     {
         // Include the major version number of the geocoder to avoid issues unserializing.
-        return 'v4'.sha1((string) $query);
+        return 'v4' . sha1((string) $query);
     }
 }

--- a/src/Provider/GeoIP2/GeoIP2Adapter.php
+++ b/src/Provider/GeoIP2/GeoIP2Adapter.php
@@ -42,7 +42,7 @@ class GeoIP2Adapter
      * @param \GeoIp2\ProviderInterface $geoIpProvider
      * @param string                    $geoIP2Model   (e.g. self::GEOIP2_MODEL_CITY)
      */
-    public function __construct(ProviderInterface $geoIpProvider, $geoIP2Model = self::GEOIP2_MODEL_CITY)
+    public function __construct(ProviderInterface $geoIpProvider, string $geoIP2Model = self::GEOIP2_MODEL_CITY)
     {
         $this->geoIp2Provider = $geoIpProvider;
 

--- a/src/Provider/Geonames/Geonames.php
+++ b/src/Provider/Geonames/Geonames.php
@@ -205,8 +205,8 @@ final class Geonames extends AbstractHttpProvider implements Provider
             }
 
             for ($level = 1; $level <= AdminLevelCollection::MAX_LEVEL_DEPTH; ++$level) {
-                $adminNameProp = 'adminName' . $level;
-                $adminCodeProp = 'adminCode' . $level;
+                $adminNameProp = 'adminName'.$level;
+                $adminCodeProp = 'adminCode'.$level;
                 if (!empty($item->$adminNameProp)) {
                     $builder->addAdminLevel($level, $item->$adminNameProp, $item->$adminCodeProp ?? null);
                 }

--- a/src/Provider/Geonames/Geonames.php
+++ b/src/Provider/Geonames/Geonames.php
@@ -105,7 +105,7 @@ final class Geonames extends AbstractHttpProvider implements Provider
      *
      * @throws \Geocoder\Exception\Exception
      */
-    public function getCountryInfo(string $country = null, string $locale = null): array
+    public function getCountryInfo(?string $country = null, ?string $locale = null): array
     {
         $url = sprintf(self::BASE_ENDPOINT_URL, 'countryInfoJSON', $this->username);
 
@@ -174,7 +174,7 @@ final class Geonames extends AbstractHttpProvider implements Provider
      *
      * @return AddressCollection
      */
-    private function executeQuery(string $url, string $locale = null): AddressCollection
+    private function executeQuery(string $url, ?string $locale = null): AddressCollection
     {
         if (null !== $locale) {
             // Locale code transformation: for example from it_IT to it
@@ -205,8 +205,8 @@ final class Geonames extends AbstractHttpProvider implements Provider
             }
 
             for ($level = 1; $level <= AdminLevelCollection::MAX_LEVEL_DEPTH; ++$level) {
-                $adminNameProp = 'adminName'.$level;
-                $adminCodeProp = 'adminCode'.$level;
+                $adminNameProp = 'adminName' . $level;
+                $adminCodeProp = 'adminCode' . $level;
                 if (!empty($item->$adminNameProp)) {
                     $builder->addAdminLevel($level, $item->$adminNameProp, $item->$adminCodeProp ?? null);
                 }

--- a/src/Provider/Geonames/Model/CountryInfo.php
+++ b/src/Provider/Geonames/Model/CountryInfo.php
@@ -122,7 +122,7 @@ final class CountryInfo
     /**
      * @return null|string
      */
-    public function getContinent()
+    public function getContinent(): ?string
     {
         return $this->continent;
     }
@@ -132,7 +132,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withContinent(string $continent = null): self
+    public function withContinent(?string $continent = null): self
     {
         $new = clone $this;
         $new->continent = $continent;
@@ -143,7 +143,7 @@ final class CountryInfo
     /**
      * @return null|string
      */
-    public function getCapital()
+    public function getCapital(): ?string
     {
         return $this->capital;
     }
@@ -153,7 +153,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withCapital(string $capital = null): self
+    public function withCapital(?string $capital = null): self
     {
         $new = clone $this;
         $new->capital = $capital;
@@ -206,7 +206,7 @@ final class CountryInfo
     /**
      * @return null|string
      */
-    public function getIsoAlpha3()
+    public function getIsoAlpha3(): ?string
     {
         return $this->isoAlpha3;
     }
@@ -216,7 +216,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withIsoAlpha3(string $isoAlpha3 = null): self
+    public function withIsoAlpha3(?string $isoAlpha3 = null): self
     {
         $new = clone $this;
         $new->isoAlpha3 = $isoAlpha3;
@@ -227,7 +227,7 @@ final class CountryInfo
     /**
      * @return null|string
      */
-    public function getFipsCode()
+    public function getFipsCode(): ?string
     {
         return $this->fipsCode;
     }
@@ -237,7 +237,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withFipsCode(string $fipsCode = null): self
+    public function withFipsCode(?string $fipsCode = null): self
     {
         $new = clone $this;
         $new->fipsCode = $fipsCode;
@@ -269,7 +269,7 @@ final class CountryInfo
     /**
      * @return null|int
      */
-    public function getIsoNumeric()
+    public function getIsoNumeric(): ?int
     {
         return $this->isoNumeric;
     }
@@ -279,7 +279,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withIsoNumeric(string $isoNumeric = null): self
+    public function withIsoNumeric(?string $isoNumeric = null): self
     {
         $new = clone $this;
         $new->isoNumeric = null === $isoNumeric ? null : (int) $isoNumeric;
@@ -290,7 +290,7 @@ final class CountryInfo
     /**
      * @return null|float
      */
-    public function getAreaInSqKm()
+    public function getAreaInSqKm(): ?float
     {
         return $this->areaInSqKm;
     }
@@ -300,7 +300,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withAreaInSqKm(string $areaInSqKm = null): self
+    public function withAreaInSqKm(?string $areaInSqKm = null): self
     {
         $new = clone $this;
         $new->areaInSqKm = null === $areaInSqKm ? null : (float) $areaInSqKm;
@@ -311,7 +311,7 @@ final class CountryInfo
     /**
      * @return null|string
      */
-    public function getCountryCode()
+    public function getCountryCode(): ?string
     {
         return $this->countryCode;
     }
@@ -321,7 +321,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withCountryCode(string $countryCode = null): self
+    public function withCountryCode(?string $countryCode = null): self
     {
         $new = clone $this;
         $new->countryCode = $countryCode;
@@ -332,7 +332,7 @@ final class CountryInfo
     /**
      * @return null|string
      */
-    public function getCountryName()
+    public function getCountryName(): ?string
     {
         return $this->countryName;
     }
@@ -342,7 +342,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withCountryName(string $countryName = null): self
+    public function withCountryName(?string $countryName = null): self
     {
         $new = clone $this;
         $new->countryName = $countryName;
@@ -353,7 +353,7 @@ final class CountryInfo
     /**
      * @return null|string
      */
-    public function getContinentName()
+    public function getContinentName(): ?string
     {
         return $this->continentName;
     }
@@ -363,7 +363,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withContinentName(string $continentName = null): self
+    public function withContinentName(?string $continentName = null): self
     {
         $new = clone $this;
         $new->continentName = $continentName;
@@ -374,7 +374,7 @@ final class CountryInfo
     /**
      * @return null|string
      */
-    public function getCurrencyCode()
+    public function getCurrencyCode(): ?string
     {
         return $this->currencyCode;
     }
@@ -384,7 +384,7 @@ final class CountryInfo
      *
      * @return CountryInfo
      */
-    public function withCurrencyCode(string $currencyCode = null): self
+    public function withCurrencyCode(?string $currencyCode = null): self
     {
         $new = clone $this;
         $new->currencyCode = $currencyCode;

--- a/src/Provider/Geonames/Model/GeonamesAddress.php
+++ b/src/Provider/Geonames/Model/GeonamesAddress.php
@@ -61,7 +61,7 @@ final class GeonamesAddress extends Address
     /**
      * @return null|string
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -69,9 +69,9 @@ final class GeonamesAddress extends Address
     /**
      * @param null|string $name
      *
-     * @return self
+     * @return GeonamesAddress
      */
-    public function withName(string $name = null): self
+    public function withName(?string $name = null): self
     {
         $new = clone $this;
         $new->name = $name;
@@ -82,7 +82,7 @@ final class GeonamesAddress extends Address
     /**
      * @return null|string
      */
-    public function getFcode()
+    public function getFcode(): ?string
     {
         return $this->fcode;
     }
@@ -92,7 +92,7 @@ final class GeonamesAddress extends Address
      *
      * @return GeonamesAddress
      */
-    public function withFcode($fcode)
+    public function withFcode(?string $fcode): self
     {
         $new = clone $this;
         $new->fcode = $fcode;
@@ -103,7 +103,7 @@ final class GeonamesAddress extends Address
     /**
      * @return null|string
      */
-    public function getFclName()
+    public function getFclName(): ?string
     {
         return $this->fclName;
     }
@@ -113,7 +113,7 @@ final class GeonamesAddress extends Address
      *
      * @return GeonamesAddress
      */
-    public function withFclName($fclName)
+    public function withFclName(?string $fclName): self
     {
         $new = clone $this;
         $new->fclName = $fclName;
@@ -124,7 +124,7 @@ final class GeonamesAddress extends Address
     /**
      * @return int|null
      */
-    public function getPopulation()
+    public function getPopulation(): ?int
     {
         return $this->population;
     }
@@ -134,7 +134,7 @@ final class GeonamesAddress extends Address
      *
      * @return GeonamesAddress
      */
-    public function withPopulation($population)
+    public function withPopulation(?int $population): self
     {
         $new = clone $this;
         $new->population = $population;
@@ -145,7 +145,7 @@ final class GeonamesAddress extends Address
     /**
      * @return int|null
      */
-    public function getGeonameId()
+    public function getGeonameId(): ?int
     {
         return $this->geonameId;
     }
@@ -155,7 +155,7 @@ final class GeonamesAddress extends Address
      *
      * @return GeonamesAddress
      */
-    public function withGeonameId($geonameId)
+    public function withGeonameId(?int $geonameId): self
     {
         $new = clone $this;
         $new->geonameId = $geonameId;
@@ -176,7 +176,7 @@ final class GeonamesAddress extends Address
      *
      * @return GeonamesAddress
      */
-    public function withAlternateNames(array $alternateNames)
+    public function withAlternateNames(array $alternateNames): self
     {
         $new = clone $this;
         $new->alternateNames = $alternateNames;
@@ -187,7 +187,7 @@ final class GeonamesAddress extends Address
     /**
      * @return null|string
      */
-    public function getAsciiName()
+    public function getAsciiName(): ?string
     {
         return $this->asciiName;
     }
@@ -197,7 +197,7 @@ final class GeonamesAddress extends Address
      *
      * @return GeonamesAddress
      */
-    public function withAsciiName($asciiName)
+    public function withAsciiName(?string $asciiName): self
     {
         $new = clone $this;
         $new->asciiName = $asciiName;

--- a/src/Provider/GoogleMaps/Model/GoogleAddress.php
+++ b/src/Provider/GoogleMaps/Model/GoogleAddress.php
@@ -126,7 +126,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withId(string $id = null)
+    public function withId(?string $id = null): self
     {
         $new = clone $this;
         $new->id = $id;
@@ -139,7 +139,7 @@ final class GoogleAddress extends Address
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
@@ -149,7 +149,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withLocationType(string $locationType = null)
+    public function withLocationType(?string $locationType = null): self
     {
         $new = clone $this;
         $new->locationType = $locationType;
@@ -160,7 +160,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getLocationType()
+    public function getLocationType(): ?string
     {
         return $this->locationType;
     }
@@ -178,7 +178,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withResultType(array $resultType)
+    public function withResultType(array $resultType): self
     {
         $new = clone $this;
         $new->resultType = $resultType;
@@ -189,7 +189,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getFormattedAddress()
+    public function getFormattedAddress(): ?string
     {
         return $this->formattedAddress;
     }
@@ -199,7 +199,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withFormattedAddress(string $formattedAddress = null)
+    public function withFormattedAddress(?string $formattedAddress = null): self
     {
         $new = clone $this;
         $new->formattedAddress = $formattedAddress;
@@ -210,7 +210,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getAirport()
+    public function getAirport(): ?string
     {
         return $this->airport;
     }
@@ -220,7 +220,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withAirport(string $airport = null)
+    public function withAirport(?string $airport = null): self
     {
         $new = clone $this;
         $new->airport = $airport;
@@ -231,7 +231,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getColloquialArea()
+    public function getColloquialArea(): ?string
     {
         return $this->colloquialArea;
     }
@@ -241,7 +241,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withColloquialArea(string $colloquialArea = null)
+    public function withColloquialArea(?string $colloquialArea = null): self
     {
         $new = clone $this;
         $new->colloquialArea = $colloquialArea;
@@ -252,7 +252,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getIntersection()
+    public function getIntersection(): ?string
     {
         return $this->intersection;
     }
@@ -262,7 +262,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withIntersection(string $intersection = null)
+    public function withIntersection(?string $intersection = null): self
     {
         $new = clone $this;
         $new->intersection = $intersection;
@@ -273,7 +273,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getPostalCodeSuffix()
+    public function getPostalCodeSuffix(): ?string
     {
         return $this->postalCodeSuffix;
     }
@@ -283,7 +283,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withPostalCodeSuffix(string $postalCodeSuffix = null)
+    public function withPostalCodeSuffix(?string $postalCodeSuffix = null): self
     {
         $new = clone $this;
         $new->postalCodeSuffix = $postalCodeSuffix;
@@ -294,7 +294,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getNaturalFeature()
+    public function getNaturalFeature(): ?string
     {
         return $this->naturalFeature;
     }
@@ -304,7 +304,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withNaturalFeature(string $naturalFeature = null)
+    public function withNaturalFeature(?string $naturalFeature = null): self
     {
         $new = clone $this;
         $new->naturalFeature = $naturalFeature;
@@ -315,7 +315,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getNeighborhood()
+    public function getNeighborhood(): ?string
     {
         return $this->neighborhood;
     }
@@ -325,7 +325,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withNeighborhood(string $neighborhood = null)
+    public function withNeighborhood(?string $neighborhood = null): self
     {
         $new = clone $this;
         $new->neighborhood = $neighborhood;
@@ -336,7 +336,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getPark()
+    public function getPark(): ?string
     {
         return $this->park;
     }
@@ -346,7 +346,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withPark(string $park = null)
+    public function withPark(?string $park = null): self
     {
         $new = clone $this;
         $new->park = $park;
@@ -357,7 +357,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getPointOfInterest()
+    public function getPointOfInterest(): ?string
     {
         return $this->pointOfInterest;
     }
@@ -367,7 +367,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withPointOfInterest(string $pointOfInterest = null)
+    public function withPointOfInterest(?string $pointOfInterest = null): self
     {
         $new = clone $this;
         $new->pointOfInterest = $pointOfInterest;
@@ -378,7 +378,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getPolitical()
+    public function getPolitical(): ?string
     {
         return $this->political;
     }
@@ -388,7 +388,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withPolitical(string $political = null)
+    public function withPolitical(?string $political = null): self
     {
         $new = clone $this;
         $new->political = $political;
@@ -399,7 +399,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getPremise()
+    public function getPremise(): ?string
     {
         return $this->premise;
     }
@@ -409,7 +409,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withPremise(string $premise = null)
+    public function withPremise(?string $premise = null): self
     {
         $new = clone $this;
         $new->premise = $premise;
@@ -420,7 +420,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getStreetAddress()
+    public function getStreetAddress(): ?string
     {
         return $this->streetAddress;
     }
@@ -430,7 +430,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withStreetAddress(string $streetAddress = null)
+    public function withStreetAddress(?string $streetAddress = null): self
     {
         $new = clone $this;
         $new->streetAddress = $streetAddress;
@@ -441,7 +441,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getSubpremise()
+    public function getSubpremise(): ?string
     {
         return $this->subpremise;
     }
@@ -451,7 +451,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withSubpremise(string $subpremise = null)
+    public function withSubpremise(?string $subpremise = null): self
     {
         $new = clone $this;
         $new->subpremise = $subpremise;
@@ -462,7 +462,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getWard()
+    public function getWard(): ?string
     {
         return $this->ward;
     }
@@ -472,7 +472,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withWard(string $ward = null)
+    public function withWard(?string $ward = null): self
     {
         $new = clone $this;
         $new->ward = $ward;
@@ -483,7 +483,7 @@ final class GoogleAddress extends Address
     /**
      * @return null|string
      */
-    public function getEstablishment()
+    public function getEstablishment(): ?string
     {
         return $this->establishment;
     }
@@ -493,7 +493,7 @@ final class GoogleAddress extends Address
      *
      * @return GoogleAddress
      */
-    public function withEstablishment(string $establishment = null)
+    public function withEstablishment(?string $establishment = null): self
     {
         $new = clone $this;
         $new->establishment = $establishment;
@@ -504,7 +504,7 @@ final class GoogleAddress extends Address
     /**
      * @return AdminLevelCollection
      */
-    public function getSubLocalityLevels()
+    public function getSubLocalityLevels(): AdminLevelCollection
     {
         return $this->subLocalityLevels;
     }
@@ -512,9 +512,9 @@ final class GoogleAddress extends Address
     /**
      * @param array $subLocalityLevel
      *
-     * @return $this
+     * @return GoogleAddress
      */
-    public function withSubLocalityLevels(array $subLocalityLevel)
+    public function withSubLocalityLevels(array $subLocalityLevel): self
     {
         $subLocalityLevels = [];
         foreach ($subLocalityLevel as $level) {
@@ -541,7 +541,7 @@ final class GoogleAddress extends Address
     /**
      * @return bool
      */
-    public function isPartialMatch()
+    public function isPartialMatch(): bool
     {
         return $this->partialMatch;
     }
@@ -549,9 +549,9 @@ final class GoogleAddress extends Address
     /**
      * @param bool $partialMatch
      *
-     * @return $this
+     * @return GoogleAddress
      */
-    public function withPartialMatch(bool $partialMatch)
+    public function withPartialMatch(bool $partialMatch): self
     {
         $new = clone $this;
         $new->partialMatch = $partialMatch;

--- a/src/Provider/GoogleMapsPlaces/Model/GooglePlace.php
+++ b/src/Provider/GoogleMapsPlaces/Model/GooglePlace.php
@@ -94,7 +94,7 @@ final class GooglePlace extends Address
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
@@ -104,7 +104,7 @@ final class GooglePlace extends Address
      *
      * @return GooglePlace
      */
-    public function withId(string $id = null)
+    public function withId(?string $id = null): self
     {
         $new = clone $this;
         $new->id = $id;
@@ -115,7 +115,7 @@ final class GooglePlace extends Address
     /**
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -125,7 +125,7 @@ final class GooglePlace extends Address
      *
      * @return GooglePlace
      */
-    public function withName(string $name = null)
+    public function withName(?string $name = null): self
     {
         $new = clone $this;
         $new->name = $name;
@@ -146,7 +146,7 @@ final class GooglePlace extends Address
      *
      * @return GooglePlace
      */
-    public function withType(array $type)
+    public function withType(array $type): self
     {
         $new = clone $this;
         $new->type = $type;
@@ -157,7 +157,7 @@ final class GooglePlace extends Address
     /**
      * @return null|string
      */
-    public function getFormattedAddress()
+    public function getFormattedAddress(): ?string
     {
         return $this->formattedAddress;
     }
@@ -167,7 +167,7 @@ final class GooglePlace extends Address
      *
      * @return GooglePlace
      */
-    public function withFormattedAddress(string $formattedAddress = null)
+    public function withFormattedAddress(?string $formattedAddress = null): self
     {
         $new = clone $this;
         $new->formattedAddress = $formattedAddress;
@@ -178,12 +178,17 @@ final class GooglePlace extends Address
     /**
      * @return string|null
      */
-    public function getIcon(): string
+    public function getIcon(): ?string
     {
         return $this->icon;
     }
 
-    public function withIcon(string $icon = null)
+    /**
+     * @param string|null $icon
+     *
+     * @return GooglePlace
+     */
+    public function withIcon(string $icon = null): self
     {
         $new = clone $this;
         $new->icon = $icon;
@@ -199,7 +204,12 @@ final class GooglePlace extends Address
         return $this->plusCode;
     }
 
-    public function withPlusCode(PlusCode $plusCode = null)
+    /**
+     * @param PlusCode|null $plusCode
+     *
+     * @return GooglePlace
+     */
+    public function withPlusCode(?PlusCode $plusCode = null): self
     {
         $new = clone $this;
         $new->plusCode = $plusCode;
@@ -210,12 +220,17 @@ final class GooglePlace extends Address
     /**
      * @return Photo[]|null
      */
-    public function getPhotos(): array
+    public function getPhotos(): ?array
     {
         return $this->photos;
     }
 
-    public function withPhotos(array $photos = null)
+    /**
+     * @param Photo[]|null $photos
+     *
+     * @return GooglePlace
+     */
+    public function withPhotos(?array $photos = null): self
     {
         $new = clone $this;
         $new->photos = $photos;
@@ -234,12 +249,17 @@ final class GooglePlace extends Address
      *
      * @return int|null
      */
-    public function getPriceLevel(): int
+    public function getPriceLevel(): ?int
     {
         return $this->priceLevel;
     }
 
-    public function withPriceLevel(int $priceLevel = null)
+    /**
+     * @param int|null $priceLevel
+     *
+     * @return GooglePlace
+     */
+    public function withPriceLevel(?int $priceLevel = null): self
     {
         $new = clone $this;
         $new->priceLevel = $priceLevel;
@@ -250,12 +270,17 @@ final class GooglePlace extends Address
     /**
      * @return float|null
      */
-    public function getRating(): float
+    public function getRating(): ?float
     {
         return $this->rating;
     }
 
-    public function withRating(float $rating = null)
+    /**
+     * @param float|null $rating
+     *
+     * @return GooglePlace
+     */
+    public function withRating(?float $rating = null): self
     {
         $new = clone $this;
         $new->rating = $rating;
@@ -266,12 +291,17 @@ final class GooglePlace extends Address
     /**
      * @return string|null
      */
-    public function getFormattedPhoneNumber()
+    public function getFormattedPhoneNumber(): ?string
     {
         return $this->formattedPhoneNumber;
     }
 
-    public function withFormattedPhoneNumber(string $phone)
+    /**
+     * @param string|null $phone
+     *
+     * @return GooglePlace
+     */
+    public function withFormattedPhoneNumber(?string $phone = null): self
     {
         $new = clone $this;
         $new->formattedPhoneNumber = $phone;
@@ -282,12 +312,17 @@ final class GooglePlace extends Address
     /**
      * @return string|null
      */
-    public function getInternationalPhoneNumber()
+    public function getInternationalPhoneNumber(): ?string
     {
         return $this->internationalPhoneNumber;
     }
 
-    public function withInternationalPhoneNumber(string $phone)
+    /**
+     * @param string|null $phone
+     *
+     * @return GooglePlace
+     */
+    public function withInternationalPhoneNumber(?string $phone = null): self
     {
         $new = clone $this;
         $new->internationalPhoneNumber = $phone;
@@ -303,7 +338,12 @@ final class GooglePlace extends Address
         return $this->website;
     }
 
-    public function withWebsite(string $website)
+    /**
+     * @param string|null $website
+     *
+     * @return GooglePlace
+     */
+    public function withWebsite(?string $website = null): self
     {
         $new = clone $this;
         $new->website = $website;
@@ -312,14 +352,19 @@ final class GooglePlace extends Address
     }
 
     /**
-     * @return OpeningHours
+     * @return OpeningHours|null
      */
-    public function getOpeningHours()
+    public function getOpeningHours(): ?OpeningHours
     {
         return $this->openingHours;
     }
 
-    public function withOpeningHours(OpeningHours $openingHours)
+    /**
+     * @param OpeningHours $openingHours
+     *
+     * @return GooglePlace
+     */
+    public function withOpeningHours(OpeningHours $openingHours): self
     {
         $new = clone $this;
         $new->openingHours = $openingHours;
@@ -335,7 +380,10 @@ final class GooglePlace extends Address
         return $this->permanentlyClosed;
     }
 
-    public function setPermanentlyClosed()
+    /**
+     * @return GooglePlace
+     */
+    public function setPermanentlyClosed(): self
     {
         $new = clone $this;
         $new->permanentlyClosed = true;

--- a/src/Provider/Here/Model/HereAddress.php
+++ b/src/Provider/Here/Model/HereAddress.php
@@ -47,7 +47,7 @@ final class HereAddress extends Address
     /**
      * @return null|string
      */
-    public function getLocationId()
+    public function getLocationId(): ?string
     {
         return $this->locationId;
     }
@@ -57,7 +57,7 @@ final class HereAddress extends Address
      *
      * @return HereAddress
      */
-    public function withLocationId(string $locationId = null): self
+    public function withLocationId(?string $locationId = null): self
     {
         $new = clone $this;
         $new->locationId = $locationId;
@@ -68,7 +68,7 @@ final class HereAddress extends Address
     /**
      * @return null|string
      */
-    public function getLocationType()
+    public function getLocationType(): ?string
     {
         return $this->locationType;
     }
@@ -78,7 +78,7 @@ final class HereAddress extends Address
      *
      * @return HereAddress
      */
-    public function withLocationType(string $locationType = null): self
+    public function withLocationType(?string $locationType = null): self
     {
         $new = clone $this;
         $new->locationType = $locationType;
@@ -89,7 +89,7 @@ final class HereAddress extends Address
     /**
      * @return null|string
      */
-    public function getLocationName()
+    public function getLocationName(): ?string
     {
         return $this->locationName;
     }
@@ -99,7 +99,7 @@ final class HereAddress extends Address
      *
      * @return HereAddress
      */
-    public function withLocationName(string $locationName = null): self
+    public function withLocationName(?string $locationName = null): self
     {
         $new = clone $this;
         $new->locationName = $locationName;
@@ -110,7 +110,7 @@ final class HereAddress extends Address
     /**
      * @return null|array
      */
-    public function getAdditionalData()
+    public function getAdditionalData(): ?array
     {
         return $this->additionalData;
     }
@@ -120,7 +120,7 @@ final class HereAddress extends Address
      *
      * @return HereAddress
      */
-    public function withAdditionalData(array $additionalData = null): self
+    public function withAdditionalData(?array $additionalData = null): self
     {
         $new = clone $this;
 
@@ -175,7 +175,7 @@ final class HereAddress extends Address
      *
      * @return HereAddress
      */
-    public function withShape(array $shape = null): self
+    public function withShape(?array $shape = null): self
     {
         $new = clone $this;
 

--- a/src/Provider/MapQuest/GetAddressInterface.php
+++ b/src/Provider/MapQuest/GetAddressInterface.php
@@ -17,5 +17,5 @@ interface GetAddressInterface
     /**
      * @return Location|null
      */
-    public function getAddress();
+    public function getAddress(): ?Location;
 }

--- a/src/Provider/MapQuest/MapQuest.php
+++ b/src/Provider/MapQuest/MapQuest.php
@@ -198,7 +198,7 @@ final class MapQuest extends AbstractHttpProvider implements Provider
         return $query->getData(static::DATA_KEY_ADDRESS);
     }
 
-    private function getUrl($endpoint): string
+    private function getUrl(string $endpoint): string
     {
         if ($this->licensed) {
             $baseUrl = static::LICENSED_BASE_URL;
@@ -206,12 +206,12 @@ final class MapQuest extends AbstractHttpProvider implements Provider
             $baseUrl = static::OPEN_BASE_URL;
         }
 
-        return $baseUrl.$endpoint;
+        return $baseUrl . $endpoint;
     }
 
     private function addGetQuery(string $url, array $params): string
     {
-        return $url.'?'.http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+        return $url . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
     }
 
     private function addOptionsForGetQuery(array $params, array $options): array
@@ -241,7 +241,7 @@ final class MapQuest extends AbstractHttpProvider implements Provider
 
         $appKey = $params[static::KEY_API_KEY];
         unset($params[static::KEY_API_KEY]);
-        $url .= '?key='.$appKey;
+        $url .= '?key=' . $appKey;
 
         $requestBody = json_encode($params);
         $request = $this->getMessageFactory()->createRequest('POST', $url, [], $requestBody);
@@ -388,7 +388,7 @@ final class MapQuest extends AbstractHttpProvider implements Provider
         return $location;
     }
 
-    private function mapBoundsToArray(Bounds $bounds)
+    private function mapBoundsToArray(Bounds $bounds): array
     {
         return [
             'ul' => [static::KEY_LAT => $bounds->getNorth(), static::KEY_LNG => $bounds->getWest()],

--- a/src/Provider/MapQuest/MapQuest.php
+++ b/src/Provider/MapQuest/MapQuest.php
@@ -206,12 +206,12 @@ final class MapQuest extends AbstractHttpProvider implements Provider
             $baseUrl = static::OPEN_BASE_URL;
         }
 
-        return $baseUrl . $endpoint;
+        return $baseUrl.$endpoint;
     }
 
     private function addGetQuery(string $url, array $params): string
     {
-        return $url . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+        return $url.'?'.http_build_query($params, '', '&', PHP_QUERY_RFC3986);
     }
 
     private function addOptionsForGetQuery(array $params, array $options): array
@@ -241,7 +241,7 @@ final class MapQuest extends AbstractHttpProvider implements Provider
 
         $appKey = $params[static::KEY_API_KEY];
         unset($params[static::KEY_API_KEY]);
-        $url .= '?key=' . $appKey;
+        $url .= '?key='.$appKey;
 
         $requestBody = json_encode($params);
         $request = $this->getMessageFactory()->createRequest('POST', $url, [], $requestBody);

--- a/src/Provider/Mapbox/Mapbox.php
+++ b/src/Provider/Mapbox/Mapbox.php
@@ -152,7 +152,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
     public function __construct(
         HttpClient $client,
         string $accessToken,
-        string $country = null,
+        ?string $country = null,
         string $geocodingMode = self::GEOCODING_MODE_PLACES
     ) {
         parent::__construct($client);
@@ -196,7 +196,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
         }
 
         if ($urlParameters) {
-            $url .= '?'.http_build_query($urlParameters);
+            $url .= '?' . http_build_query($urlParameters);
         }
 
         return $this->fetchUrl($url, $query->getLimit(), $query->getLocale(), $query->getData('country', $this->country));
@@ -219,7 +219,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
         }
 
         if ($urlParameters) {
-            $url .= '?'.http_build_query($urlParameters);
+            $url .= '?' . http_build_query($urlParameters);
         }
 
         return $this->fetchUrl($url, $query->getLimit(), $query->getLocale(), $query->getData('country', $this->country));
@@ -241,7 +241,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
      *
      * @return string query with extra params
      */
-    private function buildQuery(string $url, int $limit, string $locale = null, string $country = null): string
+    private function buildQuery(string $url, int $limit, ?string $locale = null, ?string $country = null): string
     {
         $parameters = array_filter([
             'country' => $country,
@@ -252,7 +252,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
 
         $separator = parse_url($url, PHP_URL_QUERY) ? '&' : '?';
 
-        return $url.$separator.http_build_query($parameters);
+        return $url . $separator . http_build_query($parameters);
     }
 
     /**
@@ -263,7 +263,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
      *
      * @return AddressCollection
      */
-    private function fetchUrl(string $url, int $limit, string $locale = null, string $country = null): AddressCollection
+    private function fetchUrl(string $url, int $limit, ?string $locale = null, ?string $country = null): AddressCollection
     {
         $url = $this->buildQuery($url, $limit, $locale, $country);
         $content = $this->getUrlContents($url);
@@ -385,7 +385,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
      *
      * @return array
      */
-    private function validateResponse(string $url, $content): array
+    private function validateResponse(string $url, string $content): array
     {
         $json = json_decode($content, true);
 

--- a/src/Provider/Mapbox/Mapbox.php
+++ b/src/Provider/Mapbox/Mapbox.php
@@ -196,7 +196,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
         }
 
         if ($urlParameters) {
-            $url .= '?' . http_build_query($urlParameters);
+            $url .= '?'.http_build_query($urlParameters);
         }
 
         return $this->fetchUrl($url, $query->getLimit(), $query->getLocale(), $query->getData('country', $this->country));
@@ -219,7 +219,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
         }
 
         if ($urlParameters) {
-            $url .= '?' . http_build_query($urlParameters);
+            $url .= '?'.http_build_query($urlParameters);
         }
 
         return $this->fetchUrl($url, $query->getLimit(), $query->getLocale(), $query->getData('country', $this->country));
@@ -252,7 +252,7 @@ final class Mapbox extends AbstractHttpProvider implements Provider
 
         $separator = parse_url($url, PHP_URL_QUERY) ? '&' : '?';
 
-        return $url . $separator . http_build_query($parameters);
+        return $url.$separator.http_build_query($parameters);
     }
 
     /**

--- a/src/Provider/Mapbox/Model/MapboxAddress.php
+++ b/src/Provider/Mapbox/Model/MapboxAddress.php
@@ -51,7 +51,7 @@ final class MapboxAddress extends Address
      *
      * @return MapboxAddress
      */
-    public function withId(string $id = null)
+    public function withId(?string $id = null): self
     {
         $new = clone $this;
         $new->id = $id;
@@ -64,7 +64,7 @@ final class MapboxAddress extends Address
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
@@ -72,7 +72,7 @@ final class MapboxAddress extends Address
     /**
      * @return null|string
      */
-    public function getStreetName()
+    public function getStreetName(): ?string
     {
         return $this->streetName;
     }
@@ -82,7 +82,7 @@ final class MapboxAddress extends Address
      *
      * @return MapboxAddress
      */
-    public function withStreetName(string $streetName = null)
+    public function withStreetName(?string $streetName = null): self
     {
         $new = clone $this;
         $new->streetName = $streetName;
@@ -103,7 +103,7 @@ final class MapboxAddress extends Address
      *
      * @return MapboxAddress
      */
-    public function withStreetNumber(string $streetNumber = null)
+    public function withStreetNumber(?string $streetNumber = null): self
     {
         $new = clone $this;
         $new->streetNumber = $streetNumber;
@@ -124,7 +124,7 @@ final class MapboxAddress extends Address
      *
      * @return MapboxAddress
      */
-    public function withResultType(array $resultType)
+    public function withResultType(array $resultType): self
     {
         $new = clone $this;
         $new->resultType = $resultType;
@@ -135,7 +135,7 @@ final class MapboxAddress extends Address
     /**
      * @return null|string
      */
-    public function getFormattedAddress()
+    public function getFormattedAddress(): ?string
     {
         return $this->formattedAddress;
     }
@@ -145,7 +145,7 @@ final class MapboxAddress extends Address
      *
      * @return MapboxAddress
      */
-    public function withFormattedAddress(string $formattedAddress = null)
+    public function withFormattedAddress(?string $formattedAddress = null): self
     {
         $new = clone $this;
         $new->formattedAddress = $formattedAddress;
@@ -156,7 +156,7 @@ final class MapboxAddress extends Address
     /**
      * @return null|string
      */
-    public function getNeighborhood()
+    public function getNeighborhood(): ?string
     {
         return $this->neighborhood;
     }
@@ -166,7 +166,7 @@ final class MapboxAddress extends Address
      *
      * @return MapboxAddress
      */
-    public function withNeighborhood(string $neighborhood = null)
+    public function withNeighborhood(?string $neighborhood = null): self
     {
         $new = clone $this;
         $new->neighborhood = $neighborhood;

--- a/src/Provider/Mapzen/Mapzen.php
+++ b/src/Provider/Mapzen/Mapzen.php
@@ -182,7 +182,7 @@ final class Mapzen extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessLocality(array $components)
+    protected function guessLocality(array $components): ?string
     {
         $localityKeys = ['city', 'town', 'village', 'hamlet'];
 
@@ -194,7 +194,7 @@ final class Mapzen extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessStreetName(array $components)
+    protected function guessStreetName(array $components): ?string
     {
         $streetNameKeys = ['road', 'street', 'street_name', 'residential'];
 
@@ -206,7 +206,7 @@ final class Mapzen extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessSubLocality(array $components)
+    protected function guessSubLocality(array $components): ?string
     {
         $subLocalityKeys = ['neighbourhood', 'city_district'];
 
@@ -219,7 +219,7 @@ final class Mapzen extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessBestComponent(array $components, array $keys)
+    protected function guessBestComponent(array $components, array $keys): ?string
     {
         foreach ($keys as $key) {
             if (isset($components[$key]) && !empty($components[$key])) {

--- a/src/Provider/MaxMindBinary/MaxMindBinary.php
+++ b/src/Provider/MaxMindBinary/MaxMindBinary.php
@@ -42,7 +42,7 @@ final class MaxMindBinary extends AbstractProvider implements Provider
      * @throws FunctionNotFound if maxmind's lib not installed
      * @throws InvalidArgument  if dat file is not correct (optional)
      */
-    public function __construct(string $datFile, int $openFlag = null)
+    public function __construct(string $datFile, ?int $openFlag = null)
     {
         if (false === function_exists('geoip_open')) {
             throw new FunctionNotFound('geoip_open', 'The MaxMindBinary requires maxmind\'s lib to be installed and loaded. Have you included geoip.inc file?');

--- a/src/Provider/Nominatim/Model/NominatimAddress.php
+++ b/src/Provider/Nominatim/Model/NominatimAddress.php
@@ -52,7 +52,7 @@ final class NominatimAddress extends Address
     /**
      * @return null|string
      */
-    public function getAttribution()
+    public function getAttribution(): ?string
     {
         return $this->attribution;
     }
@@ -62,7 +62,7 @@ final class NominatimAddress extends Address
      *
      * @return NominatimAddress
      */
-    public function withAttribution(string $attribution = null): self
+    public function withAttribution(?string $attribution = null): self
     {
         $new = clone $this;
         $new->attribution = $attribution;
@@ -75,7 +75,7 @@ final class NominatimAddress extends Address
      *
      * @return null|string
      */
-    public function getClass()
+    public function getClass(): ?string
     {
         return $this->getCategory();
     }
@@ -87,7 +87,7 @@ final class NominatimAddress extends Address
      *
      * @return NominatimAddress
      */
-    public function withClass(string $category = null): self
+    public function withClass(?string $category = null): self
     {
         return $this->withCategory($category);
     }
@@ -95,7 +95,7 @@ final class NominatimAddress extends Address
     /**
      * @return null|string
      */
-    public function getCategory()
+    public function getCategory(): ?string
     {
         return $this->category;
     }
@@ -105,7 +105,7 @@ final class NominatimAddress extends Address
      *
      * @return NominatimAddress
      */
-    public function withCategory(string $category = null): self
+    public function withCategory(?string $category = null): self
     {
         $new = clone $this;
         $new->category = $category;
@@ -116,7 +116,7 @@ final class NominatimAddress extends Address
     /**
      * @return null|string
      */
-    public function getDisplayName()
+    public function getDisplayName(): ?string
     {
         return $this->displayName;
     }
@@ -126,7 +126,7 @@ final class NominatimAddress extends Address
      *
      * @return NominatimAddress
      */
-    public function withDisplayName(string $displayName = null): self
+    public function withDisplayName(?string $displayName = null): self
     {
         $new = clone $this;
         $new->displayName = $displayName;
@@ -137,7 +137,7 @@ final class NominatimAddress extends Address
     /**
      * @return null|int
      */
-    public function getOSMId()
+    public function getOSMId(): ?int
     {
         return $this->osmId;
     }
@@ -147,7 +147,7 @@ final class NominatimAddress extends Address
      *
      * @return NominatimAddress
      */
-    public function withOSMId(int $osmId = null): self
+    public function withOSMId(?int $osmId = null): self
     {
         $new = clone $this;
         $new->osmId = $osmId;
@@ -158,7 +158,7 @@ final class NominatimAddress extends Address
     /**
      * @return null|string
      */
-    public function getOSMType()
+    public function getOSMType(): ?string
     {
         return $this->osmType;
     }
@@ -168,7 +168,7 @@ final class NominatimAddress extends Address
      *
      * @return NominatimAddress
      */
-    public function withOSMType(string $osmType = null): self
+    public function withOSMType(?string $osmType = null): self
     {
         $new = clone $this;
         $new->osmType = $osmType;
@@ -179,7 +179,7 @@ final class NominatimAddress extends Address
     /**
      * @return null|string
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }
@@ -189,7 +189,7 @@ final class NominatimAddress extends Address
      *
      * @return NominatimAddress
      */
-    public function withType(string $type = null): self
+    public function withType(?string $type = null): self
     {
         $new = clone $this;
         $new->type = $type;

--- a/src/Provider/Nominatim/Nominatim.php
+++ b/src/Provider/Nominatim/Nominatim.php
@@ -91,8 +91,8 @@ final class Nominatim extends AbstractHttpProvider implements Provider
         }
 
         $url = $this->rootUrl
-            .'/search?'
-            .http_build_query([
+            . '/search?'
+            . http_build_query([
                 'format' => 'jsonv2',
                 'q' => $address,
                 'addressdetails' => 1,
@@ -104,11 +104,11 @@ final class Nominatim extends AbstractHttpProvider implements Provider
             if (is_array($countrycodes)) {
                 $countrycodes = array_map('strtolower', $countrycodes);
 
-                $url .= '&'.http_build_query([
+                $url .= '&' . http_build_query([
                     'countrycodes' => implode(',', $countrycodes),
                 ]);
             } else {
-                $url .= '&'.http_build_query([
+                $url .= '&' . http_build_query([
                     'countrycodes' => strtolower($countrycodes),
                 ]);
             }
@@ -116,13 +116,13 @@ final class Nominatim extends AbstractHttpProvider implements Provider
 
         $viewbox = $query->getData('viewbox');
         if (!is_null($viewbox) && is_array($viewbox) && 4 === count($viewbox)) {
-            $url .= '&'.http_build_query([
+            $url .= '&' . http_build_query([
                 'viewbox' => implode(',', $viewbox),
             ]);
 
             $bounded = $query->getData('bounded');
             if (!is_null($bounded) && true === $bounded) {
-                $url .= '&'.http_build_query([
+                $url .= '&' . http_build_query([
                     'bounded' => 1,
                 ]);
             }
@@ -157,8 +157,8 @@ final class Nominatim extends AbstractHttpProvider implements Provider
         $latitude = $coordinates->getLatitude();
 
         $url = $this->rootUrl
-            .'/reverse?'
-            .http_build_query([
+            . '/reverse?'
+            . http_build_query([
                 'format' => 'jsonv2',
                 'lat' => $latitude,
                 'lon' => $longitude,
@@ -261,10 +261,10 @@ final class Nominatim extends AbstractHttpProvider implements Provider
      *
      * @return string
      */
-    private function executeQuery(string $url, string $locale = null): string
+    private function executeQuery(string $url, ?string $locale = null): string
     {
         if (null !== $locale) {
-            $url .= '&'.http_build_query([
+            $url .= '&' . http_build_query([
                 'accept-language' => $locale,
             ]);
         }

--- a/src/Provider/Nominatim/Nominatim.php
+++ b/src/Provider/Nominatim/Nominatim.php
@@ -91,8 +91,8 @@ final class Nominatim extends AbstractHttpProvider implements Provider
         }
 
         $url = $this->rootUrl
-            . '/search?'
-            . http_build_query([
+            .'/search?'
+            .http_build_query([
                 'format' => 'jsonv2',
                 'q' => $address,
                 'addressdetails' => 1,
@@ -104,11 +104,11 @@ final class Nominatim extends AbstractHttpProvider implements Provider
             if (is_array($countrycodes)) {
                 $countrycodes = array_map('strtolower', $countrycodes);
 
-                $url .= '&' . http_build_query([
+                $url .= '&'.http_build_query([
                     'countrycodes' => implode(',', $countrycodes),
                 ]);
             } else {
-                $url .= '&' . http_build_query([
+                $url .= '&'.http_build_query([
                     'countrycodes' => strtolower($countrycodes),
                 ]);
             }
@@ -116,13 +116,13 @@ final class Nominatim extends AbstractHttpProvider implements Provider
 
         $viewbox = $query->getData('viewbox');
         if (!is_null($viewbox) && is_array($viewbox) && 4 === count($viewbox)) {
-            $url .= '&' . http_build_query([
+            $url .= '&'.http_build_query([
                 'viewbox' => implode(',', $viewbox),
             ]);
 
             $bounded = $query->getData('bounded');
             if (!is_null($bounded) && true === $bounded) {
-                $url .= '&' . http_build_query([
+                $url .= '&'.http_build_query([
                     'bounded' => 1,
                 ]);
             }
@@ -157,8 +157,8 @@ final class Nominatim extends AbstractHttpProvider implements Provider
         $latitude = $coordinates->getLatitude();
 
         $url = $this->rootUrl
-            . '/reverse?'
-            . http_build_query([
+            .'/reverse?'
+            .http_build_query([
                 'format' => 'jsonv2',
                 'lat' => $latitude,
                 'lon' => $longitude,
@@ -264,7 +264,7 @@ final class Nominatim extends AbstractHttpProvider implements Provider
     private function executeQuery(string $url, ?string $locale = null): string
     {
         if (null !== $locale) {
-            $url .= '&' . http_build_query([
+            $url .= '&'.http_build_query([
                 'accept-language' => $locale,
             ]);
         }

--- a/src/Provider/OpenCage/Model/OpenCageAddress.php
+++ b/src/Provider/OpenCage/Model/OpenCageAddress.php
@@ -54,7 +54,7 @@ final class OpenCageAddress extends Address
      *
      * @return OpenCageAddress
      */
-    public function withMGRS(string $mgrs = null): self
+    public function withMGRS(?string $mgrs = null): self
     {
         $new = clone $this;
         $new->mgrs = $mgrs;
@@ -65,7 +65,7 @@ final class OpenCageAddress extends Address
     /**
      * @return null|string
      */
-    public function getMGRS()
+    public function getMGRS(): ?string
     {
         return $this->mgrs;
     }
@@ -75,7 +75,7 @@ final class OpenCageAddress extends Address
      *
      * @return OpenCageAddress
      */
-    public function withMaidenhead(string $maidenhead = null): self
+    public function withMaidenhead(?string $maidenhead = null): self
     {
         $new = clone $this;
         $new->maidenhead = $maidenhead;
@@ -86,7 +86,7 @@ final class OpenCageAddress extends Address
     /**
      * @return null|string
      */
-    public function getMaidenhead()
+    public function getMaidenhead(): ?string
     {
         return $this->maidenhead;
     }
@@ -96,7 +96,7 @@ final class OpenCageAddress extends Address
      *
      * @return OpenCageAddress
      */
-    public function withGeohash(string $geohash = null): self
+    public function withGeohash(?string $geohash = null): self
     {
         $new = clone $this;
         $new->geohash = $geohash;
@@ -107,7 +107,7 @@ final class OpenCageAddress extends Address
     /**
      * @return null|string
      */
-    public function getGeohash()
+    public function getGeohash(): ?string
     {
         return $this->geohash;
     }
@@ -117,7 +117,7 @@ final class OpenCageAddress extends Address
      *
      * @return OpenCageAddress
      */
-    public function withWhat3words(string $what3words = null): self
+    public function withWhat3words(?string $what3words = null): self
     {
         $new = clone $this;
         $new->what3words = $what3words;
@@ -128,7 +128,7 @@ final class OpenCageAddress extends Address
     /**
      * @return null|string
      */
-    public function getWhat3words()
+    public function getWhat3words(): ?string
     {
         return $this->what3words;
     }
@@ -138,7 +138,7 @@ final class OpenCageAddress extends Address
      *
      * @return OpenCageAddress
      */
-    public function withFormattedAddress(string $formattedAddress = null): self
+    public function withFormattedAddress(?string $formattedAddress = null): self
     {
         $new = clone $this;
         $new->formattedAddress = $formattedAddress;
@@ -149,7 +149,7 @@ final class OpenCageAddress extends Address
     /**
      * @return null|string
      */
-    public function getFormattedAddress()
+    public function getFormattedAddress(): ?string
     {
         return $this->formattedAddress;
     }

--- a/src/Provider/OpenCage/OpenCage.php
+++ b/src/Provider/OpenCage/OpenCage.php
@@ -243,7 +243,7 @@ final class OpenCage extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessLocality(array $components)
+    protected function guessLocality(array $components): ?string
     {
         $localityKeys = ['city', 'town', 'municipality', 'village', 'hamlet', 'locality', 'croft'];
 
@@ -255,7 +255,7 @@ final class OpenCage extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessStreetName(array $components)
+    protected function guessStreetName(array $components): ?string
     {
         $streetNameKeys = ['road', 'footway', 'street', 'street_name', 'residential', 'path', 'pedestrian', 'road_reference', 'road_reference_intl'];
 
@@ -267,7 +267,7 @@ final class OpenCage extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessSubLocality(array $components)
+    protected function guessSubLocality(array $components): ?string
     {
         $subLocalityKeys = ['neighbourhood', 'suburb', 'city_district', 'district', 'quarter', 'houses', 'subdivision'];
 
@@ -280,7 +280,7 @@ final class OpenCage extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessBestComponent(array $components, array $keys)
+    protected function guessBestComponent(array $components, array $keys): ?string
     {
         foreach ($keys as $key) {
             if (isset($components[$key]) && !empty($components[$key])) {

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -207,7 +207,7 @@ class Pelias extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessLocality(array $components)
+    protected function guessLocality(array $components): ?string
     {
         $localityKeys = ['city', 'town', 'village', 'hamlet'];
 
@@ -219,7 +219,7 @@ class Pelias extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessStreetName(array $components)
+    protected function guessStreetName(array $components): ?string
     {
         $streetNameKeys = ['road', 'street', 'street_name', 'residential'];
 
@@ -231,7 +231,7 @@ class Pelias extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessSubLocality(array $components)
+    protected function guessSubLocality(array $components): ?string
     {
         $subLocalityKeys = ['neighbourhood', 'city_district'];
 
@@ -244,7 +244,7 @@ class Pelias extends AbstractHttpProvider implements Provider
      *
      * @return null|string
      */
-    protected function guessBestComponent(array $components, array $keys)
+    protected function guessBestComponent(array $components, array $keys): ?string
     {
         foreach ($keys as $key) {
             if (isset($components[$key]) && !empty($components[$key])) {

--- a/src/Provider/Photon/Model/PhotonAddress.php
+++ b/src/Provider/Photon/Model/PhotonAddress.php
@@ -47,7 +47,7 @@ final class PhotonAddress extends Address
      *
      * @return PhotonAddress
      */
-    public function withOSMId(int $osmId = null): self
+    public function withOSMId(?int $osmId = null): self
     {
         $new = clone $this;
         $new->osmId = $osmId;
@@ -58,7 +58,7 @@ final class PhotonAddress extends Address
     /**
      * @return null|string
      */
-    public function getOSMType()
+    public function getOSMType(): ?string
     {
         return $this->osmType;
     }
@@ -68,7 +68,7 @@ final class PhotonAddress extends Address
      *
      * @return PhotonAddress
      */
-    public function withOSMType(string $osmType = null): self
+    public function withOSMType(?string $osmType = null): self
     {
         $new = clone $this;
         $new->osmType = $osmType;
@@ -90,7 +90,7 @@ final class PhotonAddress extends Address
      *
      * @return PhotonAddress
      */
-    public function withOSMTag(string $key = null, string $value = null): self
+    public function withOSMTag(?string $key = null, ?string $value = null): self
     {
         $new = clone $this;
 

--- a/src/Provider/Photon/Photon.php
+++ b/src/Provider/Photon/Photon.php
@@ -70,8 +70,8 @@ final class Photon extends AbstractHttpProvider implements Provider
         }
 
         $url = $this->rootUrl
-            . '/api?'
-            . http_build_query([
+            .'/api?'
+            .http_build_query([
                 'q' => $address,
                 'limit' => $query->getLimit(),
                 'lang' => $query->getLocale(),
@@ -102,8 +102,8 @@ final class Photon extends AbstractHttpProvider implements Provider
         $latitude = $coordinates->getLatitude();
 
         $url = $this->rootUrl
-            . '/reverse?'
-            . http_build_query([
+            .'/reverse?'
+            .http_build_query([
                 'lat' => $latitude,
                 'lon' => $longitude,
                 'lang' => $query->getLocale(),

--- a/src/Provider/Photon/Photon.php
+++ b/src/Provider/Photon/Photon.php
@@ -50,7 +50,7 @@ final class Photon extends AbstractHttpProvider implements Provider
      * @param HttpClient $client  an HTTP client
      * @param string     $rootUrl Root URL of the photon server
      */
-    public function __construct(HttpClient $client, $rootUrl)
+    public function __construct(HttpClient $client, string $rootUrl)
     {
         parent::__construct($client);
 
@@ -70,8 +70,8 @@ final class Photon extends AbstractHttpProvider implements Provider
         }
 
         $url = $this->rootUrl
-            .'/api?'
-            .http_build_query([
+            . '/api?'
+            . http_build_query([
                 'q' => $address,
                 'limit' => $query->getLimit(),
                 'lang' => $query->getLocale(),
@@ -102,8 +102,8 @@ final class Photon extends AbstractHttpProvider implements Provider
         $latitude = $coordinates->getLatitude();
 
         $url = $this->rootUrl
-            .'/reverse?'
-            .http_build_query([
+            . '/reverse?'
+            . http_build_query([
                 'lat' => $latitude,
                 'lon' => $longitude,
                 'lang' => $query->getLocale(),

--- a/src/Provider/PickPoint/PickPoint.php
+++ b/src/Provider/PickPoint/PickPoint.php
@@ -171,12 +171,12 @@ final class PickPoint extends AbstractHttpProvider implements Provider
 
     private function getGeocodeEndpointUrl(): string
     {
-        return self::BASE_API_URL . '/forward?q=%s&format=xml&addressdetails=1&limit=%d&key=' . $this->apiKey;
+        return self::BASE_API_URL.'/forward?q=%s&format=xml&addressdetails=1&limit=%d&key='.$this->apiKey;
     }
 
     private function getReverseEndpointUrl(): string
     {
-        return self::BASE_API_URL . '/reverse?format=xml&lat=%F&lon=%F&addressdetails=1&zoom=%d&key=' . $this->apiKey;
+        return self::BASE_API_URL.'/reverse?format=xml&lat=%F&lon=%F&addressdetails=1&zoom=%d&key='.$this->apiKey;
     }
 
     private function getNodeValue(\DOMNodeList $element)

--- a/src/Provider/PickPoint/PickPoint.php
+++ b/src/Provider/PickPoint/PickPoint.php
@@ -160,7 +160,7 @@ final class PickPoint extends AbstractHttpProvider implements Provider
      *
      * @return string
      */
-    private function executeQuery(string $url, string $locale = null): string
+    private function executeQuery(string $url, ?string $locale = null): string
     {
         if (null !== $locale) {
             $url = sprintf('%s&accept-language=%s', $url, $locale);
@@ -171,12 +171,12 @@ final class PickPoint extends AbstractHttpProvider implements Provider
 
     private function getGeocodeEndpointUrl(): string
     {
-        return self::BASE_API_URL.'/forward?q=%s&format=xml&addressdetails=1&limit=%d&key='.$this->apiKey;
+        return self::BASE_API_URL . '/forward?q=%s&format=xml&addressdetails=1&limit=%d&key=' . $this->apiKey;
     }
 
     private function getReverseEndpointUrl(): string
     {
-        return self::BASE_API_URL.'/reverse?format=xml&lat=%F&lon=%F&addressdetails=1&zoom=%d&key='.$this->apiKey;
+        return self::BASE_API_URL . '/reverse?format=xml&lat=%F&lon=%F&addressdetails=1&zoom=%d&key=' . $this->apiKey;
     }
 
     private function getNodeValue(\DOMNodeList $element)

--- a/src/Provider/Yandex/Model/YandexAddress.php
+++ b/src/Provider/Yandex/Model/YandexAddress.php
@@ -41,7 +41,7 @@ final class YandexAddress extends Address
     /**
      * @return null|string
      */
-    public function getPrecision()
+    public function getPrecision(): ?string
     {
         return $this->precision;
     }
@@ -51,7 +51,7 @@ final class YandexAddress extends Address
      *
      * @return YandexAddress
      */
-    public function withPrecision(string $precision = null): self
+    public function withPrecision(?string $precision = null): self
     {
         $new = clone $this;
         $new->precision = $precision;
@@ -62,7 +62,7 @@ final class YandexAddress extends Address
     /**
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -72,7 +72,7 @@ final class YandexAddress extends Address
      *
      * @return YandexAddress
      */
-    public function withName(string $name = null): self
+    public function withName(?string $name = null): self
     {
         $new = clone $this;
         $new->name = $name;
@@ -83,7 +83,7 @@ final class YandexAddress extends Address
     /**
      * @return string|null
      */
-    public function getKind(): string
+    public function getKind(): ?string
     {
         return $this->kind;
     }
@@ -93,7 +93,7 @@ final class YandexAddress extends Address
      *
      * @return YandexAddress
      */
-    public function withKind(string $kind = null): self
+    public function withKind(?string $kind = null): self
     {
         $new = clone $this;
         $new->kind = $kind;

--- a/src/Provider/Yandex/Yandex.php
+++ b/src/Provider/Yandex/Yandex.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
-                 * This file is part of the Geocoder package.
+ * This file is part of the Geocoder package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *

--- a/src/Provider/Yandex/Yandex.php
+++ b/src/Provider/Yandex/Yandex.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Geocoder package.
+                 * This file is part of the Geocoder package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
@@ -110,7 +110,7 @@ final class Yandex extends AbstractHttpProvider implements Provider
      *
      * @return AddressCollection
      */
-    private function executeQuery(string $url, int $limit, string $locale = null): AddressCollection
+    private function executeQuery(string $url, int $limit, ?string $locale = null): AddressCollection
     {
         if (null !== $locale) {
             $url = sprintf('%s&lang=%s', $url, str_replace('_', '-', $locale));
@@ -124,7 +124,8 @@ final class Yandex extends AbstractHttpProvider implements Provider
         $content = $this->getUrlContents($url);
         $json = json_decode($content, true);
 
-        if (empty($json) || isset($json['error']) ||
+        if (
+            empty($json) || isset($json['error']) ||
             (isset($json['response']) && '0' === $json['response']['GeoObjectCollection']['metaDataProperty']['GeocoderResponseMetaData']['found'])
         ) {
             return new AddressCollection([]);


### PR DESCRIPTION
Now that we removed support for PHP 7.0, we can use [nullable types](https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types).

I took the opportunity to improve functions signature.