### PR TITLE
Check if geonames key exists

### DIFF
--- a/src/Provider/Geonames/Geonames.php
+++ b/src/Provider/Geonames/Geonames.php
@@ -190,6 +190,10 @@ final class Geonames extends AbstractHttpProvider implements Provider
             return new AddressCollection([]);
         }
 
+        if (!isset($json->geonames)) {
+            return new AddressCollection([]);
+        }
+
         $data = $json->geonames;
 
         if (empty($data)) {


### PR DESCRIPTION
Check if `geonames` key exists before accessing it (similar to #783)