### PR TITLE
Pelias/custom address fields

### DIFF
--- a/src/Provider/Pelias/CHANGELOG.md
+++ b/src/Provider/Pelias/CHANGELOG.md
@@ -8,6 +8,12 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 - Add support for PHP 8.1
 - Add GitHub Actions workflow
+- Returns the following pelias properties as well:
+    - layer
+    - confidence
+    - source
+    - match_type
+    - accuracy
 
 ### Removed
 

--- a/src/Provider/Pelias/Model/PeliasAddress.php
+++ b/src/Provider/Pelias/Model/PeliasAddress.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Geocoder\Provider\Pelias\Model;
+
+use Geocoder\Model\Address;
+
+class PeliasAddress extends Address
+{
+    /**
+     * The pelias layer returned
+     * @var string|null
+     */
+    private $layer;
+
+    /**
+     * Confidence score from pelias
+     * @var float|null
+     */
+    private $confidence;
+
+    /**
+     * Match type from pelias
+     * @var string|null
+     */
+    private $matchType;
+
+    /**
+     * Data source from pelias
+     * @var string|null
+     */
+    private $source;
+
+    /**
+     * Accuracy from pelias
+     * @var string|null
+     */
+    private $accuracy;
+
+    public static function createFromArray(array $data)
+    {
+        $address = parent::createFromArray($data);
+        $address->layer = $data['layer'] ?? null;
+        $address->confidence = $data['confidence'] ?? null;
+        $address->matchType = $data['match_type'] ?? null;
+        $address->source = $data['source'] ?? null;
+        $address->accuracy = $data['accuracy'] ?? null;
+        return $address;
+    }
+
+    /**
+     * Get the pelias layer returned
+     *
+     * @return  string|null
+     */ 
+    public function getLayer()
+    {
+        return $this->layer;
+    }
+
+    /**
+     * Get confidence score from pelias
+     *
+     * @return  float|null
+     */ 
+    public function getConfidence()
+    {
+        return $this->confidence;
+    }
+
+    /**
+     * Get match type from pelias
+     *
+     * @return  string|null
+     */ 
+    public function getMatchType()
+    {
+        return $this->matchType;
+    }
+
+    /**
+     * Get data source from pelias
+     *
+     * @return  string|null
+     */ 
+    public function getSource()
+    {
+        return $this->source;
+    }
+
+    /**
+     * Get accuracy from pelias
+     *
+     * @return  string|null
+     */
+    public function getAccuracy()
+    {
+        return $this->accuracy;
+    }
+
+    /**
+     * Set the pelias layer returned
+     * @param string|null $layer name of the pelias layer
+     * @return PeliasAddress
+     */
+    public function withLayer(string $layer = null)
+    {
+        $new = clone $this;
+        $new->layer = $layer;
+
+        return $new;
+    }
+
+    /**
+     * Set confidence score from pelias
+     * @param float|null $confidence confidence level as a float
+     * @return PeliasAddress
+     */
+    public function withConfidence(float $confidence = null)
+    {
+        $new = clone $this;
+        $new->confidence = $confidence;
+
+        return $new;
+    }
+
+    /**
+     * Set match type from pelias
+     * @param string|null $matchType precision of the match like "exact"
+     * @return PeliasAddress
+     */
+    public function withMatchType(string $matchType = null)
+    {
+        $new = clone $this;
+        $new->matchType = $matchType;
+
+        return $new;
+    }
+
+    /**
+     * Set data source from pelias
+     * @param string|null $source address source from pelias
+     * @return PeliasAddress
+     */
+    public function withSource(string $source = null)
+    {
+        $new = clone $this;
+        $new->source = $source;
+
+        return $new;
+    }
+
+    /**
+     * Set accuracy from pelias
+     * @param string|null $accuracy accuracy level from pelias like "point"
+     * @return PeliasAddress
+     */
+    public function withAccuracy(string $accuracy = null)
+    {
+        $new = clone $this;
+        $new->accuracy = $accuracy;
+
+        return $new;
+    }
+
+}

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -132,48 +132,57 @@ class Pelias extends AbstractHttpProvider implements Provider
 
         $results = [];
         foreach ($locations as $location) {
-            if (isset($location['bbox'])) {
-                $bounds = [
-                    'south' => $location['bbox'][3],
-                    'west' => $location['bbox'][2],
-                    'north' => $location['bbox'][1],
-                    'east' => $location['bbox'][0],
-                ];
-            } else {
-                $bounds = [
-                    'south' => null,
-                    'west' => null,
-                    'north' => null,
-                    'east' => null,
-                ];
-            }
-
-            $props = $location['properties'];
-
-            $adminLevels = [];
-            foreach (['region', 'county', 'locality', 'macroregion', 'country'] as $i => $component) {
-                if (isset($props[$component])) {
-                    $adminLevels[] = ['name' => $props[$component], 'level' => $i + 1];
-                }
-            }
-
-            $results[] = Address::createFromArray([
-                'providedBy' => $this->getName(),
-                'latitude' => $location['geometry']['coordinates'][1],
-                'longitude' => $location['geometry']['coordinates'][0],
-                'bounds' => $bounds,
-                'streetNumber' => isset($props['housenumber']) ? $props['housenumber'] : null,
-                'streetName' => isset($props['street']) ? $props['street'] : null,
-                'subLocality' => isset($props['neighbourhood']) ? $props['neighbourhood'] : null,
-                'locality' => isset($props['locality']) ? $props['locality'] : null,
-                'postalCode' => isset($props['postalcode']) ? $props['postalcode'] : null,
-                'adminLevels' => $adminLevels,
-                'country' => isset($props['country']) ? $props['country'] : null,
-                'countryCode' => isset($props['country_a']) ? strtoupper($props['country_a']) : null,
-            ]);
+            $results[] = $this->buildAddress($location);
         }
 
         return new AddressCollection($results);
