### PR TITLE
Replace empty() by more strict checks

### DIFF
--- a/src/Common/Dumper/AbstractArrayDumper.php
+++ b/src/Common/Dumper/AbstractArrayDumper.php
@@ -36,7 +36,7 @@ abstract class AbstractArrayDumper
             $properties['bounds']
         );
 
-        if (0 === count($properties)) {
+        if ([] === $properties) {
             $properties = null;
         }
 

--- a/src/Common/Model/Address.php
+++ b/src/Common/Model/Address.php
@@ -235,12 +235,12 @@ class Address implements Location
 
         $adminLevels = [];
         foreach ($data['adminLevels'] as $adminLevel) {
-            if (empty($adminLevel['level'])) {
+            if (null === $adminLevel['level'] || $adminLevel['level'] === 0) {
                 continue;
             }
 
             $name = $adminLevel['name'] ?? $adminLevel['code'] ?? null;
-            if (empty($name)) {
+            if (null === $name || strlen($name) === 0) {
                 continue;
             }
 

--- a/src/Common/Model/Address.php
+++ b/src/Common/Model/Address.php
@@ -240,7 +240,7 @@ class Address implements Location
             }
 
             $name = $adminLevel['name'] ?? $adminLevel['code'] ?? null;
-            if (null === $name || 0 === strlen($name)) {
+            if (null === $name || '' === $name) {
                 continue;
             }
 

--- a/src/Common/Model/Address.php
+++ b/src/Common/Model/Address.php
@@ -235,12 +235,12 @@ class Address implements Location
 
         $adminLevels = [];
         foreach ($data['adminLevels'] as $adminLevel) {
-            if (null === $adminLevel['level'] || $adminLevel['level'] === 0) {
+            if (null === $adminLevel['level'] || 0 === $adminLevel['level']) {
                 continue;
             }
 
             $name = $adminLevel['name'] ?? $adminLevel['code'] ?? null;
-            if (null === $name || strlen($name) === 0) {
+            if (null === $name || 0 === strlen($name)) {
                 continue;
             }
 

--- a/src/Common/Model/AddressBuilder.php
+++ b/src/Common/Model/AddressBuilder.php
@@ -109,7 +109,7 @@ final class AddressBuilder
         }
 
         $country = null;
-        if (!empty($this->country) || !empty($this->countryCode)) {
+        if ((null !== $this->country && strlen($this->country) > 0) || (null !== $this->countryCode && strlen($this->countryCode) > 0)) {
             $country = new Country($this->country, $this->countryCode);
         }
 

--- a/src/Common/Model/AddressBuilder.php
+++ b/src/Common/Model/AddressBuilder.php
@@ -109,7 +109,7 @@ final class AddressBuilder
         }
 
         $country = null;
-        if ((null !== $this->country && strlen($this->country) > 0) || (null !== $this->countryCode && strlen($this->countryCode) > 0)) {
+        if ((null !== $this->country && '' !== $this->country) || (null !== $this->countryCode && '' !== $this->countryCode)) {
             $country = new Country($this->country, $this->countryCode);
         }
 

--- a/src/Common/Model/AddressCollection.php
+++ b/src/Common/Model/AddressCollection.php
@@ -53,7 +53,7 @@ final class AddressCollection implements Collection
      */
     public function first(): Location
     {
-        if (empty($this->locations)) {
+        if (count($this->locations) === 0) {
             throw new CollectionIsEmpty();
         }
 
@@ -65,7 +65,7 @@ final class AddressCollection implements Collection
      */
     public function isEmpty(): bool
     {
-        return empty($this->locations);
+        return count($this->locations) === 0;
     }
 
     /**

--- a/src/Common/Model/AddressCollection.php
+++ b/src/Common/Model/AddressCollection.php
@@ -53,7 +53,7 @@ final class AddressCollection implements Collection
      */
     public function first(): Location
     {
-        if (count($this->locations) === 0) {
+        if (0 === count($this->locations)) {
             throw new CollectionIsEmpty();
         }
 
@@ -65,7 +65,7 @@ final class AddressCollection implements Collection
      */
     public function isEmpty(): bool
     {
-        return count($this->locations) === 0;
+        return 0 === count($this->locations);
     }
 
     /**

--- a/src/Common/Model/AddressCollection.php
+++ b/src/Common/Model/AddressCollection.php
@@ -53,7 +53,7 @@ final class AddressCollection implements Collection
      */
     public function first(): Location
     {
-        if (0 === count($this->locations)) {
+        if ([] === $this->locations) {
             throw new CollectionIsEmpty();
         }
 
@@ -65,7 +65,7 @@ final class AddressCollection implements Collection
      */
     public function isEmpty(): bool
     {
-        return 0 === count($this->locations);
+        return [] === $this->locations;
     }
 
     /**

--- a/src/Common/Model/AdminLevelCollection.php
+++ b/src/Common/Model/AdminLevelCollection.php
@@ -73,7 +73,7 @@ final class AdminLevelCollection implements \IteratorAggregate, \Countable
      */
     public function first(): AdminLevel
     {
-        if (empty($this->adminLevels)) {
+        if (count($this->adminLevels) === 0) {
             throw new CollectionIsEmpty();
         }
 

--- a/src/Common/Model/AdminLevelCollection.php
+++ b/src/Common/Model/AdminLevelCollection.php
@@ -73,7 +73,7 @@ final class AdminLevelCollection implements \IteratorAggregate, \Countable
      */
     public function first(): AdminLevel
     {
-        if (count($this->adminLevels) === 0) {
+        if (0 === count($this->adminLevels)) {
             throw new CollectionIsEmpty();
         }
 

--- a/src/Common/Model/AdminLevelCollection.php
+++ b/src/Common/Model/AdminLevelCollection.php
@@ -73,7 +73,7 @@ final class AdminLevelCollection implements \IteratorAggregate, \Countable
      */
     public function first(): AdminLevel
     {
-        if (0 === count($this->adminLevels)) {
+        if ([] === $this->adminLevels) {
             throw new CollectionIsEmpty();
         }
 

--- a/src/Common/ProviderAggregator.php
+++ b/src/Common/ProviderAggregator.php
@@ -180,7 +180,7 @@ class ProviderAggregator implements Geocoder
             return $currentProvider;
         }
 
-        if (0 === count($providers)) {
+        if ([] === $providers) {
             throw ProviderNotRegistered::noProviderRegistered();
         }
 

--- a/src/Common/Query/GeocodeQuery.php
+++ b/src/Common/Query/GeocodeQuery.php
@@ -53,7 +53,7 @@ final class GeocodeQuery implements Query
      */
     private function __construct(string $text)
     {
-        if (0 === strlen($text)) {
+        if ('' === $text) {
             throw new InvalidArgument('Geocode query cannot be empty');
         }
 

--- a/src/Common/Query/GeocodeQuery.php
+++ b/src/Common/Query/GeocodeQuery.php
@@ -53,7 +53,7 @@ final class GeocodeQuery implements Query
      */
     private function __construct(string $text)
     {
-        if (strlen($text) === 0) {
+        if (0 === strlen($text)) {
             throw new InvalidArgument('Geocode query cannot be empty');
         }
 

--- a/src/Common/Query/GeocodeQuery.php
+++ b/src/Common/Query/GeocodeQuery.php
@@ -53,7 +53,7 @@ final class GeocodeQuery implements Query
      */
     private function __construct(string $text)
     {
-        if (empty($text)) {
+        if (strlen($text) === 0) {
             throw new InvalidArgument('Geocode query cannot be empty');
         }
 

--- a/src/Common/StatefulGeocoder.php
+++ b/src/Common/StatefulGeocoder.php
@@ -93,7 +93,7 @@ final class StatefulGeocoder implements Geocoder
     public function geocodeQuery(GeocodeQuery $query): Collection
     {
         $locale = $query->getLocale();
-        if ((null === $locale || strlen($locale) === 0) && null !== $this->locale) {
+        if ((null === $locale || 0 === strlen($locale)) && null !== $this->locale) {
             $query = $query->withLocale($this->locale);
         }
 
@@ -111,7 +111,7 @@ final class StatefulGeocoder implements Geocoder
     public function reverseQuery(ReverseQuery $query): Collection
     {
         $locale = $query->getLocale();
-        if ((null === $locale || strlen($locale) === 0) && null !== $this->locale) {
+        if ((null === $locale || 0 === strlen($locale)) && null !== $this->locale) {
             $query = $query->withLocale($this->locale);
         }
 

--- a/src/Common/StatefulGeocoder.php
+++ b/src/Common/StatefulGeocoder.php
@@ -93,7 +93,7 @@ final class StatefulGeocoder implements Geocoder
     public function geocodeQuery(GeocodeQuery $query): Collection
     {
         $locale = $query->getLocale();
-        if ((null === $locale || 0 === strlen($locale)) && null !== $this->locale) {
+        if ((null === $locale || '' === $locale) && null !== $this->locale) {
             $query = $query->withLocale($this->locale);
         }
 
@@ -111,7 +111,7 @@ final class StatefulGeocoder implements Geocoder
     public function reverseQuery(ReverseQuery $query): Collection
     {
         $locale = $query->getLocale();
-        if ((null === $locale || 0 === strlen($locale)) && null !== $this->locale) {
+        if ((null === $locale || '' === $locale) && null !== $this->locale) {
             $query = $query->withLocale($this->locale);
         }
 

--- a/src/Common/StatefulGeocoder.php
+++ b/src/Common/StatefulGeocoder.php
@@ -23,7 +23,7 @@ use Geocoder\Provider\Provider;
 final class StatefulGeocoder implements Geocoder
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $locale;
 
@@ -61,7 +61,7 @@ final class StatefulGeocoder implements Geocoder
         $query = GeocodeQuery::create($value)
             ->withLimit($this->limit);
 
-        if (!empty($this->locale)) {
+        if (null !== $this->locale && strlen($this->locale) > 0) {
             $query = $query->withLocale($this->locale);
         }
 
@@ -80,7 +80,7 @@ final class StatefulGeocoder implements Geocoder
         $query = ReverseQuery::fromCoordinates($latitude, $longitude)
             ->withLimit($this->limit);
 
-        if (!empty($this->locale)) {
+        if (null !== $this->locale && strlen($this->locale) > 0) {
             $query = $query->withLocale($this->locale);
         }
 
@@ -93,7 +93,7 @@ final class StatefulGeocoder implements Geocoder
     public function geocodeQuery(GeocodeQuery $query): Collection
     {
         $locale = $query->getLocale();
-        if (empty($locale) && null !== $this->locale) {
+        if ((null === $locale || strlen($locale) === 0) && null !== $this->locale) {
             $query = $query->withLocale($this->locale);
         }
 
@@ -111,7 +111,7 @@ final class StatefulGeocoder implements Geocoder
     public function reverseQuery(ReverseQuery $query): Collection
     {
         $locale = $query->getLocale();
-        if (empty($locale) && null !== $this->locale) {
+        if ((null === $locale || strlen($locale) === 0) && null !== $this->locale) {
             $query = $query->withLocale($this->locale);
         }
 

--- a/src/Common/StatefulGeocoder.php
+++ b/src/Common/StatefulGeocoder.php
@@ -61,7 +61,7 @@ final class StatefulGeocoder implements Geocoder
         $query = GeocodeQuery::create($value)
             ->withLimit($this->limit);
 
-        if (null !== $this->locale && strlen($this->locale) > 0) {
+        if (null !== $this->locale && '' !== $this->locale) {
             $query = $query->withLocale($this->locale);
         }
 
@@ -80,7 +80,7 @@ final class StatefulGeocoder implements Geocoder
         $query = ReverseQuery::fromCoordinates($latitude, $longitude)
             ->withLimit($this->limit);
 
-        if (null !== $this->locale && strlen($this->locale) > 0) {
+        if (null !== $this->locale && '' !== $this->locale) {
             $query = $query->withLocale($this->locale);
         }
 

--- a/src/Http/Provider/AbstractHttpProvider.php
+++ b/src/Http/Provider/AbstractHttpProvider.php
@@ -96,7 +96,7 @@ abstract class AbstractHttpProvider extends AbstractProvider
         }
 
         $body = (string) $response->getBody();
-        if (empty($body)) {
+        if (strlen($body) === 0) {
             throw InvalidServerResponse::emptyResponse((string) $request->getUri());
         }
 

--- a/src/Http/Provider/AbstractHttpProvider.php
+++ b/src/Http/Provider/AbstractHttpProvider.php
@@ -96,7 +96,7 @@ abstract class AbstractHttpProvider extends AbstractProvider
         }
 
         $body = (string) $response->getBody();
-        if (0 === strlen($body)) {
+        if ('' === $body) {
             throw InvalidServerResponse::emptyResponse((string) $request->getUri());
         }
 

--- a/src/Http/Provider/AbstractHttpProvider.php
+++ b/src/Http/Provider/AbstractHttpProvider.php
@@ -96,7 +96,7 @@ abstract class AbstractHttpProvider extends AbstractProvider
         }
 
         $body = (string) $response->getBody();
-        if (strlen($body) === 0) {
+        if (0 === strlen($body)) {
             throw InvalidServerResponse::emptyResponse((string) $request->getUri());
         }
 

--- a/src/Plugin/Plugin/LimitPlugin.php
+++ b/src/Plugin/Plugin/LimitPlugin.php
@@ -40,7 +40,8 @@ class LimitPlugin implements Plugin
      */
     public function handleQuery(Query $query, callable $next, callable $first)
     {
-        if (empty($query->getLocale())) {
+        $limit = $query->getLimit();
+        if (null !== $limit && $limit > 0) {
             $query = $query->withLimit($this->limit);
         }
 

--- a/src/Plugin/Plugin/LocalePlugin.php
+++ b/src/Plugin/Plugin/LocalePlugin.php
@@ -40,7 +40,8 @@ class LocalePlugin implements Plugin
      */
     public function handleQuery(Query $query, callable $next, callable $first)
     {
-        if (empty($query->getLocale())) {
+        $locale = $query->getLocale();
+        if (null !== $locale && strlen($locale) > 0) {
             $query = $query->withLocale($this->locale);
         }
 

--- a/src/Plugin/Plugin/LocalePlugin.php
+++ b/src/Plugin/Plugin/LocalePlugin.php
@@ -41,7 +41,7 @@ class LocalePlugin implements Plugin
     public function handleQuery(Query $query, callable $next, callable $first)
     {
         $locale = $query->getLocale();
-        if (null !== $locale && strlen($locale) > 0) {
+        if (null !== $locale && '' !== $locale) {
             $query = $query->withLocale($this->locale);
         }
 

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -145,7 +145,7 @@ class Pelias extends AbstractHttpProvider implements Provider
             !isset($json['type'])
             || 'FeatureCollection' !== $json['type']
             || !isset($json['features'])
-            || 0 === count($json['features'])
+            || [] === $json['features']
         ) {
             return new AddressCollection([]);
         }

--- a/src/Provider/TomTom/TomTom.php
+++ b/src/Provider/TomTom/TomTom.php
@@ -126,7 +126,7 @@ final class TomTom extends AbstractHttpProvider implements Provider
 
         $json = json_decode($content, true);
 
-        if (!isset($json['addresses']) || 0 === count($json['addresses'])) {
+        if (!isset($json['addresses']) || [] === $json['addresses']) {
             return new AddressCollection([]);
         }
 


### PR DESCRIPTION
The function `empty()` is a very loose comparison (see [manual](https://www.php.net/manual/en/function.empty)), it's recommended to use more strict comparison (also close #1124).

- Replace `empty($string)` for strings by `null !== $string && strlen($string) > 0`
- Replace `empty($array)` for arrays by `null !== $array && count($array) > 0`

---

I left `empty()` for all the `Bounds` check because I don't really see how to replace it by a more strict check but I think it should be updated as well.

@Nyholm What do you consider an "empty bound" ?

---

I left an `empty()` in [`AbstractArrayDumper`](https://github.com/geocoder-php/Geocoder/blob/c02b93a471a4e7043448b518183d449ceefa81b9/src/Common/Dumper/AbstractArrayDumper.php#L29-L31) because I think it makes sense to keep a loose check there.

---

@Nyholm Doing this check, I stumble upon something that seemed strange.
In the `LimitPlugin`, it checked [`$query->getLocale()`](https://github.com/geocoder-php/Geocoder/blob/1714d61578ea4881c8d481feae4e214e902095e4/src/Plugin/Plugin/LimitPlugin.php#L43-L45) but I think it should check [`$query->getLimit()`](https://github.com/geocoder-php/Geocoder/blob/c02b93a471a4e7043448b518183d449ceefa81b9/src/Plugin/Plugin/LimitPlugin.php#L43-L46) instead.
Let me know if it was correct and I missed something.
