### PR TITLE
Enable PHP 8.0 support (1)

### DIFF
--- a/src/Common/.travis.yml
+++ b/src/Common/.travis.yml
@@ -1,6 +1,11 @@
 language: php
 
-php: 7.2
+matrix:
+    fast_finish: true
+    include:
+        - php: 7.3
+        - php: 7.4
+        - php: 8.0
 
 install:
     - composer update --prefer-stable --prefer-dist

--- a/src/Common/CHANGELOG.md
+++ b/src/Common/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 4.4.0
+
+### Added
+
+- Add support for PHP 8.0
+
+### Removed
+
+- Drop support for PHP 7.2
+
+### Changed
+
+- Upgrade PHPUnit to version 9
+
 ## 4.3.0
 
 ### Removed
@@ -17,7 +31,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ### Fixed
 
-- Fix building ProviderNotRegistered exception message 
+- Fix building ProviderNotRegistered exception message
 
 ## 4.2.1
 
@@ -33,17 +47,17 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ### Fixed
 
-- Bug in `StatefulGeocoder` where different locale or bounds did not have any effect. 
+- Bug in `StatefulGeocoder` where different locale or bounds did not have any effect.
 
 ## 4.1.0
 
 ### Changed
 
-- Make sure a `Country` never will be empty of data. 
+- Make sure a `Country` never will be empty of data.
 
 ## 4.0.0
 
-No changes since Beta 5. 
+No changes since Beta 5.
 
 ## 4.0.0 - Beta 5
 
@@ -60,40 +74,38 @@ No changes since Beta 5.
 
 ## 4.0.0 - Beta 3
 
-### Added 
+### Added
 
-- The constructor of `ProvierAggregator` will accept a callable that can decide what providers should be used for a specific query. 
+- The constructor of `ProvierAggregator` will accept a callable that can decide what providers should be used for a specific query.
 
 ### Changed
 
 - `ProvierAggregator::getProvider` is now private
 - `ProvierAggregator::limit` was removed
 - `ProvierAggregator::getLimit` was removed
-- `ProvierAggregator::__constructor` changed the order of the parameters. 
-- `ProvierAggregator` is not final. 
-
+- `ProvierAggregator::__constructor` changed the order of the parameters.
+- `ProvierAggregator` is not final.
 
 ## 4.0.0 - Beta 2
 
 ### Added
 
-- PHP7 type hints. 
+- PHP7 type hints.
 - `AbstractArrayDumper` and `AbstractDumper`
 - `LogicException` and `OutOfBounds`
 - `GeocodeQuery::__toString` and `ReverseQuery::__toString`
 
 ### Changed
 
-- All Dumpers are now final. 
-- All Exceptions are now final. 
-- `AddressCollection` is now final. 
-- `ProviderAggregator` is now final. 
-- `StatefulGeocoder` is now final. 
-- `TimedGeocoder` is now final. 
+- All Dumpers are now final.
+- All Exceptions are now final.
+- `AddressCollection` is now final.
+- `ProviderAggregator` is now final.
+- `StatefulGeocoder` is now final.
+- `TimedGeocoder` is now final.
 - `ProviderAggregator::getName()` will return "provider_aggregator"
 - `TimedGeocoder::getName()` will return "timed_geocoder"
 
-
 ## 4.0.0 - Beta1
 
-First release of this library. 
+First release of this library.

