### PR TITLE
[Nominatim] Add support for structured requests

### DIFF
--- a/src/Provider/Nominatim/Tests/NominatimTest.php
+++ b/src/Provider/Nominatim/Tests/NominatimTest.php
@@ -168,6 +168,23 @@ class NominatimTest extends BaseTestCase
         $this->assertEquals('yes', $result->getType());
     }
 
+    public function testGeocodeWithStructuredRequest()
+    {
+        $provider = Nominatim::withOpenStreetMapServer($this->getHttpClient(), 'Geocoder PHP/Nominatim Provider/Nominatim Test');
+
+        $query = GeocodeQuery::create(' ')->withData('state', 'Nevada');
+
+        $results = $provider->geocodeQuery($query);
+
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
+        $this->assertCount(1, $results);
+
+        /** @var \Geocoder\Model\Address $result */
+        $result = $results->first();
+        $this->assertInstanceOf('\Geocoder\Model\Address', $result);
+        $this->assertEquals('Nevada, United States', $result->getDisplayName());
+    }
+
     public function testGeocodeNoOSMId()
     {
         $provider = Nominatim::withOpenStreetMapServer($this->getHttpClient(), 'Geocoder PHP/Nominatim Provider/Nominatim Test');


### PR DESCRIPTION
For the Nominatim search API, the search term may be specified with two different sets of parameters:

- Free-form query string `q`; or
- Structured request parameters: `street`, `city`, `county`, `state`, `country` and `postalcode`.

We currently only support the free-form format. This PR adds support for structured requests:

```PHP
$query = GeocodeQuery::create(' ')->withData('city', 'Las Vegas')->withData('state', 'Nevada');
```

Note that free-form format and structured request format cannot be combined. So, if structured requests parameters are given, we remove the `q` parameter.