### PR TITLE
Replace HTTPlug factories by PSR-17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 4.4.0 (2023-??-??)
+
+* Added: Method `AbstractHttpProvider::createRequest()`
+* Deprecated: Method `AbstractHttpProvider::getMessageFactory()`
+
 ## 4.3.0 (2022-07-30)
 
 * Removed: Support for PHP 7.3

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,10 @@
     "require": {
         "php": "^8.0",
         "igorw/get-in": "^1.0",
-        "php-http/discovery": "^1.4",
-        "php-http/message-factory": "^1.0.2",
+        "php-http/discovery": "^1.17",
         "php-http/promise": "^1.0",
-        "psr/http-client": "^1.0",
         "psr/http-client-implementation": "^1.0",
-        "psr/http-message-implementation": "^1.0",
+        "psr/http-factory-implementation": "^1.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
@@ -32,18 +30,19 @@
         "cache/array-adapter": "^1.0",
         "cache/simple-cache-bridge": "^1.0",
         "cache/void-adapter": "^1.0",
-        "geocoder-php/provider-integration-tests": "^1.6.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "geoip2/geoip2": "~2.0",
         "nyholm/nsa": "^1.1",
         "nyholm/psr7": "^1.0",
         "php-cs-fixer/shim": "^3.22",
-        "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
+        "php-http/message-factory": "^1.0.2",
         "php-http/mock-client": "^1.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^9.5",
+        "symfony/http-client": "^5.4 || ^6.3",
         "symfony/stopwatch": "~2.5 || ~5.0"
     },
     "suggest": {
@@ -72,7 +71,7 @@
     "config": {
         "allow-plugins": {
             "phpstan/extension-installer": true,
-            "php-http/discovery": true
+            "php-http/discovery": false
         },
         "sort-packages": true
     },

--- a/src/Common/Model/Address.php
+++ b/src/Common/Model/Address.php
@@ -255,10 +255,6 @@ class Address implements Location
     }
 
     /**
-     * @param float $south
-     * @param float $west
-     * @param float $north
-     *
      * @return Bounds|null
      */
     private static function createBounds(?float $south, ?float $west, ?float $north, ?float $east)

--- a/src/Common/Model/Country.php
+++ b/src/Common/Model/Country.php
@@ -31,10 +31,6 @@ final class Country
      */
     private $code;
 
