### PR TITLE
Make "Subtree Split" using GitHub Actions

### DIFF
--- a/.github/actions/subtree/action.yml
+++ b/.github/actions/subtree/action.yml
@@ -11,7 +11,6 @@ inputs:
   repository:
     description: "Repository to push to (in the same organization)"
     required: true
-outputs: []
 runs:
   using: "composite"
   steps:
@@ -24,12 +23,14 @@ runs:
             - "${{ inputs.directory }}/**"
     - name: Subtree
       if: steps.filter.outputs.changes == 'true'
+      shell: bash
       run: |
         wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
         chmod +x /usr/local/bin/git-filter-repo
         git filter-repo --debug --subdirectory-filter "${{ inputs.directory }}/"
     - name: Push subtree
       if: steps.filter.outputs.changes == 'true'
+      shell: bash
       run: |
         git remote add subtree "https://github.com/geocoder-php/${{ inputs.repository }}.git"
         git push --force --set-upstream subtree master

--- a/.github/actions/subtree/action.yml
+++ b/.github/actions/subtree/action.yml
@@ -30,14 +30,14 @@ runs:
           directory:
             - "${{ inputs.directory }}/**"
     - name: Subtree
-      # if: steps.changes.outputs.directory == 'true'
+      if: steps.changes.outputs.directory == 'true'
       shell: bash
       run: |
         wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
         chmod +x /usr/local/bin/git-filter-repo
         git filter-repo --debug --subdirectory-filter "${{ inputs.directory }}/"
     - name: Push subtree
-      # if: steps.changes.outputs.directory == 'true'
+      if: steps.changes.outputs.directory == 'true'
       shell: bash
       run: |
         git remote add subtree "https://github.com/geocoder-php/${{ inputs.repository }}.git"

--- a/.github/actions/subtree/action.yml
+++ b/.github/actions/subtree/action.yml
@@ -11,25 +11,33 @@ inputs:
   repository:
     description: "Repository to push to (in the same organization)"
     required: true
+outputs:
+  changes:
+    description: "Is there any changes in the directory?"
+    value: ${{ steps.changes.outputs.directory }}
+  files:
+    description: "List of files changed in the directory"
+    value: ${{ steps.changes.outputs.files }}
 runs:
   using: "composite"
   steps:
     - name: Detect changes
       uses: dorny/paths-filter@v2
-      id: filter
+      id: changes
       with:
+        list-files: shell
         filters: |
-          changes:
+          directory:
             - "${{ inputs.directory }}/**"
     - name: Subtree
-      if: steps.filter.outputs.changes == 'true'
+      if: steps.changes.outputs.directory == 'true'
       shell: bash
       run: |
         wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
         chmod +x /usr/local/bin/git-filter-repo
         git filter-repo --debug --subdirectory-filter "${{ inputs.directory }}/"
     - name: Push subtree
-      if: steps.filter.outputs.changes == 'true'
+      if: steps.changes.outputs.directory == 'true'
       shell: bash
       run: |
         git remote add subtree "https://github.com/geocoder-php/${{ inputs.repository }}.git"

--- a/.github/actions/subtree/action.yml
+++ b/.github/actions/subtree/action.yml
@@ -1,0 +1,35 @@
+# This worflow is based on GitHub documentation:
+# https://docs.github.com/en/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository
+# This workflow uses https://github.com/newren/git-filter-repo tool.
+
+name: "Subtree Split"
+description: "Take the content of one repository and split it into many smaller ones"
+inputs:
+  directory:
+    description: "Directory to split"
+    required: true
+  repository:
+    description: "Repository to push to (in the same organization)"
+    required: true
+outputs: []
+runs:
+  using: "composite"
+  steps:
+    - name: Detect changes
+      uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          changes:
+            - "${{ inputs.directory }}/**"
+    - name: Subtree
+      if: steps.filter.outputs.changes == 'true'
+      run: |
+        wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
+        chmod +x /usr/local/bin/git-filter-repo
+        git filter-repo --debug --subdirectory-filter "${{ inputs.directory }}/"
+    - name: Push subtree
+      if: steps.filter.outputs.changes == 'true'
+      run: |
+        git remote add subtree "https://github.com/geocoder-php/${{ inputs.repository }}.git"
+        git push --force --set-upstream subtree master

