### PR TITLE
Fix Reverse Geocode failure - Here maps - Undefined index: LocationId

### DIFF
--- a/src/Provider/Here/Here.php
+++ b/src/Provider/Here/Here.php
@@ -255,7 +255,7 @@ final class Here extends AbstractHttpProvider implements Provider
 
             /** @var HereAddress $address */
             $address = $builder->build(HereAddress::class);
-            $address = $address->withLocationId($location['LocationId']);
+            $address = $address->withLocationId($location['LocationId'] ?? null);
             $address = $address->withLocationType($location['LocationType']);
             $address = $address->withAdditionalData(array_merge($additionalData, $extraAdditionalData));
             $address = $address->withShape($location['Shape'] ?? null);


### PR DESCRIPTION
Undefined index: LocationId at /var/www/api/html/releases/20230704155244/vendor/geocoder-php/here-provider/Here.php:258 Not all the location responses from Here maps reverse geocode API include LocationId, e.g. if the LocationType is area.