-    /**
-     * @param string $name
-     * @param string $code
-     */
     public function __construct(string $name = null, string $code = null)
     {
         if (null === $name && null === $code) {

--- a/src/Common/ProviderAggregator.php
+++ b/src/Common/ProviderAggregator.php
@@ -131,7 +131,6 @@ class ProviderAggregator implements Geocoder
      *
      * @param GeocodeQuery|ReverseQuery $query
      * @param Provider[]                $providers
-     * @param Provider                  $currentProvider
      *
      * @throws ProviderNotRegistered
      */

--- a/src/Common/StatefulGeocoder.php
+++ b/src/Common/StatefulGeocoder.php
@@ -42,9 +42,6 @@ final class StatefulGeocoder implements Geocoder
      */
     private $provider;
 
-    /**
-     * @param string $locale
-     */
     public function __construct(Provider $provider, string $locale = null)
     {
         $this->provider = $provider;

--- a/src/Common/composer.json
+++ b/src/Common/composer.json
@@ -43,5 +43,10 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     }
 }

--- a/src/Http/Provider/AbstractHttpProvider.php
+++ b/src/Http/Provider/AbstractHttpProvider.php
@@ -16,10 +16,16 @@ use Geocoder\Exception\InvalidCredentials;
 use Geocoder\Exception\InvalidServerResponse;
 use Geocoder\Exception\QuotaExceeded;
 use Geocoder\Provider\AbstractProvider;
-use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\Psr17Factory;
 use Http\Message\MessageFactory;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -33,14 +39,17 @@ abstract class AbstractHttpProvider extends AbstractProvider
     private $client;
 
     /**
-     * @var MessageFactory
+     * @var RequestFactoryInterface&StreamFactoryInterface)|MessageFactory
      */
     private $messageFactory;
 
-    public function __construct(ClientInterface $client, MessageFactory $factory = null)
+    /**
+     * @param Psr17Factory|MessageFactory|null $factory Passing a MessageFactory is @deprecated
+     */
+    public function __construct(ClientInterface $client, MessageFactory|Psr17Factory $factory = null)
     {
         $this->client = $client;
-        $this->messageFactory = $factory ?: MessageFactoryDiscovery::find();
+        $this->messageFactory = $factory ?? ($client instanceof RequestFactoryInterface && $client instanceof StreamFactoryInterface ? $client : new Psr17Factory());
     }
 
     /**
@@ -57,7 +66,35 @@ abstract class AbstractHttpProvider extends AbstractProvider
 
     protected function getRequest(string $url): RequestInterface
     {
-        return $this->getMessageFactory()->createRequest('GET', $url);
+        return $this->createRequest('GET', $url);
+    }
+
+    /**
+     * @param array<string,string|string[]> $headers
+     */
+    protected function createRequest(string $method, string $uri, array $headers = [], string $body = null): RequestInterface
+    {
+        if ($this->messageFactory instanceof MessageFactory) {
+            return $this->messageFactory->createRequest($method, $uri, $headers, $body);
+        }
+
+        $request = $this->messageFactory->createRequest($method, $uri);
+
+        foreach ($headers as $name => $value) {
+            $request = $request->withAddedHeader($name, $value);
+        }
+
+        if (null === $body) {
+            return $request;
+        }
+
+        $stream = $this->messageFactory->createStream($body);
+
+        if ($stream->isSeekable()) {
+            $stream->seek(0);
+        }
+
+        return $request->withBody($stream);
     }
 
     /**
@@ -94,8 +131,93 @@ abstract class AbstractHttpProvider extends AbstractProvider
         return $this->client;
     }
 
+    /**
+     * @deprecated Use createRequest instead
+     */
     protected function getMessageFactory(): MessageFactory
     {
-        return $this->messageFactory;
+        if ($this->messageFactory instanceof MessageFactory) {
+            return $this->messageFactory;
+        }
+
+        $factory = $this->messageFactory instanceof ResponseFactoryInterface ? $this->messageFactory : new Psr17Factory();
+
+        return new class($factory) implements MessageFactory {
+            public function __construct(
+                /**
+                 * @param RequestFactoryInterface&ResponseFactoryInterface&StreamFactoryInterface $factory
+                 */
+                private RequestFactoryInterface|ResponseFactoryInterface|StreamFactoryInterface $factory,
+            ) {
+            }
+
+            /**
+             * @param string                               $method
+             * @param string|UriInterface                  $uri
+             * @param array<string,string|string[]>        $headers
+             * @param resource|string|StreamInterface|null $body
+             * @param string                               $protocolVersion
+             */
+            public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1'): RequestInterface
+            {
+                $request = $this->factory->createRequest($method, $uri);
+
+                foreach ($headers as $name => $value) {
+                    $request = $request->withAddedHeader($name, $value);
+                }
+
+                if (null !== $body) {
+                    $request = $request->withBody($this->createStream($body));
+                }
+
+                return $request->withProtocolVersion($protocolVersion);
+            }
+
+            /**
+             * @param int                                  $statusCode
+             * @param string|null                          $reasonPhrase
+             * @param array<string,string|string[]>        $headers
+             * @param resource|string|StreamInterface|null $body
+             * @param string                               $protocolVersion
+             */
+            public function createResponse($statusCode = 200, $reasonPhrase = null, array $headers = [], $body = null, $protocolVersion = '1.1'): ResponseInterface
+            {
+                $response = $this->factory->createResponse($statusCode, $reasonPhrase);
+
+                foreach ($headers as $name => $value) {
+                    $response = $response->withAddedHeader($name, $value);
+                }
+
+                if (null !== $body) {
+                    $response = $response->withBody($this->createStream($body));
+                }
+
+                return $response->withProtocolVersion($protocolVersion);
+            }
+
+            /**
+             * @param string|resource|StreamInterface|null $body
+             */
+            private function createStream($body = ''): StreamInterface
+            {
+                if ($body instanceof StreamInterface) {
+                    return $body;
+                }
+
+                if (\is_string($body ?? '')) {
+                    $stream = $this->factory->createStream($body ?? '');
+                } elseif (\is_resource($body)) {
+                    $stream = $this->factory->createStreamFromResource($body);
+                } else {
+                    throw new \InvalidArgumentException(sprintf('"%s()" expects string, resource or StreamInterface, "%s" given.', __METHOD__, get_debug_type($body)));
+                }
+
+                if ($stream->isSeekable()) {
+                    $stream->seek(0);
+                }
+
+                return $stream;
+            }
+        };
     }
 }

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "php": "^7.4 || ^8.0",
         "php-http/discovery": "^1.17",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -15,12 +15,10 @@
     ],
     "require": {
         "php": "^8.0",
-        "php-http/client-implementation": "^1.0",
-        "php-http/discovery": "^1.6",
-        "php-http/httplug": "^1.0 || ^2.0",
-        "php-http/message-factory": "^1.0.2",
-        "psr/http-message": "^1.0 || ^2.0",
-        "psr/http-message-implementation": "^1.0",
+        "php": "^7.4 || ^8.0",
+        "php-http/discovery": "^1.17",
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory-implementation": "^1.0",
         "willdurand/geocoder": "^4.0"
     },
     "require-dev": {
@@ -48,5 +46,10 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     }
 }

