### PR TITLE
Fix LocalePlugin

### DIFF
--- a/src/Plugin/Plugin/LocalePlugin.php
+++ b/src/Plugin/Plugin/LocalePlugin.php
@@ -41,7 +41,7 @@ class LocalePlugin implements Plugin
     public function handleQuery(Query $query, callable $next, callable $first)
     {
         $locale = $query->getLocale();
-        if (null !== $locale && '' !== $locale) {
+        if (null === $locale || '' === $locale) {
             $query = $query->withLocale($this->locale);
         }
 


### PR DESCRIPTION
Previous PR #1125 brought an error in the LocalePlugin.

```php
if (empty($query->getLocale())) {
  $query = $query->withLocale($this->locale);
}
```

was replaced by 

```php
$locale = $query->getLocale();
if (null !== $locale && '' !== $locale) {
  $query = $query->withLocale($this->locale);
}
```

instead of

```php
$locale = $query->getLocale();
if (null === $locale || '' === $locale) {
  $query = $query->withLocale($this->locale);
}
```