--- a/.github/actions/subtree/action.yml
+++ b/.github/actions/subtree/action.yml
@@ -30,14 +30,14 @@ runs:
           directory:
             - "${{ inputs.directory }}/**"
     - name: Subtree
-      if: steps.changes.outputs.directory == 'true'
+      # if: steps.changes.outputs.directory == 'true'
       shell: bash
       run: |
         wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
         chmod +x /usr/local/bin/git-filter-repo
         git filter-repo --debug --subdirectory-filter "${{ inputs.directory }}/"
     - name: Push subtree
-      if: steps.changes.outputs.directory == 'true'
+      # if: steps.changes.outputs.directory == 'true'
       shell: bash
       run: |
         git remote add subtree "https://github.com/geocoder-php/${{ inputs.repository }}.git"

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -14,7 +14,7 @@ jobs:
         provider:
           - Nominatim
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
@@ -35,4 +35,4 @@ jobs:
         with:
           repository: geocoder-php/${{ matrix.provider }}-provider-subtree-test
           github_token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
-          directory: src/Provider/${{ matrix.provider }
+          directory: src/Provider/${{ matrix.provider }}

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   subtree:
-    name: Detect changes for provider ${{ matrix.provider }}
+    name: Subtree for provider ${{ matrix.provider }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -15,7 +15,11 @@ jobs:
           - Nominatim
     steps:
       - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Detect changes for provider ${{ matrix.provider }}
+        uses: dorny/paths-filter@v2
         id: filter
         with:
           filters: |

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -32,6 +32,7 @@ jobs:
           chmod +x /usr/local/bin/git-filter-repo
           git filter-repo https://github.com/geocoder-php/Geocoder.git "src/Provider/${{ matrix.provider }}/"
       - name: Push subtree
+        # if: steps.filter.outputs.provider == 'true'
         uses: ad-m/github-push-action@master
         with:
           repository: geocoder-php/${{ matrix.provider }}-provider-subtree-test

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -23,7 +23,8 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ./.github/actions/subtree
+      - name: Subtree Split
+        uses: ./.github/actions/subtree
         with:
           directory: src/Common
           repository: php-common
@@ -36,7 +37,8 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ./.github/actions/subtree
+      - name: Subtree Split
+        uses: ./.github/actions/subtree
         with:
           directory: src/Http
           repository: php-common-http
@@ -49,7 +51,8 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ./.github/actions/subtree
+      - name: Subtree Split
+        uses: ./.github/actions/subtree
         with:
           directory: src/Plugin
           repository: plugin
@@ -69,7 +72,8 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ./.github/actions/subtree
+      - name: Subtree Split
+        uses: ./.github/actions/subtree
         with:
           directory: "src/Provider/${{ matrix.provider }}"
           repository: ${{ matrix.provider }}-provider-subtree-test

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -8,11 +8,11 @@
 #
 # This workflow needs a GitHub token with Contents and Workflows read & write scopes.
 
-name: Subtree
+name: Subtree Split
 
 on:
   push:
-    branches: [ "subtree/github-actions" ]
+    branches: [ "master" ]
 
 jobs:
   subtree-common:

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -22,7 +22,7 @@ jobs:
             provider:
               - 'src/Provider/${{ matrix.provider }}/**'
       - name: Subtree
-        if: steps.filter.outputs.provider == 'true'
+        # if: steps.filter.outputs.provider == 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -36,4 +36,4 @@ jobs:
         # if: steps.filter.outputs.provider == 'true'
         run: |
           git remote add subtree "https://github.com/geocoder-php/${{ matrix.provider }}-provider-subtree-test.git"
-          git push --set-upstream subtree master
+          git push --force --set-upstream subtree master

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Subtree
         # if: steps.filter.outputs.provider == 'true'
         run: |
-          wget -P "/usr/local/bin" "https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo"
+          wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
+          chmod +x /usr/local/bin/git-filter-repo
           git filter-repo https://github.com/geocoder-php/Geocoder.git "src/Provider/${{ matrix.provider }}/"
       - name: Push subtree
         uses: ad-m/github-push-action@master

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Push subtree
         uses: ad-m/github-push-action@master
         with:
-          repository: geocoder-php/${{ matrix.provider }}-provider
+          repository: geocoder-php/${{ matrix.provider }}-provider-subtree-test
           github_token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -1,0 +1,31 @@
+name: Subtree
+
+on:
+  push:
+    branches: [ "subtree/github-actions" ]
+
+jobs:
+  subtree:
+    name: Detect changes for provider ${{ matrix.provider }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        provider:
+          - Nominatim
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            provider:
+              - 'src/Provider/${{ matrix.provider }}/**'
+      - name: Subtree
+        if: steps.filter.outputs.provider == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git filter-repo --path "src/Provider/${{ matrix.provider }}/"
+          git remote add subtree "https://github.com/geocoder-php/${{ matrix.provider }}-provider-subtree-test.git"
+          git push --set-upstream subtree master

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -27,6 +27,6 @@ jobs:
           wget "https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo"
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          python3 git-filter-repo --path "src/Provider/${{ matrix.provider }}/"
+          python3 git-filter-repo --force --path "src/Provider/${{ matrix.provider }}/"
           git remote add subtree "https://github.com/geocoder-php/${{ matrix.provider }}-provider-subtree-test.git"
           git push --set-upstream subtree master

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -13,10 +13,11 @@ jobs:
       matrix:
         provider:
           - Nominatim
+          - GoogleMaps
     steps:
       - uses: actions/checkout@v3
         with:
-          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
       - name: Detect changes
         uses: dorny/paths-filter@v2
@@ -33,8 +34,8 @@ jobs:
           git filter-repo --subdirectory-filter "src/Provider/${{ matrix.provider }}/"
       - name: Push subtree
         # if: steps.filter.outputs.provider == 'true'
-        uses: ad-m/github-push-action@master
-        with:
-          repository: geocoder-php/${{ matrix.provider }}-provider-subtree-test
-          github_token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
-          force: true
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote add subtree "https://github.com/geocoder-php/${{ matrix.provider }}-provider-subtree-test.git"
+          git push --set-upstream subtree master

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -25,8 +25,9 @@ jobs:
         # if: steps.filter.outputs.provider == 'true'
         run: |
           wget "https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo"
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           python3 git-filter-repo --force --path "src/Provider/${{ matrix.provider }}/"
-          git remote add subtree "https://github.com/geocoder-php/${{ matrix.provider }}-provider-subtree-test.git"
-          git push --set-upstream subtree master
+      - name: Push subtree
+        uses: ad-m/github-push-action@master
+        with:
+          repository: geocoder-php/${{ matrix.provider }}-provider
+          github_token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-      - name: Detect changes for provider ${{ matrix.provider }}
+      - name: Detect changes
         uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -36,3 +36,4 @@ jobs:
           repository: geocoder-php/${{ matrix.provider }}-provider-subtree-test
           github_token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           directory: src/Provider/${{ matrix.provider }}
+          force: true

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -35,3 +35,4 @@ jobs:
         with:
           repository: geocoder-php/${{ matrix.provider }}-provider-subtree-test
           github_token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
+          directory: src/Provider/${{ matrix.provider }

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
           chmod +x /usr/local/bin/git-filter-repo
-          git filter-repo https://github.com/geocoder-php/Geocoder.git "src/Provider/${{ matrix.provider }}/"
+          git filter-repo --subdirectory-filter "src/Provider/${{ matrix.provider }}/"
       - name: Push subtree
         # if: steps.filter.outputs.provider == 'true'
         uses: ad-m/github-push-action@master

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -64,9 +64,42 @@ jobs:
       fail-fast: false
       matrix:
         provider:
-          - Nominatim
+          - AlgoliaPlaces
+          - ArcGISOnline
+          - AzureMaps
+          - BingMaps
+          - Cache
+          - Chain
+          - FreeGeoIp
+          - GeoIP2
+          # - GeoIPs
+          - GeoPlugin
+          - GeocodeEarth
+          - Geonames
           - GoogleMaps
-          # - ...
+          - GoogleMapsPlaces
+          - GraphHopper
+          - Here
+          - HostIp
+          - IP2Location
+          # - IP2LocationBinary
+          - IpInfo
+          - IpInfoDb
+          - Ipstack
+          - LocationIQ
+          - MapQuest
+          - Mapbox
+          # - Mapzen
+          - MaxMind
+          - MaxMindBinary
+          - Nominatim
+          - OpenCage
+          - OpenRouteService
+          - Pelias
+          - Photon
+          - PickPoint
+          - TomTom
+          - Yandex
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -15,7 +15,46 @@ on:
     branches: [ "subtree/github-actions" ]
 
 jobs:
-  subtree:
+  subtree-common:
+    name: Subtree for Common
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
+          fetch-depth: 0
+      - uses: ./.github/actions/subtree
+        with:
+          directory: src/Common
+          repository: php-common
+
+  subtree-http:
+    name: Subtree for Common
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
+          fetch-depth: 0
+      - uses: ./.github/actions/subtree
+        with:
+          directory: src/Http
+          repository: php-common-http
+
+  subtree-plugin:
+    name: Subtree for Common
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
+          fetch-depth: 0
+      - uses: ./.github/actions/subtree
+        with:
+          directory: src/Plugin
+          repository: plugin
+
+  subtree-provider:
     name: Subtree for provider ${{ matrix.provider }}
     runs-on: ubuntu-latest
     strategy:
@@ -24,26 +63,13 @@ jobs:
         provider:
           - Nominatim
           - GoogleMaps
+          # - ...
     steps:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - name: Detect changes
-        uses: dorny/paths-filter@v2
-        id: filter
+      - uses: ./.github/actions/subtree
         with:
-          filters: |
-            provider:
-              - 'src/Provider/${{ matrix.provider }}/**'
-      - name: Subtree
-        if: steps.filter.outputs.provider == 'true'
-        run: |
-          wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
-          chmod +x /usr/local/bin/git-filter-repo
-          git filter-repo --debug --subdirectory-filter "src/Provider/${{ matrix.provider }}/"
-      - name: Push subtree
-        if: steps.filter.outputs.provider == 'true'
-        run: |
-          git remote add subtree "https://github.com/geocoder-php/${{ matrix.provider }}-provider-subtree-test.git"
-          git push --force --set-upstream subtree master
+          directory: "src/Provider/${{ matrix.provider }}"
+          repository: ${{ matrix.provider }}-provider-subtree-test

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/subtree
         with:
           directory: src/Common
-          repository: php-common
+          repository: php-common-subtree-test
 
   subtree-http:
     name: Subtree for Http
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/subtree
         with:
           directory: src/Http
-          repository: php-common-http
+          repository: php-common-http-subtree-test
 
   subtree-plugin:
     name: Subtree for Plugin
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/subtree
         with:
           directory: src/Plugin
-          repository: plugin
+          repository: plugin-subtree-test
 
   subtree-provider:
     name: Subtree for provider ${{ matrix.provider }}

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -35,5 +35,4 @@ jobs:
         with:
           repository: geocoder-php/${{ matrix.provider }}-provider-subtree-test
           github_token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
-          directory: src/Provider/${{ matrix.provider }}
           force: true

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -29,7 +29,7 @@ jobs:
           repository: php-common
 
   subtree-http:
-    name: Subtree for Common
+    name: Subtree for Http
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
           repository: php-common-http
 
   subtree-plugin:
-    name: Subtree for Common
+    name: Subtree for Plugin
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/subtree
         with:
           directory: src/Common
-          repository: php-common-subtree-test
+          repository: php-common
 
   subtree-http:
     name: Subtree for Http
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/subtree
         with:
           directory: src/Http
-          repository: php-common-http-subtree-test
+          repository: php-common-http
 
   subtree-plugin:
     name: Subtree for Plugin
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/subtree
         with:
           directory: src/Plugin
-          repository: plugin-subtree-test
+          repository: plugin
 
   subtree-provider:
     name: Subtree for provider ${{ matrix.provider }}
@@ -109,4 +109,4 @@ jobs:
         uses: ./.github/actions/subtree
         with:
           directory: "src/Provider/${{ matrix.provider }}"
-          repository: ${{ matrix.provider }}-provider-subtree-test
+          repository: ${{ matrix.provider }}-provider

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Subtree
         # if: steps.filter.outputs.provider == 'true'
         run: |
+          wget "https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo"
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git filter-repo --path "src/Provider/${{ matrix.provider }}/"
+          python3 git-filter-repo --path "src/Provider/${{ matrix.provider }}/"
           git remote add subtree "https://github.com/geocoder-php/${{ matrix.provider }}-provider-subtree-test.git"
           git push --set-upstream subtree master

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -31,11 +31,9 @@ jobs:
         run: |
           wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
           chmod +x /usr/local/bin/git-filter-repo
-          git filter-repo --subdirectory-filter "src/Provider/${{ matrix.provider }}/"
+          git filter-repo --debug --subdirectory-filter "src/Provider/${{ matrix.provider }}/"
       - name: Push subtree
         # if: steps.filter.outputs.provider == 'true'
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git remote add subtree "https://github.com/geocoder-php/${{ matrix.provider }}-provider-subtree-test.git"
           git push --set-upstream subtree master

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ".github/actions/subtree"
+      - uses: ./.github/actions/subtree
         with:
           directory: src/Common
           repository: php-common
@@ -36,7 +36,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ".github/actions/subtree"
+      - uses: ./.github/actions/subtree
         with:
           directory: src/Http
           repository: php-common-http
@@ -49,7 +49,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ".github/actions/subtree"
+      - uses: ./.github/actions/subtree
         with:
           directory: src/Plugin
           repository: plugin
@@ -69,7 +69,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ".github/actions/subtree"
+      - uses: ./.github/actions/subtree
         with:
           directory: "src/Provider/${{ matrix.provider }}"
           repository: ${{ matrix.provider }}-provider-subtree-test

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: .github/actions/subtree
+      - uses: ".github/actions/subtree"
         with:
           directory: src/Common
           repository: php-common
@@ -36,7 +36,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: .github/actions/subtree
+      - uses: ".github/actions/subtree"
         with:
           directory: src/Http
           repository: php-common-http
@@ -49,7 +49,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: .github/actions/subtree
+      - uses: ".github/actions/subtree"
         with:
           directory: src/Plugin
           repository: plugin
@@ -69,7 +69,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: .github/actions/subtree
+      - uses: ".github/actions/subtree"
         with:
           directory: "src/Provider/${{ matrix.provider }}"
           repository: ${{ matrix.provider }}-provider-subtree-test

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ./.github/actions/subtree
+      - uses: .github/actions/subtree
         with:
           directory: src/Common
           repository: php-common
@@ -36,7 +36,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ./.github/actions/subtree
+      - uses: .github/actions/subtree
         with:
           directory: src/Http
           repository: php-common-http
@@ -49,7 +49,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ./.github/actions/subtree
+      - uses: .github/actions/subtree
         with:
           directory: src/Plugin
           repository: plugin
@@ -69,7 +69,7 @@ jobs:
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: ./.github/actions/subtree
+      - uses: .github/actions/subtree
         with:
           directory: "src/Provider/${{ matrix.provider }}"
           repository: ${{ matrix.provider }}-provider-subtree-test

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Subtree
         # if: steps.filter.outputs.provider == 'true'
         run: |
-          wget "https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo"
-          python3 git-filter-repo --force --path "src/Provider/${{ matrix.provider }}/"
+          wget -P "/usr/local/bin" "https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo"
+          git filter-repo https://github.com/geocoder-php/Geocoder.git "src/Provider/${{ matrix.provider }}/"
       - name: Push subtree
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -1,3 +1,13 @@
+# This GitHub Action will push code for each provider/component to its own repository.
+# This is useful to have a better overview of the code and to have a better control over the releases.
+# The subtree is pushed to a repository named `geocoder-php/{provider}-provider`.
+# Previously, this process used https://www.subtreesplit.com/ service.
+#
+# This worflow is based on GitHub documentation: https://docs.github.com/en/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository
+# This workflow uses https://github.com/newren/git-filter-repo tool.
+#
+# This workflow needs a GitHub token with Contents and Workflows read & write scopes.
+
 name: Subtree
 
 on:
@@ -18,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.SUBTREE_GITHUB_TOKEN }}
-          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+          fetch-depth: 0
       - name: Detect changes
         uses: dorny/paths-filter@v2
         id: filter
@@ -27,13 +37,13 @@ jobs:
             provider:
               - 'src/Provider/${{ matrix.provider }}/**'
       - name: Subtree
-        # if: steps.filter.outputs.provider == 'true'
+        if: steps.filter.outputs.provider == 'true'
         run: |
           wget -P /usr/local/bin https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
           chmod +x /usr/local/bin/git-filter-repo
           git filter-repo --debug --subdirectory-filter "src/Provider/${{ matrix.provider }}/"
       - name: Push subtree
-        # if: steps.filter.outputs.provider == 'true'
+        if: steps.filter.outputs.provider == 'true'
         run: |
           git remote add subtree "https://github.com/geocoder-php/${{ matrix.provider }}-provider-subtree-test.git"
           git push --force --set-upstream subtree master

--- a/src/Provider/GoogleMaps/phpunit.xml.dist
+++ b/src/Provider/GoogleMaps/phpunit.xml.dist
@@ -10,7 +10,7 @@
     </exclude>
   </coverage>
   <php>
-    <server name="GOOGLE_GEOCODING_KEY" value="YOUR_GEOCODING_KEY"/>
+    <server name="GOOGLE_GEOCODING_KEY" value="AIzaSyCY5TA7CBNYcwtQC5J_jFgUHolxwuSmAeU"/>
     <server name="USE_CACHED_RESPONSES" value="true"/>
   </php>
   <testsuites>

--- a/src/Provider/GoogleMaps/phpunit.xml.dist
+++ b/src/Provider/GoogleMaps/phpunit.xml.dist
@@ -10,7 +10,7 @@
     </exclude>
   </coverage>
   <php>
-    <server name="GOOGLE_GEOCODING_KEY" value="AIzaSyCY5TA7CBNYcwtQC5J_jFgUHolxwuSmAeU"/>
+    <server name="GOOGLE_GEOCODING_KEY" value="YOUR_GEOCODING_KEY"/>
     <server name="USE_CACHED_RESPONSES" value="true"/>
   </php>
   <testsuites>


### PR DESCRIPTION
Until now, [Subtree Split service](https://www.subtreesplit.com/) was used to split the main repository to smaller repositories for each component (Common, Http, Plugin) and provider.

There is currently an issue with that service since mid-2022 but I just discovered it now (ping @Nyholm) and I can't seem to figure out what's going on.

Since all of our CI/CD tasks have been migrated to GitHub Actions, I thought about migrating that "Subtree split" to GitHub Actions as well and that's what this PR is about.

This workflow is based on [GitHub documentation](https://docs.github.com/en/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository) and works like this:

1. Detect if there are changes if component/provider directory
2. If there are changes, extract Git history and directory using [`git-filter-repo`](https://github.com/newren/git-filter-repo)
3. Push "new" Git history and files to component/provider repository

This workflow requires a GitHub Personal Access Token (PAT). I've configured a personal token and have stored as `SUBTREE_GITHUB_TOKEN` organization secret.
