### PR TITLE
Enable PHP 8.0 support (2)

### DIFF
--- a/src/Provider/AlgoliaPlaces/composer.json
+++ b/src/Provider/AlgoliaPlaces/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.1",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/AlgoliaPlaces/phpunit.xml.dist
+++ b/src/Provider/AlgoliaPlaces/phpunit.xml.dist
@@ -1,29 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="ALGOLIA_API_KEY" value="" />
-        <server name="ALGOLIA_APP_ID" value="" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="ALGOLIA_API_KEY" value=""/>
+    <server name="ALGOLIA_APP_ID" value=""/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/ArcGISOnline/composer.json
+++ b/src/Provider/ArcGISOnline/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/ArcGISOnline/phpunit.xml.dist
+++ b/src/Provider/ArcGISOnline/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="ARCGIS_TOKEN" value="YOUR_ARCGIS_TOKEN" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="ARCGIS_TOKEN" value="YOUR_ARCGIS_TOKEN"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/AzureMaps/composer.json
+++ b/src/Provider/AzureMaps/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/AzureMaps/phpunit.xml.dist
+++ b/src/Provider/AzureMaps/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="AZURE_MAPS_SUBSCRIPTION_KEY" value="YOUR_AZURE_MAPS_SUBSCRIPTION_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="AZURE_MAPS_SUBSCRIPTION_KEY" value="YOUR_AZURE_MAPS_SUBSCRIPTION_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/BingMaps/composer.json
+++ b/src/Provider/BingMaps/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/BingMaps/phpunit.xml.dist
+++ b/src/Provider/BingMaps/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="BINGMAPS_API_KEY" value="YOUR_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="BINGMAPS_API_KEY" value="YOUR_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Cache/phpunit.xml.dist
+++ b/src/Provider/Cache/phpunit.xml.dist
@@ -1,25 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Chain/composer.json
+++ b/src/Provider/Chain/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "nyholm/nsa": "^1.1",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Chain/phpunit.xml.dist
+++ b/src/Provider/Chain/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/FreeGeoIp/composer.json
+++ b/src/Provider/FreeGeoIp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/FreeGeoIp/phpunit.xml.dist
+++ b/src/Provider/FreeGeoIp/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/GeoIP2/phpunit.xml.dist
+++ b/src/Provider/GeoIP2/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/GeoIPs/composer.json
+++ b/src/Provider/GeoIPs/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GeoIPs/phpunit.xml.dist
+++ b/src/Provider/GeoIPs/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-        <server name="GEOIPS_API_KEY" value="YOUR_API_KEY" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+    <server name="GEOIPS_API_KEY" value="YOUR_API_KEY"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/GeoPlugin/composer.json
+++ b/src/Provider/GeoPlugin/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GeoPlugin/phpunit.xml.dist
+++ b/src/Provider/GeoPlugin/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/GeocodeEarth/composer.json
+++ b/src/Provider/GeocodeEarth/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GeocodeEarth/phpunit.xml.dist
+++ b/src/Provider/GeocodeEarth/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="GEOCODE_EARTH_API_KEY" value="YOUR_GEOCODE_EARTH_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="GEOCODE_EARTH_API_KEY" value="YOUR_GEOCODE_EARTH_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Geonames/composer.json
+++ b/src/Provider/Geonames/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Geonames/phpunit.xml.dist
+++ b/src/Provider/Geonames/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="GEONAMES_USERNAME" value="YOUR_USERNAME" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="GEONAMES_USERNAME" value="YOUR_USERNAME"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/GoogleMaps/composer.json
+++ b/src/Provider/GoogleMaps/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GoogleMaps/phpunit.xml.dist
+++ b/src/Provider/GoogleMaps/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="GOOGLE_GEOCODING_KEY" value="YOUR_GEOCODING_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="GOOGLE_GEOCODING_KEY" value="YOUR_GEOCODING_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/GoogleMapsPlaces/composer.json
+++ b/src/Provider/GoogleMapsPlaces/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GoogleMapsPlaces/phpunit.xml.dist
+++ b/src/Provider/GoogleMapsPlaces/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="GOOGLE_GEOCODING_KEY" value="YOUR_GEOCODING_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="GOOGLE_GEOCODING_KEY" value="YOUR_GEOCODING_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/GraphHopper/composer.json
+++ b/src/Provider/GraphHopper/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GraphHopper/phpunit.xml.dist
+++ b/src/Provider/GraphHopper/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="GRAPHHOPPER_API_KEY" value="YOUR_GRAPHHOPPER_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="GRAPHHOPPER_API_KEY" value="YOUR_GRAPHHOPPER_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Here/composer.json
+++ b/src/Provider/Here/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.1",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Here/phpunit.xml.dist
+++ b/src/Provider/Here/phpunit.xml.dist
@@ -1,31 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="HERE_APP_ID" value="YOUR_APP_ID" />
-        <server name="HERE_APP_CODE" value="YOUR_APP_CODE" />
-        <server name="HERE_API_KEY" value="YOUR_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="HERE_APP_ID" value="YOUR_APP_ID"/>
+    <server name="HERE_APP_CODE" value="YOUR_APP_CODE"/>
+    <server name="HERE_API_KEY" value="YOUR_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/HostIp/composer.json
+++ b/src/Provider/HostIp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/HostIp/phpunit.xml.dist
+++ b/src/Provider/HostIp/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/IP2Location/composer.json
+++ b/src/Provider/IP2Location/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/IP2Location/phpunit.xml.dist
+++ b/src/Provider/IP2Location/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <!--<server name="IP2LOCATION_API_KEY" value="YOUR_API_KEY" />-->
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <!--<server name="IP2LOCATION_API_KEY" value="YOUR_API_KEY" />-->
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/IP2LocationBinary/phpunit.xml.dist
+++ b/src/Provider/IP2LocationBinary/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/IpInfo/composer.json
+++ b/src/Provider/IpInfo/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/IpInfo/phpunit.xml.dist
+++ b/src/Provider/IpInfo/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/IpInfoDb/composer.json
+++ b/src/Provider/IpInfoDb/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/IpInfoDb/phpunit.xml.dist
+++ b/src/Provider/IpInfoDb/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="IPINFODB_API_KEY" value="YOUR_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="IPINFODB_API_KEY" value="YOUR_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Ipstack/composer.json
+++ b/src/Provider/Ipstack/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Ipstack/phpunit.xml.dist
+++ b/src/Provider/Ipstack/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="IPSTACK_API_KEY" value="YOUR_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="IPSTACK_API_KEY" value="YOUR_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/LocationIQ/composer.json
+++ b/src/Provider/LocationIQ/composer.json
@@ -25,7 +25,7 @@
         "phpunit/phpunit": "^9.5",
         "geocoder-php/provider-integration-tests": "^1.0",
         "php-http/message": "^1.0",
