### PR TITLE
tests: fix deprecation from PHPUnit

### DIFF
--- a/src/Provider/GeoIP2/Tests/GeoIP2AdapterTest.php
+++ b/src/Provider/GeoIP2/Tests/GeoIP2AdapterTest.php
@@ -118,7 +118,7 @@ class GeoIP2AdapterTest extends TestCase
         $this->assertJson($result);
 
         $decodedResult = json_decode($result);
-        $this->assertObjectHasAttribute('city', $decodedResult);
+        $this->assertObjectHasProperty('city', $decodedResult);
     }
 
     /**


### PR DESCRIPTION
```
There was 1 warning:

1) Geocoder\Provider\GeoIP2\Tests\GeoIP2AdapterTest::testReaderResponseIsJsonEncoded
assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10. Refactor your test to use assertObjectHasProperty() instead.
```