### PR TITLE
[Photon] Improve locality for city layer & Add layer & radius query params

### DIFF
--- a/src/Provider/Photon/Model/PhotonAddress.php
+++ b/src/Provider/Photon/Model/PhotonAddress.php
@@ -62,7 +62,7 @@ final class PhotonAddress extends Address
     public function getLocality(): ?string
     {
         $locality = parent::getLocality();
-        if ($locality === null && $this->type === 'city' && $this->name !== null) {
+        if (null === $locality && 'city' === $this->type && null !== $this->name) {
             $locality = $this->name;
         }
 

--- a/src/Provider/Photon/Model/PhotonAddress.php
+++ b/src/Provider/Photon/Model/PhotonAddress.php
@@ -55,6 +55,21 @@ final class PhotonAddress extends Address
     private $district;
 
     /**
+     * @var string|null
+     */
+    private $type;
+
+    public function getLocality(): ?string
+    {
+        $locality = parent::getLocality();
+        if ($locality === null && $this->type === 'city' && $this->name !== null) {
+            $locality = $this->name;
+        }
+
+        return $locality;
+    }
+
+    /**
      * @return string|null
      */
     public function getName()
@@ -170,6 +185,19 @@ final class PhotonAddress extends Address
     {
         $new = clone $this;
         $new->district = $district;
+
+        return $new;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function withType(?string $type = null): self
+    {
+        $new = clone $this;
+        $new->type = $type;
 
         return $new;
     }

--- a/src/Provider/Photon/Photon.php
+++ b/src/Provider/Photon/Photon.php
@@ -68,6 +68,7 @@ final class Photon extends AbstractHttpProvider implements Provider
             .'/api?'
             .http_build_query([
                 'q' => $address,
+                'layer' => $query->getData('layer'),
                 'limit' => $query->getLimit(),
                 'lang' => $query->getLocale(),
             ]);
@@ -102,6 +103,8 @@ final class Photon extends AbstractHttpProvider implements Provider
             .http_build_query([
                 'lat' => $latitude,
                 'lon' => $longitude,
+                'layer' => $query->getData('layer'),
+                'radius' => $query->getData('radius'),
                 'limit' => $query->getLimit(),
                 'lang' => $query->getLocale(),
             ]);
@@ -157,7 +160,8 @@ final class Photon extends AbstractHttpProvider implements Provider
             ->withName($properties->name ?? null)
             ->withState($properties->state ?? null)
             ->withCounty($properties->county ?? null)
-            ->withDistrict($properties->district ?? null);
+            ->withDistrict($properties->district ?? null)
+            ->withType($properties->type ?? null);
 
         return $address;
     }

--- a/src/Provider/Photon/Tests/.cached_responses/photon.komoot.io_1452fda1b72428b0f5de90de04038275fd7f7e7e
+++ b/src/Provider/Photon/Tests/.cached_responses/photon.komoot.io_1452fda1b72428b0f5de90de04038275fd7f7e7e
@@ -1,0 +1,1 @@
+s:334:"{"features":[{"geometry":{"coordinates":[13.3989367,52.510885],"type":"Point"},"type":"Feature","properties":{"osm_type":"R","osm_id":62422,"extent":[13.088345,52.6755087,13.7611609,52.3382448],"country":"Deutschland","osm_key":"place","countrycode":"DE","osm_value":"city","name":"Berlin","type":"city"}}],"type":"FeatureCollection"}";

--- a/src/Provider/Photon/Tests/PhotonTest.php
+++ b/src/Provider/Photon/Tests/PhotonTest.php
@@ -178,4 +178,18 @@ class PhotonTest extends BaseTestCase
             $this->assertEquals('pharmacy', $result->getOSMTag()->value);
         }
     }
+
+    public function testReverseQueryWithLayerCityAndRadiusFilter(): void
+    {
+        $provider = Photon::withKomootServer($this->getHttpClient());
+        $reverseQuery = ReverseQuery::fromCoordinates(52.51644, 13.38890)
+            ->withData('layer', 'city')
+            ->withData('radius', 20)
+            ->withLimit(1);
+        $result = $provider->reverseQuery($reverseQuery)->first();
+
+        $this->assertInstanceOf(PhotonAddress::class, $result);
+        $this->assertEquals('city', $result->getType());
+        $this->assertEquals('Berlin', $result->getLocality());
+    }
 }


### PR DESCRIPTION
The idea here is to get the city in the PhotonAddress Model when the object returned by Photon is of type "city".
For example : [https://photon.komoot.io/reverse?lon=13.38890&lat=52.51644&lang=default&limit=1&layer=city&radius=10](https://photon.komoot.io/reverse?lon=13.38890&lat=52.51644&lang=default&limit=1&layer=city&radius=10)

In this example, we don't have the field city returned by Photon because it is the city element itself (so in this case the city/locality name is in the `name` field).


I also added :
- support for `radius` and `layer` query params as documented here [https://github.com/komoot/photon](https://github.com/komoot/photon)
- wrapping `type` in PhotonAddress model