-        "php-http/curl-client": "^1.7"
+        "php-http/curl-client": "^2.2"
     },
     "provide": {
         "geocoder-php/provider-implementation": "1.0"

--- a/src/Provider/LocationIQ/phpunit.xml.dist
+++ b/src/Provider/LocationIQ/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="LOCATIONIQ_API_KEY" value="YOUR_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="LOCATIONIQ_API_KEY" value="YOUR_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/MapQuest/composer.json
+++ b/src/Provider/MapQuest/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.1",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/MapQuest/phpunit.xml.dist
+++ b/src/Provider/MapQuest/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="MAPQUEST_API_KEY" value="YOUR_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="MAPQUEST_API_KEY" value="YOUR_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Mapbox/composer.json
+++ b/src/Provider/Mapbox/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Mapbox/phpunit.xml.dist
+++ b/src/Provider/Mapbox/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="MAPBOX_GEOCODING_KEY" value="YOUR_GEOCODING_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="MAPBOX_GEOCODING_KEY" value="YOUR_GEOCODING_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Mapzen/composer.json
+++ b/src/Provider/Mapzen/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Mapzen/phpunit.xml.dist
+++ b/src/Provider/Mapzen/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="MAPZEN_API_KEY" value="YOUR_MAPZEN_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="MAPZEN_API_KEY" value="YOUR_MAPZEN_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/MaxMind/composer.json
+++ b/src/Provider/MaxMind/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/common-http": "^4.0",
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/MaxMind/phpunit.xml.dist
+++ b/src/Provider/MaxMind/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <!--<server name="MAXMIND_API_KEY" value="YOUR_API_KEY" />-->
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <!--<server name="MAXMIND_API_KEY" value="YOUR_API_KEY" />-->
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/MaxMindBinary/phpunit.xml.dist
+++ b/src/Provider/MaxMindBinary/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="BINGMAPS_API_KEY" value="YOUR_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="BINGMAPS_API_KEY" value="YOUR_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Nominatim/composer.json
+++ b/src/Provider/Nominatim/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Nominatim/phpunit.xml.dist
+++ b/src/Provider/Nominatim/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/OpenCage/composer.json
+++ b/src/Provider/OpenCage/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.2",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/OpenCage/phpunit.xml.dist
+++ b/src/Provider/OpenCage/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="OPENCAGE_API_KEY" value="YOUR_GEOCODING_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="OPENCAGE_API_KEY" value="YOUR_GEOCODING_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/OpenRouteService/composer.json
+++ b/src/Provider/OpenRouteService/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/OpenRouteService/phpunit.xml.dist
+++ b/src/Provider/OpenRouteService/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="OPEN_ROUTE_SERVICE_API_KEY" value="YOUR_OPEN_ROUTE_SERVICE_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="OPEN_ROUTE_SERVICE_API_KEY" value="YOUR_OPEN_ROUTE_SERVICE_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Pelias/composer.json
+++ b/src/Provider/Pelias/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.7",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Pelias/phpunit.xml.dist
+++ b/src/Provider/Pelias/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Photon/composer.json
+++ b/src/Provider/Photon/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Photon/phpunit.xml.dist
+++ b/src/Provider/Photon/phpunit.xml.dist
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/PickPoint/composer.json
+++ b/src/Provider/PickPoint/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/PickPoint/phpunit.xml.dist
+++ b/src/Provider/PickPoint/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="PICKPOINT_API_KEY" value="YOUR_API_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="PICKPOINT_API_KEY" value="YOUR_API_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/TomTom/composer.json
+++ b/src/Provider/TomTom/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/TomTom/phpunit.xml.dist
+++ b/src/Provider/TomTom/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="TOMTOM_MAP_KEY" value="YOUR_MAP_KEY" />
-        <server name="USE_CACHED_RESPONSES" value="true" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="TOMTOM_MAP_KEY" value="YOUR_MAP_KEY"/>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Provider/Yandex/composer.json
+++ b/src/Provider/Yandex/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Yandex/phpunit.xml.dist
+++ b/src/Provider/Yandex/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
-        <server name="YANDEX_API_KEY" value="YOUR_API_KEY" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Geocoder Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <server name="USE_CACHED_RESPONSES" value="true"/>
+    <server name="YANDEX_API_KEY" value="YOUR_API_KEY"/>
+  </php>
+  <testsuites>
+    <testsuite name="Geocoder Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Following #1103 !

- Upgrade `php-http/curl-client` for every provider
- Upgrade PHPUnit config

This is the last step to complete full PHP 8.0 support.