### PR TITLE
[Pelias][OpenRouteService][GeocodeEarth] Fix admin level ordering

### DIFF
--- a/src/Provider/GeocodeEarth/CHANGELOG.md
+++ b/src/Provider/GeocodeEarth/CHANGELOG.md
@@ -16,6 +16,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ### Changed
 
 - Migrate from PHP-HTTP to PSR-18 client
+- Admin levels are numbered in a strict top->down order. 1 is the Country level, 5 is the locality level.
 
 ## 1.3.0
 

--- a/src/Provider/GeocodeEarth/Tests/GeocodeEarthTest.php
+++ b/src/Provider/GeocodeEarth/Tests/GeocodeEarthTest.php
@@ -60,7 +60,7 @@ class GeocodeEarthTest extends BaseTestCase
         $this->assertEquals('Acklam Road', $result->getStreetName());
         $this->assertEquals('London', $result->getLocality());
         $this->assertCount(3, $result->getAdminLevels());
-        $this->assertEquals('London', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('London', $result->getAdminLevels()->get(5)->getName());
         $this->assertEquals('United Kingdom', $result->getCountry()->getName());
         $this->assertEquals('GBR', $result->getCountry()->getCode());
     }
@@ -87,8 +87,8 @@ class GeocodeEarthTest extends BaseTestCase
         $this->assertEquals('LA1 1UH', $result->getPostalCode());
         $this->assertEquals('Lancaster', $result->getLocality());
         $this->assertCount(4, $result->getAdminLevels());
-        $this->assertEquals('Lancashire', $result->getAdminLevels()->get(1)->getName());
-        $this->assertEquals('England', $result->getAdminLevels()->get(4)->getName());
+        $this->assertEquals('England', $result->getAdminLevels()->get(2)->getName());
+        $this->assertEquals('Lancashire', $result->getAdminLevels()->get(3)->getName());
         $this->assertEquals('United Kingdom', $result->getCountry()->getName());
         $this->assertEquals('GBR', $result->getCountry()->getCode());
     }
@@ -130,8 +130,8 @@ class GeocodeEarthTest extends BaseTestCase
         $this->assertEqualsWithDelta(9.787455, $result->getCoordinates()->getLongitude(), 0.01);
         $this->assertEquals('Hanover', $result->getLocality());
         $this->assertCount(4, $result->getAdminLevels());