--- a/src/Plugin/composer.json
+++ b/src/Plugin/composer.json
@@ -42,5 +42,10 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     }
 }

--- a/src/Provider/AlgoliaPlaces/AlgoliaPlaces.php
+++ b/src/Provider/AlgoliaPlaces/AlgoliaPlaces.php
@@ -115,7 +115,7 @@ class AlgoliaPlaces extends AbstractHttpProvider implements Provider
 
     protected function getRequest(string $url): RequestInterface
     {
-        return $this->getMessageFactory()->createRequest(
+        return $this->createRequest(
             'POST',
             $url,
             $this->buildHeaders(),

--- a/src/Provider/AlgoliaPlaces/README.md
+++ b/src/Provider/AlgoliaPlaces/README.md
@@ -34,7 +34,7 @@ You should set a locale on the query. If it is missing, results may not be as co
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
 
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 
 // Unauthenticated
 $provider = new \Geocoder\Provider\AlgoliaPlaces\AlgoliaPlaces($httpClient);

--- a/src/Provider/AlgoliaPlaces/Tests/AlgoliaPlacesTest.php
+++ b/src/Provider/AlgoliaPlaces/Tests/AlgoliaPlacesTest.php
@@ -17,7 +17,7 @@ use Geocoder\IntegrationTest\CachedResponseClient;
 use Geocoder\Location;
 use Geocoder\Provider\AlgoliaPlaces\AlgoliaPlaces;
 use Geocoder\Query\GeocodeQuery;
-use Http\Client\Curl\Client as HttplugClient;
+use Http\Discovery\Psr18Client;
 use Psr\Http\Client\ClientInterface;
 
 /**
@@ -35,7 +35,7 @@ class AlgoliaPlacesTest extends BaseTestCase
      */
     protected function getHttpClient(string $apiKey = null, string $appCode = null): ClientInterface
     {
-        return new CachedResponseClient(new HttplugClient(), $this->getCacheDir(), $apiKey, $appCode);
+        return new CachedResponseClient(new Psr18Client(), $this->getCacheDir(), $apiKey, $appCode);
     }
 
     public function testGeocodeQueryWithLocale(): void

--- a/src/Provider/AlgoliaPlaces/composer.json
+++ b/src/Provider/AlgoliaPlaces/composer.json
@@ -14,15 +14,14 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "geocoder-php/common-http": "^4.1",
+        "geocoder-php/common-http": "^4.6",
         "willdurand/geocoder": "^4.0"
     },
     "provide": {
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.1",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/ArcGISOnline/Readme.md
+++ b/src/Provider/ArcGISOnline/Readme.md
@@ -33,7 +33,7 @@ Since a token is required for the `geocodeAddresses` API, the
 ### Without a token
 
 ```php
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 
 $provider = new \Geocoder\Provider\ArcGISList\ArcGISList($httpClient);
 
@@ -45,7 +45,7 @@ $result = $geocoder->geocodeQuery(GeocodeQuery::create('Buckingham Palace, Londo
 
 ```php
 
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 
 // Your token is required.
 $provider = \Geocoder\Provider\ArcGISList\ArcGISList::token($httpClient, 'your-token');

--- a/src/Provider/ArcGISOnline/composer.json
+++ b/src/Provider/ArcGISOnline/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/AzureMaps/README.md
+++ b/src/Provider/AzureMaps/README.md
@@ -19,7 +19,7 @@ composer require geocoder-php/azure-maps-provider
 ## Usage
 
 ```php
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 
 // You must provide a subscription key
 $provider = new \Geocoder\Provider\AzureMaps\AzureMaps($httpClient, 'your-subscription-key');

--- a/src/Provider/AzureMaps/composer.json
+++ b/src/Provider/AzureMaps/composer.json
@@ -19,8 +19,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/BingMaps/BingMaps.php
+++ b/src/Provider/BingMaps/BingMaps.php
@@ -82,9 +82,6 @@ final class BingMaps extends AbstractHttpProvider implements Provider
         return 'bing_maps';
     }
 
-    /**
-     * @param string $locale
-     */
     private function executeQuery(string $url, string $locale = null, int $limit): Collection
     {
         if (null !== $locale) {

--- a/src/Provider/BingMaps/composer.json
+++ b/src/Provider/BingMaps/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Cache/ProviderCache.php
+++ b/src/Provider/Cache/ProviderCache.php
@@ -45,9 +45,6 @@ class ProviderCache implements Provider
      */
     private bool $separateCache;
 
-    /**
-     * @param int $lifetime
-     */
     final public function __construct(Provider $realProvider, CacheInterface $cache, int $lifetime = null, bool $separateCache = false)
     {
         $this->realProvider = $realProvider;

--- a/src/Provider/Cache/Readme.md
+++ b/src/Provider/Cache/Readme.md
@@ -24,7 +24,7 @@ By default, the result is cached forever.
 You can  set a cache expiry by passing an integer representing the number of seconds as the third parameter.
 
 ```php
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 $provider = new \Geocoder\Provider\GoogleMaps\GoogleMaps($httpClient);
 
 $psr6Cache = new ArrayCachePool(); // Requires `cache/array-adapter` package

--- a/src/Provider/FreeGeoIp/Readme.md
+++ b/src/Provider/FreeGeoIp/Readme.md
@@ -14,7 +14,7 @@ Provider Website: https://freegeoip.app
 
 ## Usage
 ```php
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 
 // Use the default provider (https://freegeoip.app)
 $provider = new Geocoder\Provider\FreeGeoIp\FreeGeoIp($httpClient);

--- a/src/Provider/FreeGeoIp/composer.json
+++ b/src/Provider/FreeGeoIp/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GeoIP2/composer.json
+++ b/src/Provider/GeoIP2/composer.json
@@ -20,7 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0.1",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "phpunit/phpunit": "^9.5"
     },
     "extra": {

--- a/src/Provider/GeoIPs/composer.json
+++ b/src/Provider/GeoIPs/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GeoPlugin/composer.json
+++ b/src/Provider/GeoPlugin/composer.json
@@ -21,8 +21,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GeocodeEarth/composer.json
+++ b/src/Provider/GeocodeEarth/composer.json
@@ -21,8 +21,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Geoip/composer.json
+++ b/src/Provider/Geoip/composer.json
@@ -20,7 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0.1",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "phpunit/phpunit": "^9.5"
     },
     "extra": {

--- a/src/Provider/Geonames/composer.json
+++ b/src/Provider/Geonames/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GoogleMaps/GoogleMaps.php
+++ b/src/Provider/GoogleMaps/GoogleMaps.php
@@ -158,8 +158,6 @@ final class GoogleMaps extends AbstractHttpProvider implements Provider
     }
 
     /**
-     * @param string $locale
-     *
      * @return string query with extra params
      */
     private function buildQuery(string $url, string $locale = null, string $region = null): string
@@ -196,9 +194,6 @@ final class GoogleMaps extends AbstractHttpProvider implements Provider
     }
 
     /**
-     * @param string $locale
-     * @param string $region
-     *
      * @throws InvalidServerResponse
      * @throws InvalidCredentials
      */

--- a/src/Provider/GoogleMaps/Model/GoogleAddress.php
+++ b/src/Provider/GoogleMaps/Model/GoogleAddress.php
@@ -381,8 +381,6 @@ final class GoogleAddress extends Address
     }
 
     /**
-     * @param string $premise
-     *
      * @return GoogleAddress
      */
     public function withPremise(string $premise = null)

--- a/src/Provider/GoogleMaps/Readme.md
+++ b/src/Provider/GoogleMaps/Readme.md
@@ -13,7 +13,7 @@ This is the Google Maps provider from the PHP Geocoder. This is a **READ ONLY** 
 ## Usage
 
 ```php
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 
 // You must provide an API key
 $provider = new \Geocoder\Provider\GoogleMaps\GoogleMaps($httpClient, null, 'your-api-key');
@@ -31,7 +31,7 @@ can use the static `business` method on the provider to create a client:
 
 ```php
 
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 
 // Client ID is required. Private key is optional.
 $provider = \Geocoder\Provider\GoogleMaps\GoogleMaps::business($httpClient, 'your-client-id', 'your-private-key');

--- a/src/Provider/GoogleMaps/composer.json
+++ b/src/Provider/GoogleMaps/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GoogleMapsPlaces/composer.json
+++ b/src/Provider/GoogleMapsPlaces/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/GraphHopper/composer.json
+++ b/src/Provider/GraphHopper/composer.json
@@ -14,8 +14,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Here/Readme.md
+++ b/src/Provider/Here/Readme.md
@@ -24,7 +24,7 @@ composer require geocoder-php/here-provider
 New applications on the Here platform use the `api_key` authentication method.
 
 ```php
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 
 // You must provide an API key
 $provider = \Geocoder\Provider\Here\Here::createUsingApiKey($httpClient, 'your-api-key');
@@ -35,7 +35,7 @@ $result = $geocoder->geocodeQuery(GeocodeQuery::create('Buckingham Palace, Londo
 If you're using the legacy `app_code` authentication method, use the constructor on the provider like so:
 
 ```php
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 
 // You must provide both the app_id and app_code
 $provider = new \Geocoder\Provider\Here\Here($httpClient, 'app-id', 'app-code');

--- a/src/Provider/Here/composer.json
+++ b/src/Provider/Here/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.1",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/HostIp/composer.json
+++ b/src/Provider/HostIp/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/IP2Location/composer.json
+++ b/src/Provider/IP2Location/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/IP2LocationBinary/composer.json
+++ b/src/Provider/IP2LocationBinary/composer.json
@@ -20,7 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0.1",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "phpunit/phpunit": "^9.5"
     },
     "extra": {

--- a/src/Provider/IpInfo/composer.json
+++ b/src/Provider/IpInfo/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/IpInfoDb/composer.json
+++ b/src/Provider/IpInfoDb/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Ipstack/composer.json
+++ b/src/Provider/Ipstack/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/LocationIQ/composer.json
+++ b/src/Provider/LocationIQ/composer.json
@@ -22,10 +22,9 @@
         "willdurand/geocoder": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "geocoder-php/provider-integration-tests": "^1.0",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "php-http/curl-client": "^2.2"
+        "phpunit/phpunit": "^9.5"
     },
     "provide": {
         "geocoder-php/provider-implementation": "1.0"

--- a/src/Provider/MapQuest/MapQuest.php
+++ b/src/Provider/MapQuest/MapQuest.php
@@ -253,7 +253,7 @@ final class MapQuest extends AbstractHttpProvider implements Provider
         $url .= '?key='.$appKey;
 
         $requestBody = json_encode($params);
-        $request = $this->getMessageFactory()->createRequest('POST', $url, [], $requestBody);
+        $request = $this->createRequest('POST', $url, [], $requestBody);
 
         $response = $this->getHttpClient()->sendRequest($request);
         $content = $this->parseHttpResponse($response, $url);

--- a/src/Provider/MapQuest/composer.json
+++ b/src/Provider/MapQuest/composer.json
@@ -13,15 +13,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "geocoder-php/common-http": "^4.0",
+        "geocoder-php/common-http": "^4.6",
         "willdurand/geocoder": "^4.0"
     },
     "provide": {
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.1",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/MapTiler/composer.json
+++ b/src/Provider/MapTiler/composer.json
@@ -19,8 +19,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Mapbox/composer.json
+++ b/src/Provider/Mapbox/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Mapzen/composer.json
+++ b/src/Provider/Mapzen/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/MaxMind/composer.json
+++ b/src/Provider/MaxMind/composer.json
@@ -21,8 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/common-http": "^4.0",
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/MaxMindBinary/composer.json
+++ b/src/Provider/MaxMindBinary/composer.json
@@ -20,7 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0.1",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "phpunit/phpunit": "^9.5"
     },
     "extra": {

--- a/src/Provider/Nominatim/composer.json
+++ b/src/Provider/Nominatim/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/OpenCage/composer.json
+++ b/src/Provider/OpenCage/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.2",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/OpenRouteService/composer.json
+++ b/src/Provider/OpenRouteService/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Pelias/composer.json
+++ b/src/Provider/Pelias/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.7",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Photon/composer.json
+++ b/src/Provider/Photon/composer.json
@@ -19,8 +19,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/PickPoint/composer.json
+++ b/src/Provider/PickPoint/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/TomTom/composer.json
+++ b/src/Provider/TomTom/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Provider/Yandex/README.md
+++ b/src/Provider/Yandex/README.md
@@ -21,7 +21,7 @@ composer require geocoder-php/yandex-provider
 The API now requires an API key. [See here for more information](https://yandex.ru/blog/mapsapi/novye-pravila-dostupa-k-api-kart?from=tech_pp).
 
 ```php
-$httpClient = new \GuzzleHttp\Client();
+$httpClient = new \Http\Discovery\Psr18Client();
 $provider = new \Geocoder\Provider\Yandex\Yandex($httpClient, null, '<your-api-key>);
 
 $result = $geocoder->geocodeQuery(GeocodeQuery::create('ул.Ленина, 19, Минск 220030, Республика Беларусь'));

--- a/src/Provider/Yandex/Yandex.php
+++ b/src/Provider/Yandex/Yandex.php
@@ -94,9 +94,6 @@ final class Yandex extends AbstractHttpProvider implements Provider
         return 'yandex';
     }
 
-    /**
-     * @param string $locale
-     */
     private function executeQuery(string $url, int $limit, string $locale = null): AddressCollection
     {
         if (null !== $locale) {

--- a/src/Provider/Yandex/composer.json
+++ b/src/Provider/Yandex/composer.json
@@ -20,8 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^2.2",
+        "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
         "phpunit/phpunit": "^9.5"
     },


### PR DESCRIPTION
All interfaces of `php-http/message-factory` are now deprecated.
This PR provides a way to move to PSR-17 instead.
