### PR TITLE
[Nominatim] added 'municipality' as a 'locality'

### DIFF
--- a/src/Provider/Nominatim/Nominatim.php
+++ b/src/Provider/Nominatim/Nominatim.php
@@ -206,7 +206,7 @@ final class Nominatim extends AbstractHttpProvider implements Provider
             $builder->setPostalCode($postalCode);
         }
 
-        $localityFields = ['city', 'town', 'village', 'hamlet'];
+        $localityFields = ['city', 'town', 'village', 'hamlet', 'municipality'];
         foreach ($localityFields as $localityField) {
             if (isset($place->address->{$localityField})) {
                 $localityFieldContent = $place->address->{$localityField};


### PR DESCRIPTION
Municipality was not in the array of 'locality' fields, see #1155.

Order matters, not sure what position in the array this should have.