### PR TITLE
Return confidence from OpenCage API

### DIFF
--- a/src/Provider/OpenCage/Model/OpenCageAddress.php
+++ b/src/Provider/OpenCage/Model/OpenCageAddress.php
@@ -49,6 +49,11 @@ final class OpenCageAddress extends Address
      */
     private $formattedAddress;
 
+    /**
+     * @var int|null
+     */
+    private $confidence;
+
     public function withMGRS(?string $mgrs = null): self
     {
         $new = clone $this;
@@ -127,5 +132,21 @@ final class OpenCageAddress extends Address
     public function getFormattedAddress()
     {
         return $this->formattedAddress;
+    }
+
+    public function withConfidence(?int $confidence = null): self
+    {
+        $new = clone $this;
+        $new->confidence = $confidence;
+
+        return $new;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getConfidence()
+    {
+        return $this->confidence;
     }
 }

--- a/src/Provider/OpenCage/OpenCage.php
+++ b/src/Provider/OpenCage/OpenCage.php
@@ -154,6 +154,7 @@ final class OpenCage extends AbstractHttpProvider implements Provider
             $address = $address->withGeohash(isset($annotations['geohash']) ? $annotations['geohash'] : null);
             $address = $address->withWhat3words(isset($annotations['what3words'], $annotations['what3words']['words']) ? $annotations['what3words']['words'] : null);
             $address = $address->withFormattedAddress($location['formatted']);
+            $address = $address->withConfidence($location['confidence']);
 
             $results[] = $address;
         }

--- a/src/Provider/OpenCage/Tests/OpenCageTest.php
+++ b/src/Provider/OpenCage/Tests/OpenCageTest.php
@@ -83,6 +83,7 @@ class OpenCageTest extends BaseTestCase
         $this->assertEquals('u09tyr78tz64jdcgfnhe', $result->getGeohash());
         $this->assertEquals('listed.emphasis.greeting', $result->getWhat3words());
         $this->assertEquals('10 Avenue Gambetta, 75020 Paris, France', $result->getFormattedAddress());
+        $this->assertEquals(10, $result->getConfidence());
     }
 
     public function testReverseWithRealCoordinates(): void


### PR DESCRIPTION
We have a business case where we would need the accuracy/confidence from the providers we are using. This PR adds this for OpenCage.