--- a/src/Common/composer.json
+++ b/src/Common/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "nyholm/nsa": "^1.1",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^9.5",
         "symfony/stopwatch": "~2.5"
     },
     "suggest": {

--- a/src/Common/phpunit.xml.dist
+++ b/src/Common/phpunit.xml.dist
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  backupGlobals="false"
+  colors="true"
+  bootstrap="vendor/autoload.php"
+  >
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Http/.travis.yml
+++ b/src/Http/.travis.yml
@@ -1,6 +1,11 @@
 language: php
 
-php: 7.2
+matrix:
+    fast_finish: true
+    include:
+        - php: 7.3
+        - php: 7.4
+        - php: 8.0
 
 install:
     - composer update --prefer-stable --prefer-dist

--- a/src/Http/CHANGELOG.md
+++ b/src/Http/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 4.4.0
+
+### Added
+
+- Add support for PHP 8.0
+
+### Removed
+
+- Drop support for PHP 7.2
+
+### Changed
+
+- Upgrade PHPUnit to version 9
+
 ## 4.3.0
 
 ### Removed
@@ -19,14 +33,14 @@ got `AbstractHttpProvider::getUrlContents`, `AbstractHttpProvider::getRequest` a
 
 ## 4.0.0
 
-No changes since beta 2. 
+No changes since beta 2.
 
 ## 4.0.0-beta2
 
 - Removed `AbstractHttpProvider::setMessageFactory`.
 - Removed `AbstractHttpProvider::getHttpClient`.
-- Make sure we have a `MessageFactory` in the constructor of `AbstractHttpProvider`. 
+- Make sure we have a `MessageFactory` in the constructor of `AbstractHttpProvider`.
 
 ## 4.0.0-beta1
 
-First release of this library. 
+First release of this library.

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -27,7 +27,7 @@
         "nyholm/psr7": "^1.0",
         "php-http/message": "^1.0",
         "php-http/mock-client": "^1.0",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^9.5",
         "symfony/stopwatch": "~2.5"
     },
     "extra": {

--- a/src/Http/phpunit.xml.dist
+++ b/src/Http/phpunit.xml.dist
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  backupGlobals="false"
+  colors="true"
+  bootstrap="vendor/autoload.php"
+  >
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Plugin/.travis.yml
+++ b/src/Plugin/.travis.yml
@@ -1,6 +1,11 @@
 language: php
 
-php: 7.2
+matrix:
+    fast_finish: true
+    include:
+        - php: 7.3
+        - php: 7.4
+        - php: 8.0
 
 install:
     - composer update --prefer-stable --prefer-dist

--- a/src/Plugin/CHANGELOG.md
+++ b/src/Plugin/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 1.3.0
+
+### Added
+
+- Add support for PHP 8.0
+
+### Removed
+
+- Drop support for PHP 7.2
+
+### Changed
+
+- Upgrade PHPUnit to version 9
+
 ## 1.2.0
 
 ### Removed
@@ -10,10 +24,10 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## 1.1.0
 
-### Added 
+### Added
 
-- Support for setting permission on the cache plugin. 
+- Support for setting permission on the cache plugin.
 
 ## 1.0.0
 
-First release of this library. 
+First release of this library.

--- a/src/Plugin/composer.json
+++ b/src/Plugin/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "cache/void-adapter": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Plugin/phpunit.xml.dist
+++ b/src/Plugin/phpunit.xml.dist
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  backupGlobals="false"
+  colors="true"
+  bootstrap="vendor/autoload.php"
+  >
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/AlgoliaPlaces/composer.json
+++ b/src/Provider/AlgoliaPlaces/composer.json
@@ -24,7 +24,7 @@
         "geocoder-php/provider-integration-tests": "^1.1",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/ArcGISOnline/composer.json
+++ b/src/Provider/ArcGISOnline/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/AzureMaps/composer.json
+++ b/src/Provider/AzureMaps/composer.json
@@ -22,7 +22,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/BingMaps/composer.json
+++ b/src/Provider/BingMaps/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Cache/composer.json
+++ b/src/Provider/Cache/composer.json
@@ -20,7 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Chain/composer.json
+++ b/src/Provider/Chain/composer.json
@@ -23,7 +23,7 @@
         "nyholm/nsa": "^1.1",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/FreeGeoIp/composer.json
+++ b/src/Provider/FreeGeoIp/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GeoIP2/composer.json
+++ b/src/Provider/GeoIP2/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0.1",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GeoIPs/composer.json
+++ b/src/Provider/GeoIPs/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GeoPlugin/composer.json
+++ b/src/Provider/GeoPlugin/composer.json
@@ -24,7 +24,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GeocodeEarth/composer.json
+++ b/src/Provider/GeocodeEarth/composer.json
@@ -24,7 +24,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Geoip/composer.json
+++ b/src/Provider/Geoip/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0.1",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Geonames/composer.json
+++ b/src/Provider/Geonames/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GoogleMaps/composer.json
+++ b/src/Provider/GoogleMaps/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GoogleMapsPlaces/composer.json
+++ b/src/Provider/GoogleMapsPlaces/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GraphHopper/composer.json
+++ b/src/Provider/GraphHopper/composer.json
@@ -17,7 +17,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Here/composer.json
+++ b/src/Provider/Here/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.1",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/HostIp/composer.json
+++ b/src/Provider/HostIp/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/IP2Location/composer.json
+++ b/src/Provider/IP2Location/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/IP2LocationBinary/composer.json
+++ b/src/Provider/IP2LocationBinary/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0.1",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/IpInfo/composer.json
+++ b/src/Provider/IpInfo/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/IpInfoDb/composer.json
+++ b/src/Provider/IpInfoDb/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Ipstack/composer.json
+++ b/src/Provider/Ipstack/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/LocationIQ/composer.json
+++ b/src/Provider/LocationIQ/composer.json
@@ -22,7 +22,7 @@
         "willdurand/geocoder": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^9.5",
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/message": "^1.0",
         "php-http/curl-client": "^1.7"

--- a/src/Provider/MapQuest/composer.json
+++ b/src/Provider/MapQuest/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.1",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Mapbox/composer.json
+++ b/src/Provider/Mapbox/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Mapzen/composer.json
+++ b/src/Provider/Mapzen/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/MaxMind/composer.json
+++ b/src/Provider/MaxMind/composer.json
@@ -24,7 +24,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/MaxMindBinary/composer.json
+++ b/src/Provider/MaxMindBinary/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0.1",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Nominatim/composer.json
+++ b/src/Provider/Nominatim/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/OpenCage/composer.json
+++ b/src/Provider/OpenCage/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.2",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/OpenRouteService/composer.json
+++ b/src/Provider/OpenRouteService/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Pelias/composer.json
+++ b/src/Provider/Pelias/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.7",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Photon/composer.json
+++ b/src/Provider/Photon/composer.json
@@ -22,7 +22,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Provider/PickPoint/composer.json
+++ b/src/Provider/PickPoint/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/TomTom/composer.json
+++ b/src/Provider/TomTom/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Yandex/composer.json
+++ b/src/Provider/Yandex/composer.json
@@ -23,7 +23,7 @@
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Following #1102 !

Upgrade PHPUnit for components `Common`, `Http`, and `Plugin`

**Next step:** Release new version of [`willdurand/geocode`](https://github.com/geocoder-php/php-common) and [`geocoder-php/common-http`](https://github.com/geocoder-php/php-common-http) so we can upgrade all providers.