### PR TITLE
Utf8 encode

### DIFF
--- a/src/Provider/IP2LocationBinary/IP2LocationBinary.php
+++ b/src/Provider/IP2LocationBinary/IP2LocationBinary.php
@@ -81,9 +81,9 @@ final class IP2LocationBinary extends AbstractProvider implements Provider
             Address::createFromArray([
                 'providedBy' => $this->getName(),
                 'countryCode' => $records['countryCode'],
-                'country' => null === $records['countryName'] ? null : utf8_encode($records['countryName']),
+                'country' => null === $records['countryName'] ? null : mb_convert_encoding($records['countryName'], 'UTF-8', 'ISO-8859-1'),
                 'adminLevels' => $adminLevels,
-                'locality' => null === $records['cityName'] ? null : utf8_encode($records['cityName']),
+                'locality' => null === $records['cityName'] ? null : mb_convert_encoding($records['cityName'], 'UTF-8', 'ISO-8859-1'),
                 'latitude' => $records['latitude'],
                 'longitude' => $records['longitude'],
                 'postalCode' => $records['zipCode'],

--- a/src/Provider/IP2LocationBinary/composer.json
+++ b/src/Provider/IP2LocationBinary/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "^8.0",
         "ip2location/ip2location-php": "^8.1.1",
+        "symfony/polyfill-mbstring": "^1.0",
         "willdurand/geocoder": "^4.0"
     },
     "provide": {

--- a/src/Provider/MaxMindBinary/MaxMindBinary.php
+++ b/src/Provider/MaxMindBinary/MaxMindBinary.php
@@ -92,9 +92,9 @@ final class MaxMindBinary extends AbstractProvider implements Provider
             Address::createFromArray([
                 'providedBy' => $this->getName(),
                 'countryCode' => $geoIpRecord->country_code,
-                'country' => null === $geoIpRecord->country_name ? null : utf8_encode($geoIpRecord->country_name),
+                'country' => null === $geoIpRecord->country_name ? null : mb_convert_encoding($geoIpRecord->country_name, 'UTF-8', 'ISO-8859-1'),
                 'adminLevels' => $adminLevels,
-                'locality' => null === $geoIpRecord->city ? null : utf8_encode($geoIpRecord->city),
+                'locality' => null === $geoIpRecord->city ? null : mb_convert_encoding($geoIpRecord->city, 'UTF-8', 'ISO-8859-1'),
                 'latitude' => $geoIpRecord->latitude,
                 'longitude' => $geoIpRecord->longitude,
                 'postalCode' => $geoIpRecord->postal_code,

--- a/src/Provider/MaxMindBinary/composer.json
+++ b/src/Provider/MaxMindBinary/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "^8.0",
         "geoip/geoip": "^1.17",
+        "symfony/polyfill-mbstring": "^1.0",
         "willdurand/geocoder": "^4.0"
     },
     "provide": {


### PR DESCRIPTION
Trying to avoid `utf8_encode` deprecation warning on PHP 8.2+

It will try to do the same using `mbstring` or `iconv`  functions depending on available extension, and eventually fallback to utf8_encode (not to break BC?).

It's a bit of duplicated code - but I didn't think this specific case (used in two providers only) would warrant moving it to parent class.