+    }
+
+    /**
+     * Build the Address object from the the Feature
+     * @param array $location the Feature array
+     * @return Address the address object
+     */
+    protected function buildAddress(array $location)
+    {
+        if (isset($location['bbox'])) {
+            $bounds = [
+                'south' => $location['bbox'][3],
+                'west' => $location['bbox'][2],
+                'north' => $location['bbox'][1],
+                'east' => $location['bbox'][0],
+            ];
+        } else {
+            $bounds = [
+                'south' => null,
+                'west' => null,
+                'north' => null,
+                'east' => null,
+            ];
+        }
+
+        $props = $location['properties'];
+        $adminLevels = [];
+        foreach (['region', 'county', 'locality', 'macroregion', 'country'] as $i => $component) {
+            if (isset($props[$component])) {
+                $adminLevels[] = ['name' => $props[$component], 'level' => $i + 1];
+            }
+        }
+
+        return Address::createFromArray([
+            'providedBy' => $this->getName(),
+            'latitude' => $location['geometry']['coordinates'][1],
+            'longitude' => $location['geometry']['coordinates'][0],
+            'bounds' => $bounds,
+            'streetNumber' => isset($props['housenumber']) ? $props['housenumber'] : null,
+            'streetName' => isset($props['street']) ? $props['street'] : null,
+            'subLocality' => isset($props['neighbourhood']) ? $props['neighbourhood'] : null,
+            'locality' => isset($props['locality']) ? $props['locality'] : null,
+            'postalCode' => isset($props['postalcode']) ? $props['postalcode'] : null,
+            'adminLevels' => $adminLevels,
+            'country' => isset($props['country']) ? $props['country'] : null,
+            'countryCode' => isset($props['country_a']) ? strtoupper($props['country_a']) : null,
+        ]);
     }
 
     /**

--- a/src/Provider/Pelias/Pelias.php
+++ b/src/Provider/Pelias/Pelias.php
@@ -19,6 +19,7 @@ use Geocoder\Exception\UnsupportedOperation;
 use Geocoder\Http\Provider\AbstractHttpProvider;
 use Geocoder\Model\Address;
 use Geocoder\Model\AddressCollection;
+use Geocoder\Provider\Pelias\Model\PeliasAddress;
 use Geocoder\Provider\Provider;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
@@ -169,7 +170,7 @@ class Pelias extends AbstractHttpProvider implements Provider
             }
         }
 
-        return Address::createFromArray([
+        return PeliasAddress::createFromArray([
             'providedBy' => $this->getName(),
             'latitude' => $location['geometry']['coordinates'][1],
             'longitude' => $location['geometry']['coordinates'][0],
@@ -182,6 +183,11 @@ class Pelias extends AbstractHttpProvider implements Provider
             'adminLevels' => $adminLevels,
             'country' => isset($props['country']) ? $props['country'] : null,
             'countryCode' => isset($props['country_a']) ? strtoupper($props['country_a']) : null,
+            'layer' => $props['layer'] ?? null,
+            'confidence' => $props['confidence'] ?? null,
+            'match_type' => $props['match_type'] ?? null,
+            'source' => $props['source'] ?? null,
+            'accuracy' => $props['accuracy'] ?? null,
         ]);
     }
 

--- a/src/Provider/Pelias/Tests/CustomPropertiesTest.php
+++ b/src/Provider/Pelias/Tests/CustomPropertiesTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Geocoder\Provider\Pelias\Tests;
+
+use Geocoder\Collection;
+use Geocoder\IntegrationTest\BaseTestCase;
+use Geocoder\Model\AdminLevelCollection;
+use Geocoder\Provider\Pelias\Model\PeliasAddress;
+use Geocoder\Provider\Pelias\Pelias;
+use Geocoder\Query\GeocodeQuery;
+
+class CustomPropertiesTest extends BaseTestCase
+{
+    protected function getCacheDir(): string
+    {
+        return __DIR__.'/.cached_responses';
+    }
+
+    public function testPeliasAddressReturned()
+    {
+        $response = '
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "coordinates": [
+                            1.000,
+                            1.000
+                        ]
+                    },
+                    "properties": {
+                        "source": "openaddresses",
+                        "layer": "address",
+                        "confidence": 1,
+                        "match_type": "exact",
+                        "accuracy": "point",
+
+                        "country": "COUNTRY",
+                        "macroregion": "MACROREGION",
+                        "region": "REGION",
+                        "county": "COUNTY",
+                        "locality": "LOCALITY",
+                        "neighbourhood": "NEIGHBORHOOD"
+                    }
+                }
+            ]
+        }
+        ';
+        $provider = new Pelias($this->getMockedHttpClient($response), 'http://localhost/');
+        $result = $provider->geocodeQuery(GeocodeQuery::create('foobar'));
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals(1, $result->count());
+        $address = $result->get(0);
+
+        $this->assertInstanceOf(PeliasAddress::class, $address);
+
+        $this->assertEquals('openaddresses', $address->getSource());
+        $this->assertEquals('address', $address->getLayer());
+        $this->assertEquals(1, $address->getConfidence());
+        $this->assertEquals('exact', $address->getMatchType());
+        $this->assertEquals('point', $address->getAccuracy());
+    }
+
+    public function testWithSource()
+    {
+        $address = new PeliasAddress('Pelias', new AdminLevelCollection());
+        $newAddress = $address->withSource('openaddresses');
+        $this->assertEquals('openaddresses', $newAddress->getSource());
+        $this->assertNull($address->getSource());
+    }
+
+    public function testWithLayer()
+    {
+        $address = new PeliasAddress('Pelias', new AdminLevelCollection());
+        $newAddress = $address->withLayer('address');
+        $this->assertEquals('address', $newAddress->getLayer());
+        $this->assertNull($address->getLayer());
+    }
+
+    public function testWithConfidence()
+    {
+        $address = new PeliasAddress('Pelias', new AdminLevelCollection());
+        $newAddress = $address->withConfidence(1);
+        $this->assertEquals(1, $newAddress->getConfidence());
+        $this->assertNull($address->getConfidence());
+    }
+
+    public function testWithMatchType()
+    {
+        $address = new PeliasAddress('Pelias', new AdminLevelCollection());
+        $newAddress = $address->withMatchType('exact');
+        $this->assertEquals('exact', $newAddress->getMatchType());
+        $this->assertNull($address->getMatchType());
+    }
+
+    public function testWithAccuracy()
+    {
+        $address = new PeliasAddress('Pelias', new AdminLevelCollection());
+        $newAddress = $address->withAccuracy('point');
+        $this->assertEquals('point', $newAddress->getAccuracy());
+        $this->assertNull($address->getAccuracy());
+    }
+    
+}


### PR DESCRIPTION
Pelias is an open source modular geocoder. It support several data sources and tries to find the best match for each query. Unfortunately a lot of this information is hidden in PHP Geocoder. This PR will expose the most important fields through an extended PeliasAddress class.

The solution is similar to the GoogleMaps provider's GoogleAddress, I have also included the with... methods although currently they are not in use.

The change also includes a minor refactor in the provider that leads to better extendability if one would want to override how the results are parsed into addresses.