-        $this->assertEquals('Niedersachsen', $result->getAdminLevels()->get(1)->getName());
-        $this->assertEquals('Hanover', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('Niedersachsen', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('Hanover', $result->getAdminLevels()->get(5)->getName());
         $this->assertEquals('Germany', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
@@ -140,7 +140,7 @@ class GeocodeEarthTest extends BaseTestCase
         $this->assertEqualsWithDelta(52.37362, $result->getCoordinates()->getLatitude(), 0.01);
         $this->assertEqualsWithDelta(9.73711, $result->getCoordinates()->getLongitude(), 0.01);
         $this->assertCount(3, $result->getAdminLevels());
-        $this->assertEquals('Niedersachsen', $result->getAdminLevels()->get(1)->getName());
+        $this->assertEquals('Niedersachsen', $result->getAdminLevels()->get(3)->getName());
         $this->assertEquals('Germany', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
@@ -150,7 +150,7 @@ class GeocodeEarthTest extends BaseTestCase
         $this->assertEqualsWithDelta(-78.107687, $result->getCoordinates()->getLongitude(), 0.01);
         $this->assertNull($result->getLocality());
         $this->assertCount(2, $result->getAdminLevels());
-        $this->assertEquals('Hanover', $result->getAdminLevels()->get(1)->getName());
+        $this->assertEquals('Hanover', $result->getAdminLevels()->get(3)->getName());
         $this->assertEquals('Jamaica', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
@@ -160,7 +160,7 @@ class GeocodeEarthTest extends BaseTestCase
         $this->assertEqualsWithDelta(-76.724140000000006, $result->getCoordinates()->getLongitude(), 0.01);
         $this->assertEquals('Hanover', $result->getLocality());
         $this->assertCount(4, $result->getAdminLevels());
-        $this->assertEquals('Hanover', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('Hanover', $result->getAdminLevels()->get(5)->getName());
         $this->assertEquals('United States', $result->getCountry()->getName());
     }
 
@@ -186,8 +186,8 @@ class GeocodeEarthTest extends BaseTestCase
         $this->assertEquals(60437, $result->getPostalCode());
         $this->assertEquals('Frankfurt', $result->getLocality());
         $this->assertCount(4, $result->getAdminLevels());
-        $this->assertEquals('Frankfurt', $result->getAdminLevels()->get(2)->getName());
-        $this->assertEquals('Hessen', $result->getAdminLevels()->get(1)->getName());
+        $this->assertEquals('Frankfurt', $result->getAdminLevels()->get(4)->getName());
+        $this->assertEquals('Hessen', $result->getAdminLevels()->get(3)->getName());
         $this->assertNull($result->getAdminLevels()->get(1)->getCode());
         $this->assertEquals('Germany', $result->getCountry()->getName());
         $this->assertEquals('DEU', $result->getCountry()->getCode());

--- a/src/Provider/OpenRouteService/CHANGELOG.md
+++ b/src/Provider/OpenRouteService/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 1.4.0
+
+### Changed
+
+ - Admin levels are numbered in a strict top->down order. 1 is the Country level, 5 is the locality level.
+
+
 ## 1.3.0
 
 ### Added

--- a/src/Provider/OpenRouteService/Tests/OpenRouteServiceTest.php
+++ b/src/Provider/OpenRouteService/Tests/OpenRouteServiceTest.php
@@ -60,7 +60,7 @@ class OpenRouteServiceTest extends BaseTestCase
         $this->assertEquals('Acklam Road', $result->getStreetName());
         $this->assertEquals('London', $result->getLocality());
         $this->assertCount(4, $result->getAdminLevels());
-        $this->assertEquals('London', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('London', $result->getAdminLevels()->get(5)->getName());
         $this->assertEquals('United Kingdom', $result->getCountry()->getName());
         $this->assertEquals('GBR', $result->getCountry()->getCode());
     }
@@ -87,8 +87,8 @@ class OpenRouteServiceTest extends BaseTestCase
         $this->assertEquals('LA1 1UH', $result->getPostalCode());
         $this->assertEquals('Lancaster', $result->getLocality());
         $this->assertCount(5, $result->getAdminLevels());
-        $this->assertEquals('Lancashire', $result->getAdminLevels()->get(1)->getName());
-        $this->assertEquals('England', $result->getAdminLevels()->get(4)->getName());
+        $this->assertEquals('England', $result->getAdminLevels()->get(2)->getName());
+        $this->assertEquals('Lancashire', $result->getAdminLevels()->get(4)->getName());
         $this->assertEquals('United Kingdom', $result->getCountry()->getName());
         $this->assertEquals('GBR', $result->getCountry()->getCode());
     }
@@ -130,8 +130,8 @@ class OpenRouteServiceTest extends BaseTestCase
         $this->assertEqualsWithDelta(9.787455, $result->getCoordinates()->getLongitude(), 0.01);
         $this->assertEquals('Hanover', $result->getLocality());
         $this->assertCount(4, $result->getAdminLevels());
-        $this->assertEquals('Niedersachsen', $result->getAdminLevels()->get(1)->getName());
-        $this->assertEquals('Hanover', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('Niedersachsen', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('Hanover', $result->getAdminLevels()->get(5)->getName());
         $this->assertEquals('Germany', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
@@ -140,7 +140,7 @@ class OpenRouteServiceTest extends BaseTestCase
         $this->assertEqualsWithDelta(52.37362, $result->getCoordinates()->getLatitude(), 0.01);
         $this->assertEqualsWithDelta(9.73711, $result->getCoordinates()->getLongitude(), 0.01);
         $this->assertCount(3, $result->getAdminLevels());
-        $this->assertEquals('Niedersachsen', $result->getAdminLevels()->get(1)->getName());
+        $this->assertEquals('Niedersachsen', $result->getAdminLevels()->get(3)->getName());
         $this->assertEquals('Germany', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
@@ -150,7 +150,7 @@ class OpenRouteServiceTest extends BaseTestCase
         $this->assertEqualsWithDelta(-78.107687, $result->getCoordinates()->getLongitude(), 0.01);
         $this->assertNull($result->getLocality());
         $this->assertCount(2, $result->getAdminLevels());
-        $this->assertEquals('Hanover', $result->getAdminLevels()->get(1)->getName());
+        $this->assertEquals('Hanover', $result->getAdminLevels()->get(3)->getName());
         $this->assertEquals('Jamaica', $result->getCountry()->getName());
 
         /** @var \Geocoder\Model\Address $result */
@@ -160,7 +160,7 @@ class OpenRouteServiceTest extends BaseTestCase
         $this->assertEqualsWithDelta(-76.724140000000006, $result->getCoordinates()->getLongitude(), 0.01);
         $this->assertEquals('Hanover', $result->getLocality());
         $this->assertCount(4, $result->getAdminLevels());
-        $this->assertEquals('Hanover', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('Hanover', $result->getAdminLevels()->get(5)->getName());
         $this->assertEquals('United States', $result->getCountry()->getName());
     }
 
@@ -186,8 +186,8 @@ class OpenRouteServiceTest extends BaseTestCase
         $this->assertEquals(60437, $result->getPostalCode());
         $this->assertEquals('Frankfurt', $result->getLocality());
         $this->assertCount(4, $result->getAdminLevels());
-        $this->assertEquals('Frankfurt', $result->getAdminLevels()->get(2)->getName());
-        $this->assertEquals('Hessen', $result->getAdminLevels()->get(1)->getName());
+        $this->assertEquals('Frankfurt', $result->getAdminLevels()->get(4)->getName());
+        $this->assertEquals('Hessen', $result->getAdminLevels()->get(3)->getName());
         $this->assertNull($result->getAdminLevels()->get(1)->getCode());
         $this->assertEquals('Germany', $result->getCountry()->getName());
         $this->assertEquals('DEU', $result->getCountry()->getCode());

--- a/src/Provider/Pelias/CHANGELOG.md
+++ b/src/Provider/Pelias/CHANGELOG.md
@@ -16,6 +16,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ### Changed
 
 - Migrate from PHP-HTTP to PSR-18 client
+- Admin levels are numbered in a strict top->down order. 1 is the Country level, 5 is the locality level.
 
 ## 1.3.0
 

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -151,7 +151,7 @@ class Pelias extends AbstractHttpProvider implements Provider
             $props = $location['properties'];
 
             $adminLevels = [];
-            foreach (['region', 'county', 'locality', 'macroregion', 'country'] as $i => $component) {
+            foreach (['country', 'macroregion', 'region', 'county', 'locality'] as $i => $component) {
                 if (isset($props[$component])) {
                     $adminLevels[] = ['name' => $props[$component], 'level' => $i + 1];
                 }

--- a/src/Provider/Pelias/Tests/AdminLevelTest.php
+++ b/src/Provider/Pelias/Tests/AdminLevelTest.php
@@ -55,10 +55,10 @@ class AdminLevelTest extends BaseTestCase
         $result = $provider->geocodeQuery(GeocodeQuery::create('foobar'));
 
         $this->assertInstanceOf(Collection::class, $result);
-        $this->assertEquals(1, $result->count());
+        $this->assertSame(1, $result->count());
         $address = $result->get(0);
 
-        $expectedOrder= [
+        $expectedOrder = [
             'COUNTRY',
             'MACROREGION',
             'REGION',
@@ -67,8 +67,8 @@ class AdminLevelTest extends BaseTestCase
         ];
 
         foreach ($address->getAdminLevels()->all() as $key => $adminLevel) {
-            $this->assertEquals($expectedOrder[$key-1], $adminLevel->getName());
-            $this->assertEquals($key, $adminLevel->getLevel(), 'Invalid admin level number for level '.$adminLevel->getName());
+            $this->assertSame($expectedOrder[$key-1], $adminLevel->getName());
+            $this->assertSame($key, $adminLevel->getLevel(), 'Invalid admin level number for level '.$adminLevel->getName());
         }
     }
 }

--- a/src/Provider/Pelias/Tests/AdminLevelTest.php
+++ b/src/Provider/Pelias/Tests/AdminLevelTest.php
@@ -19,13 +19,12 @@ use Geocoder\Query\GeocodeQuery;
 
 class AdminLevelTest extends BaseTestCase
 {
-
     protected function getCacheDir(): string
     {
         return __DIR__.'/.cached_responses';
     }
 
-    public function testAdminLevelsOrder()
+    public function testAdminLevelsOrder(): void
     {
         $response = '
         {
@@ -55,7 +54,7 @@ class AdminLevelTest extends BaseTestCase
         $result = $provider->geocodeQuery(GeocodeQuery::create('foobar'));
 
         $this->assertInstanceOf(Collection::class, $result);
-        $this->assertSame(1, $result->count());
+        $this->assertCount(1, $result);
         $address = $result->get(0);
 
         $expectedOrder = [
@@ -67,7 +66,7 @@ class AdminLevelTest extends BaseTestCase
         ];
 
         foreach ($address->getAdminLevels()->all() as $key => $adminLevel) {
-            $this->assertSame($expectedOrder[$key-1], $adminLevel->getName());
+            $this->assertSame($expectedOrder[$key - 1], $adminLevel->getName());
             $this->assertSame($key, $adminLevel->getLevel(), 'Invalid admin level number for level '.$adminLevel->getName());
         }
     }

--- a/src/Provider/Pelias/Tests/AdminLevelTest.php
+++ b/src/Provider/Pelias/Tests/AdminLevelTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Geocoder\Provider\Pelias\Tests;
+
+use Geocoder\Collection;
+use Geocoder\IntegrationTest\BaseTestCase;
+use Geocoder\Provider\Pelias\Pelias;
+use Geocoder\Query\GeocodeQuery;
+
+class AdminLevelTest extends BaseTestCase
+{
+
+    protected function getCacheDir(): string
+    {
+        return __DIR__.'/.cached_responses';
+    }
+
+    public function testAdminLevelsOrder()
+    {
+        $response = '
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "coordinates": [
+                            1.000,
+                            1.000
+                        ]
+                    },
+                    "properties": {
+                        "country": "COUNTRY",
+                        "macroregion": "MACROREGION",
+                        "region": "REGION",
+                        "county": "COUNTY",
+                        "locality": "LOCALITY",
+                        "neighbourhood": "NEIGHBORHOOD"
+                    }
+                }
+            ]
+        }
+        ';
+        $provider = new Pelias($this->getMockedHttpClient($response), 'http://localhost/');
+        $result = $provider->geocodeQuery(GeocodeQuery::create('foobar'));
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals(1, $result->count());
+        $address = $result->get(0);
+
+        $expectedOrder= [
+            'COUNTRY',
+            'MACROREGION',
+            'REGION',
+            'COUNTY',
+            'LOCALITY',
+        ];
+
+        foreach ($address->getAdminLevels()->all() as $key => $adminLevel) {
+            $this->assertEquals($expectedOrder[$key-1], $adminLevel->getName());
+            $this->assertEquals($key, $adminLevel->getLevel(), 'Invalid admin level number for level '.$adminLevel->getName());
+        }
+    }
+}


### PR DESCRIPTION
Order of the adminLeves in Pelias did not have any particular order. I have changed the order according to this ticket: https://github.com/geocoder-php/Geocoder/issues/852

Please note that this might be a **breaking change** for someone.