### PR TITLE
[GoogleMapsPlaces] Add missing fields in model

### DIFF
--- a/src/Provider/GoogleMapsPlaces/GoogleMapsPlaces.php
+++ b/src/Provider/GoogleMapsPlaces/GoogleMapsPlaces.php
@@ -347,6 +347,10 @@ final class GoogleMapsPlaces extends AbstractHttpProvider implements Provider
                 $address = $address->withName($result->name);
             }
 
+            if (isset($result->business_status)) {
+                $address = $address->withBusinessStatus($result->business_status);
+            }
+
             if (isset($result->formatted_address)) {
                 $address = $address->withFormattedAddress($result->formatted_address);
             }
@@ -361,6 +365,14 @@ final class GoogleMapsPlaces extends AbstractHttpProvider implements Provider
 
             if (isset($result->icon)) {
                 $address = $address->withIcon($result->icon);
+            }
+
+            if (isset($result->icon_background_color)) {
+                $address = $address->withIconBackgroundColor($result->icon_background_color);
+            }
+
+            if (isset($result->icon_mask_base_uri)) {
+                $address = $address->withIconMaskBaseUri($result->icon_mask_base_uri);
             }
 
             if (isset($result->plus_code)) {
@@ -380,6 +392,14 @@ final class GoogleMapsPlaces extends AbstractHttpProvider implements Provider
 
             if (isset($result->rating)) {
                 $address = $address->withRating((float) $result->rating);
+            }
+
+            if (isset($result->user_ratings_total)) {
+                $address = $address->withUserRatingsTotal((float) $result->user_ratings_total);
+            }
+
+            if (isset($result->reference)) {
+                $address = $address->withReference($result->reference);
             }
 
             if (isset($result->formatted_phone_number)) {

--- a/src/Provider/GoogleMapsPlaces/Model/GooglePlace.php
+++ b/src/Provider/GoogleMapsPlaces/Model/GooglePlace.php
@@ -37,6 +37,11 @@ final class GooglePlace extends Address
     /**
      * @var string|null
      */
+    private $businessStatus;
+
+    /**
+     * @var string|null
+     */
     private $formattedAddress;
 
     /**
@@ -48,6 +53,16 @@ final class GooglePlace extends Address
      * @var string|null
      */
     private $icon;
+
+    /**
+     * @var string|null
+     */
+    private $iconBackgroundColor;
+
+    /**
+     * @var string|null
+     */
+    private $iconMaskBaseUri;
 
     /**
      * @var PlusCode|null
@@ -68,6 +83,16 @@ final class GooglePlace extends Address
      * @var float|null
      */
     private $rating;
+
+    /**
+     * @var string|null
+     */
+    private $reference;
+
+    /**
+     * @var float|null
+     */
+    private $userRatingsTotal;
 
     /**
      * @var string|null
@@ -162,6 +187,27 @@ final class GooglePlace extends Address
     /**
      * @return string|null
      */
+    public function getBusinessStatus()
+    {
+        return $this->businessStatus;
+    }
+
+    /**
+     * @param string|null $businessStatus
+     *
+     * @return GooglePlace
+     */
+    public function withBusinessStatus(string $businessStatus = null)
+    {
+        $new = clone $this;
+        $new->businessStatus = $businessStatus;
+
+        return $new;
+    }
+
+    /**
+     * @return string|null
+     */
     public function getFormattedAddress()
     {
         return $this->formattedAddress;
@@ -213,6 +259,38 @@ final class GooglePlace extends Address
     {
         $new = clone $this;
         $new->icon = $icon;
+
+        return $new;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getIconBackgroundColor(): string
+    {
+        return $this->iconBackgroundColor;
+    }
+
+    public function withIconBackgroundColor(string $iconBackgroundColor = null)
+    {
+        $new = clone $this;
+        $new->iconBackgroundColor = $iconBackgroundColor;
+
+        return $new;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getIconMaskBaseUri(): string
+    {
+        return $this->iconMaskBaseUri;
+    }
+
+    public function withIconMaskBaseUri(string $iconMaskBaseUri = null)
+    {
+        $new = clone $this;
+        $new->iconMaskBaseUri = $iconMaskBaseUri;
 
         return $new;
     }
@@ -285,6 +363,38 @@ final class GooglePlace extends Address
     {
         $new = clone $this;
         $new->rating = $rating;
+
+        return $new;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getUserRatingsTotal()
+    {
+        return $this->userRatingsTotal;
+    }
+
+    public function withUserRatingsTotal(float $userRatingsTotal = null)
+    {
+        $new = clone $this;
+        $new->userRatingsTotal = $userRatingsTotal;
+
+        return $new;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getReference()
+    {
+        return $this->reference;
+    }
+
+    public function withReference(string $reference)
+    {
+        $new = clone $this;
+        $new->reference = $reference;
 
         return $new;
     }


### PR DESCRIPTION
The current model for the GoogleMapsPlaces provider has some missing fields. This PR allows usage of all fields provided by Google Maps Places returned when mode=search. 

Added fields:
* business_status
* icon_background_color
* icon_mask_base_uri
* user_ratings_total
* reference