### PR TITLE
Update subtree.yml

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -82,7 +82,7 @@ jobs:
           - { folder: Here, repository: here-provider }
           - { folder: HostIp, repository: host-ip-provider }
           - { folder: IP2Location, repository: ip2location-provider }
-          # - { folder: IP2LocationBinary, repository: ip2location-binary-provider }
+          - { folder: IP2LocationBinary, repository: ip2location-binary-provider }
           - { folder: IpInfo, repository: ip-info-provider }
           - { folder: IpInfoDb, repository: ip-info-db-provider }
           - { folder: Ipstack, repository: ipstack-provider }


### PR DESCRIPTION
Re-enable subtree split for [IP2Location Binary provider](https://github.com/geocoder-php/ip2location-binary-provider).

Issue reported in https://github.com/geocoder-php/Geocoder/pull/1225#issuecomment-2119149085