### PR TITLE
Add support for resolving the State/Province with the Azure provider

### DIFF
--- a/src/Provider/AzureMaps/AzureMaps.php
+++ b/src/Provider/AzureMaps/AzureMaps.php
@@ -227,6 +227,13 @@ class AzureMaps extends AbstractHttpProvider implements Provider
             $builder->setPostalCode($result->address->extendedPostalCode ?? null);
             $builder->setLocality($result->address->municipality ?? null);
 
+            if (isset($result->address->countrySubdivision)) {
+                $builder->addAdminLevel(
+                    1,
+                    $result->address->countrySubdivision,
+                );
+            }
+
             return $builder->build();
         }, $response->results);
     }
@@ -265,6 +272,13 @@ class AzureMaps extends AbstractHttpProvider implements Provider
             $builder->setCountry($address->address->country ?? null);
             $builder->setPostalCode($address->address->extendedPostalCode ?? null);
             $builder->setLocality($address->address->municipality ?? null);
+
+            if (isset($address->address->countrySubdivision)) {
+                $builder->addAdminLevel(
+                    1,
+                    $address->address->countrySubdivision,
+                );
+            }
 
             return $builder->build();
         }, $response->addresses));

--- a/src/Provider/AzureMaps/Tests/AzureMapsTest.php
+++ b/src/Provider/AzureMaps/Tests/AzureMapsTest.php
@@ -62,6 +62,7 @@ class AzureMapsTest extends BaseTestCase
         $this->assertEquals(6266924, $result->getPostalCode());
         $this->assertEquals('Israel', $result->getCountry()->getName());
         $this->assertEquals('IL', $result->getCountry()->getCode());
+        $this->assertEquals('Tel Aviv District', $result->getAdminLevels()->get(1)->getName());
     }
 
     public function testReverseWithRealCoordinates(): void
@@ -92,6 +93,7 @@ class AzureMapsTest extends BaseTestCase
         $this->assertEquals(6266924, $result->getPostalCode());
         $this->assertEquals('Israel', $result->getCountry()->getName());
         $this->assertEquals('IL', $result->getCountry()->getCode());
+        $this->assertEquals('Tel Aviv District', $result->getAdminLevels()->get(1)->getName());
     }
 
     public function testGeocodeIncludesMunicipality(): void


### PR DESCRIPTION
There have been a number of situations where we need to capture the country subdivision (state/province) from the Azure geocoder response.  

This PR extracts the country subdivision and assigns it to the first administrative level.

