### PR TITLE
[Photon] Add support for geo position query parameters.

### DIFF
--- a/src/Provider/Photon/Photon.php
+++ b/src/Provider/Photon/Photon.php
@@ -77,6 +77,13 @@ final class Photon extends AbstractHttpProvider implements Provider
                 'lang' => $query->getLocale(),
             ]);
 
+        $lat = $query->getData('lat');
+        $lon = $query->getData('lon');
+
+        if (!is_null($lat) && !is_null($lon)) {
+            $url .= '&'.http_build_query(compact('lat', 'lon'));
+        }
+
         $json = $this->executeQuery($url, $query->getLocale());
 
         if (!isset($json->features) || empty($json->features)) {

--- a/src/Provider/Photon/Tests/PhotonTest.php
+++ b/src/Provider/Photon/Tests/PhotonTest.php
@@ -90,6 +90,21 @@ class PhotonTest extends BaseTestCase
         $this->assertEquals('The Sherlock Holmes Museum and shop', $result->getName());
     }
 
+    public function testGeocodeQueryWithLatAndLon()
+    {
+        $provider = Photon::withKomootServer($this->getHttpClient());
+        $geocodeQuery = GeocodeQuery::create('Paris')
+            ->withData('lat', 33.6625)
+            ->withData('lon', -95.547778);
+        $results = $provider->geocodeQuery($geocodeQuery);
+
+        $this->assertInstanceOf('Geocoder\Model\AddressCollection', $results);
+
+        /** @var \Geocoder\Model\Address $result */
+        $result = $results->first();
+        $this->assertEquals('United States', $result->getCountry());
+    }
+
     public function testReverseQuery()
     {
         $provider = Photon::withKomootServer($this->getHttpClient());


### PR DESCRIPTION
The Photon search API supports the parameters `lat` and `lon` which serve to prioritize search results based on a given geo position.

This PR adds support for those parameters:

```PHP
$geocodeQuery = GeocodeQuery::create('Paris')
    ->withData('lat', 33.6625)
    ->withData('lon', -95.547778);
```