### PR TITLE
chore: add ci tests for php 8.2, bump github actions versions

### DIFF
--- a/.github/workflows/component.yml
+++ b/.github/workflows/component.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
         component: [Common, Http, Plugin]
 
     name: PHP ${{ matrix.php-version }} / ${{ matrix.component }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
         deps: ['low', 'high']
 
     name: PHP ${{ matrix.php-version }} (${{ matrix.deps }})

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
         provider:
           - AlgoliaPlaces
           - ArcGISOnline


### PR DESCRIPTION
bump github actions versions to fix deprecations message for Node 12.