### PR TITLE
Resolve some deprecations and remove igorw/get-in dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "homepage": "http://geocoder-php.org",
     "require": {
         "php": ">=8.2",
-        "igorw/get-in": "^1.0",
         "php-http/discovery": "^1.17",
         "php-http/promise": "^1.0",
         "psr/http-client-implementation": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^9.6.11",
         "symfony/http-client": "^5.4.45 || ^6.4 || ^7.0",
         "symfony/stopwatch": "^5.4 || ^6.4 || ^7.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,4 +7,3 @@ parameters:
     excludePaths:
         - **/vendor/**
     treatPhpDocTypesAsCertain: false
-    checkGenericClassInNonGenericObjectType: false

--- a/src/Common/Tests/TimedGeocoderTest.php
+++ b/src/Common/Tests/TimedGeocoderTest.php
@@ -47,7 +47,7 @@ class TimedGeocoderTest extends TestCase
     {
         $this->delegate->expects($this->once())
              ->method('geocodeQuery')
-             ->will($this->returnValue(new AddressCollection([])));
+             ->willReturn(new AddressCollection([]));
 
         $this->geocoder->geocode('foo');
 
@@ -74,7 +74,7 @@ class TimedGeocoderTest extends TestCase
     {
         $this->delegate->expects($this->once())
              ->method('reverseQuery')
-             ->will($this->returnValue(new AddressCollection([])));
+             ->willReturn(new AddressCollection([]));
 
         $this->geocoder->reverse(0, 0);
 

--- a/src/Common/composer.json
+++ b/src/Common/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "nyholm/nsa": "^1.1",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6.11",
         "symfony/stopwatch": "~2.5 || ~5.0 || ~7.0"
     },
     "suggest": {

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -24,7 +24,7 @@
         "nyholm/psr7": "^1.0",
         "php-http/message": "^1.0",
         "php-http/mock-client": "^1.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6.11",
         "symfony/stopwatch": "~2.5 || ~5.0"
     },
     "extra": {

--- a/src/Plugin/Tests/Plugin/CachePluginTest.php
+++ b/src/Plugin/Tests/Plugin/CachePluginTest.php
@@ -27,10 +27,7 @@ class CachePluginTest extends TestCase
         $ttl = 4711;
         $query = GeocodeQuery::create('foo');
         $queryString = sha1($query->__toString());
-        $cache = $this->getMockBuilder(VoidCachePool::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['get', 'set'])
-            ->getMock();
+        $cache = $this->createPartialMock(VoidCachePool::class, ['get', 'set']);
 
         $cache->expects($this->once())
             ->method('get')
@@ -69,10 +66,7 @@ class CachePluginTest extends TestCase
      */
     public function testPluginHit(Query $query, string $key): void
     {
-        $cache = $this->getMockBuilder(VoidCachePool::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['get', 'set'])
-            ->getMock();
+        $cache = $this->createPartialMock(VoidCachePool::class, ['get', 'set']);
 
         $cache->expects($this->once())
             ->method('get')

--- a/src/Plugin/Tests/Plugin/LoggerPluginTest.php
+++ b/src/Plugin/Tests/Plugin/LoggerPluginTest.php
@@ -25,10 +25,7 @@ class LoggerPluginTest extends TestCase
 {
     public function testPlugin(): void
     {
-        $logger = $this->getMockBuilder(AbstractLogger::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['log'])
-            ->getMock();
+        $logger = $this->createPartialMock(AbstractLogger::class, ['log']);
         $logger->expects($this->once())
             ->method('log')
             ->with('info', $this->callback(function ($message) {
@@ -38,10 +35,7 @@ class LoggerPluginTest extends TestCase
         $geocodeQuery = GeocodeQuery::create('foo');
         $collection = new AddressCollection([]);
 
-        $provider = $this->getMockBuilder(Provider::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
-            ->getMock();
+        $provider = $this->createPartialMock(Provider::class, ['geocodeQuery', 'reverseQuery', 'getName']);
         $provider->expects($this->once())
             ->method('geocodeQuery')
             ->with($geocodeQuery)
@@ -56,10 +50,7 @@ class LoggerPluginTest extends TestCase
     public function testPluginException(): void
     {
         $this->expectException(QuotaExceeded::class);
-        $logger = $this->getMockBuilder(AbstractLogger::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['log'])
-            ->getMock();
+        $logger = $this->createPartialMock(AbstractLogger::class, ['log']);
         $logger->expects($this->once())
             ->method('log')
             ->with('error', $this->callback(function ($message) {
@@ -67,10 +58,7 @@ class LoggerPluginTest extends TestCase
             }));
 
         $geocodeQuery = GeocodeQuery::create('foo');
-        $provider = $this->getMockBuilder(Provider::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
-            ->getMock();
+        $provider = $this->createPartialMock(Provider::class, ['geocodeQuery', 'reverseQuery', 'getName']);
         $provider->expects($this->once())
             ->method('geocodeQuery')
             ->willThrowException(new QuotaExceeded());

--- a/src/Plugin/Tests/PluginProviderTest.php
+++ b/src/Plugin/Tests/PluginProviderTest.php
@@ -30,10 +30,7 @@ class PluginProviderTest extends TestCase
         $reverseQuery = ReverseQuery::fromCoordinates(47, 11);
         $collection = new AddressCollection([]);
 
-        $provider = $this->getMockBuilder(Provider::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
-            ->getMock();
+        $provider = $this->createPartialMock(Provider::class, ['geocodeQuery', 'reverseQuery', 'getName']);
         $provider->expects($this->once())
             ->method('geocodeQuery')
             ->with($geocodeQuery)
@@ -54,10 +51,7 @@ class PluginProviderTest extends TestCase
         $geocodeQuery = GeocodeQuery::create('foo');
         $collection = new AddressCollection([]);
 
-        $provider = $this->getMockBuilder(Provider::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
-            ->getMock();
+        $provider = $this->createPartialMock(Provider::class, ['geocodeQuery', 'reverseQuery', 'getName']);
         $provider->expects($this->once())
             ->method('geocodeQuery')
             ->with($geocodeQuery)
@@ -65,10 +59,7 @@ class PluginProviderTest extends TestCase
         $provider->expects($this->never())->method('reverseQuery');
         $provider->expects($this->never())->method('getName');
 
-        $pluginA = $this->getMockBuilder(Plugin::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['handleQuery'])
-            ->getMock();
+        $pluginA = $this->createPartialMock(Plugin::class, ['handleQuery']);
         $pluginA->expects($this->once())
             ->method('handleQuery')
             ->with($geocodeQuery, $this->isType('callable'), $this->isType('callable'))
@@ -85,10 +76,7 @@ class PluginProviderTest extends TestCase
         $reverseQuery = ReverseQuery::fromCoordinates(47, 11);
         $collection = new AddressCollection([]);
 
-        $provider = $this->getMockBuilder(Provider::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
-            ->getMock();
+        $provider = $this->createPartialMock(Provider::class, ['geocodeQuery', 'reverseQuery', 'getName']);
         $provider->expects($this->never())->method('geocodeQuery');
         $provider->expects($this->never())->method('getName');
         $provider->expects($this->once())
@@ -96,10 +84,7 @@ class PluginProviderTest extends TestCase
             ->with($reverseQuery)
             ->willReturn($collection);
 
-        $pluginA = $this->getMockBuilder(Plugin::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['handleQuery'])
-            ->getMock();
+        $pluginA = $this->createPartialMock(Plugin::class, ['handleQuery']);
         $pluginA->expects($this->once())
             ->method('handleQuery')
             ->with($reverseQuery, $this->isType('callable'), $this->isType('callable'))
@@ -116,28 +101,19 @@ class PluginProviderTest extends TestCase
         $this->expectException(LoopException::class);
         $geocodeQuery = GeocodeQuery::create('foo');
 
-        $provider = $this->getMockBuilder(Provider::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['geocodeQuery', 'reverseQuery', 'getName'])
-            ->getMock();
+        $provider = $this->createPartialMock(Provider::class, ['geocodeQuery', 'reverseQuery', 'getName']);
         $provider->expects($this->never())->method('geocodeQuery');
         $provider->expects($this->never())->method('reverseQuery');
         $provider->expects($this->never())->method('getName');
 
-        $pluginA = $this->getMockBuilder(Plugin::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['handleQuery'])
-            ->getMock();
+        $pluginA = $this->createPartialMock(Plugin::class, ['handleQuery']);
         $pluginA->expects($this->any())
             ->method('handleQuery')
             ->with($geocodeQuery, $this->isType('callable'), $this->isType('callable'))
             ->willReturnCallback(function (Query $query, callable $next, callable $first) {
                 return $next($query);
             });
-        $pluginB = $this->getMockBuilder(Plugin::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['handleQuery'])
-            ->getMock();
+        $pluginB = $this->createPartialMock(Plugin::class, ['handleQuery']);
         $pluginB->expects($this->any())
             ->method('handleQuery')
             ->with($geocodeQuery, $this->isType('callable'), $this->isType('callable'))

--- a/src/Plugin/composer.json
+++ b/src/Plugin/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "cache/void-adapter": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/AlgoliaPlaces/composer.json
+++ b/src/Provider/AlgoliaPlaces/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/ArcGISOnline/composer.json
+++ b/src/Provider/ArcGISOnline/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/AzureMaps/composer.json
+++ b/src/Provider/AzureMaps/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/BingMaps/composer.json
+++ b/src/Provider/BingMaps/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Cache/Tests/ProviderCacheTest.php
+++ b/src/Provider/Cache/Tests/ProviderCacheTest.php
@@ -41,14 +41,9 @@ class ProviderCacheTest extends TestCase
     {
         parent::setUp();
 
-        $this->cacheMock = $this->getMockBuilder(CacheInterface::class)
-            ->setMethods(['get', 'set', 'delete', 'clear', 'setMultiple', 'getMultiple', 'deleteMultiple', 'has'])
+        $this->cacheMock = $this->createPartialMock(CacheInterface::class, ['get', 'set', 'delete', 'clear', 'setMultiple', 'getMultiple', 'deleteMultiple', 'has']);
 
-            ->getMock();
-
-        $this->providerMock = $this->getMockBuilder(Provider::class)
-            ->setMethods(['getFoo', 'getName', 'geocodeQuery', 'reverseQuery'])
-            ->getMock();
+        $this->providerMock = $this->createPartialMock(Provider::class, ['getName', 'geocodeQuery', 'reverseQuery']);
     }
 
     public function testName(): void

--- a/src/Provider/Cache/composer.json
+++ b/src/Provider/Cache/composer.json
@@ -20,7 +20,7 @@
         "geocoder-php/provider-implementation": "1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Chain/Tests/ChainTest.php
+++ b/src/Provider/Chain/Tests/ChainTest.php
@@ -53,7 +53,7 @@ class ChainTest extends TestCase
         $result = new AddressCollection(['foo' => 'bar']);
         $mockTwo->expects($this->once())
             ->method('reverseQuery')
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $chain = new Chain([$mockOne, $mockTwo]);
 
@@ -75,7 +75,7 @@ class ChainTest extends TestCase
         $mockTwo->expects($this->once())
             ->method('geocodeQuery')
             ->with($query)
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $chain = new Chain([$mockOne, $mockTwo]);
 

--- a/src/Provider/Chain/Tests/ChainTest.php
+++ b/src/Provider/Chain/Tests/ChainTest.php
@@ -45,9 +45,9 @@ class ChainTest extends TestCase
         $mockOne = $this->getMockBuilder(Provider::class)->getMock();
         $mockOne->expects($this->once())
             ->method('reverseQuery')
-            ->will($this->returnCallback(function () {
+            ->willReturnCallback(function () {
                 throw new \Exception();
-            }));
+            });
 
         $mockTwo = $this->getMockBuilder(Provider::class)->getMock();
         $result = new AddressCollection(['foo' => 'bar']);
@@ -66,9 +66,9 @@ class ChainTest extends TestCase
         $mockOne = $this->getMockBuilder(Provider::class)->getMock();
         $mockOne->expects($this->once())
             ->method('geocodeQuery')
-            ->will($this->returnCallback(function () {
+            ->willReturnCallback(function () {
                 throw new \Exception();
-            }));
+            });
 
         $mockTwo = $this->getMockBuilder(Provider::class)->getMock();
         $result = new AddressCollection(['foo' => 'bar']);

--- a/src/Provider/Chain/composer.json
+++ b/src/Provider/Chain/composer.json
@@ -23,7 +23,7 @@
         "nyholm/nsa": "^1.1",
         "php-http/curl-client": "^2.2",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/FreeGeoIp/composer.json
+++ b/src/Provider/FreeGeoIp/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GeoIP2/Tests/GeoIP2AdapterTest.php
+++ b/src/Provider/GeoIP2/Tests/GeoIP2AdapterTest.php
@@ -118,7 +118,7 @@ class GeoIP2AdapterTest extends TestCase
         $this->assertJson($result);
 
         $decodedResult = json_decode($result);
-        $this->assertObjectHasAttribute('city', $decodedResult);
+        $this->assertObjectHasProperty('city', $decodedResult);
     }
 
     /**

--- a/src/Provider/GeoIP2/Tests/GeoIP2AdapterTest.php
+++ b/src/Provider/GeoIP2/Tests/GeoIP2AdapterTest.php
@@ -86,9 +86,7 @@ class GeoIP2AdapterTest extends TestCase
             ->expects($this->once())
             ->method($geoIp2Model)
             ->with('127.0.0.1')
-            ->will($this->returnValue(
-                $this->getGeoIP2ModelMock($geoIp2Model)
-            ));
+            ->willReturn($this->getGeoIP2ModelMock($geoIp2Model));
 
         $adapter = new GeoIP2Adapter($geoIp2Provider, $geoIp2Model);
         $adapter->getContent('file://geoip?127.0.0.1');
@@ -110,7 +108,7 @@ class GeoIP2AdapterTest extends TestCase
         $geoIp2Provider
             ->expects($this->any())
             ->method('city')
-            ->will($this->returnValue($cityModel));
+            ->willReturn($cityModel);
 
         $adapter = new GeoIP2Adapter($geoIp2Provider);
 
@@ -145,23 +143,21 @@ class GeoIP2AdapterTest extends TestCase
         $mock
             ->expects($this->any())
             ->method('jsonSerialize')
-            ->will($this->returnValue(
-                [
-                    'city' => [
-                        'geoname_id' => 2911298,
-                        'names' => [
-                            'de' => 'Hamburg',
-                            'en' => 'Hamburg',
-                            'es' => 'Hamburgo',
-                            'fr' => 'Hambourg',
-                            'ja' => 'ハンブルク',
-                            'pt-BR' => 'Hamburgo',
-                            'ru' => 'Гамбург',
-                            'zh-CN' => '汉堡市',
-                        ],
+            ->willReturn([
+                'city' => [
+                    'geoname_id' => 2911298,
+                    'names' => [
+                        'de' => 'Hamburg',
+                        'en' => 'Hamburg',
+                        'es' => 'Hamburgo',
+                        'fr' => 'Hambourg',
+                        'ja' => 'ハンブルク',
+                        'pt-BR' => 'Hamburgo',
+                        'ru' => 'Гамбург',
+                        'zh-CN' => '汉堡市',
                     ],
-                ]
-            ));
+                ],
+            ]);
 
         return $mock;
     }

--- a/src/Provider/GeoIP2/Tests/GeoIP2Test.php
+++ b/src/Provider/GeoIP2/Tests/GeoIP2Test.php
@@ -264,10 +264,7 @@ class GeoIP2Test extends BaseTestCase
      */
     private function getGeoIP2AdapterMock($returnValue = '')
     {
-        $mock = $this->getMockBuilder(GeoIP2Adapter::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getContent'])
-            ->getMock();
+        $mock = $this->createPartialMock(GeoIP2Adapter::class, ['getContent']);
 
         if ($returnValue instanceof \Exception) {
             $returnValue = $this->throwException($returnValue);

--- a/src/Provider/GeoIP2/composer.json
+++ b/src/Provider/GeoIP2/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GeoIPs/composer.json
+++ b/src/Provider/GeoIPs/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GeoPlugin/GeoPlugin.php
+++ b/src/Provider/GeoPlugin/GeoPlugin.php
@@ -86,8 +86,8 @@ final class GeoPlugin extends AbstractHttpProvider implements Provider
 
         $adminLevels = [];
 
-        $region = \igorw\get_in($data, ['geoplugin_regionName']);
-        $regionCode = \igorw\get_in($data, ['geoplugin_regionCode']);
+        $region = $data['geoplugin_regionName'] ?? null;
+        $regionCode = $data['geoplugin_regionCode'] ?? null;
 
         if (null !== $region || null !== $regionCode) {
             $adminLevels[] = ['name' => $region, 'code' => $regionCode, 'level' => 1];

--- a/src/Provider/GeoPlugin/composer.json
+++ b/src/Provider/GeoPlugin/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GeoPlugin/composer.json
+++ b/src/Provider/GeoPlugin/composer.json
@@ -14,7 +14,6 @@
     "require": {
         "php": "^8.0",
         "geocoder-php/common-http": "^4.0",
-        "igorw/get-in": "^1.0",
         "willdurand/geocoder": "^4.0|^5.0"
     },
     "provide": {

--- a/src/Provider/GeocodeEarth/composer.json
+++ b/src/Provider/GeocodeEarth/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Geoip/composer.json
+++ b/src/Provider/Geoip/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Geonames/composer.json
+++ b/src/Provider/Geonames/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GoogleMaps/composer.json
+++ b/src/Provider/GoogleMaps/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GoogleMapsPlaces/composer.json
+++ b/src/Provider/GoogleMapsPlaces/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/GraphHopper/composer.json
+++ b/src/Provider/GraphHopper/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Here/composer.json
+++ b/src/Provider/Here/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/HostIp/composer.json
+++ b/src/Provider/HostIp/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/IP2Location/composer.json
+++ b/src/Provider/IP2Location/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/IP2LocationBinary/composer.json
+++ b/src/Provider/IP2LocationBinary/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/IpInfo/composer.json
+++ b/src/Provider/IpInfo/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/IpInfoDb/composer.json
+++ b/src/Provider/IpInfoDb/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Ipstack/composer.json
+++ b/src/Provider/Ipstack/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/LocationIQ/composer.json
+++ b/src/Provider/LocationIQ/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "provide": {
         "geocoder-php/provider-implementation": "1.0"

--- a/src/Provider/MapQuest/composer.json
+++ b/src/Provider/MapQuest/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/MapTiler/composer.json
+++ b/src/Provider/MapTiler/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "autoload": {
         "psr-4": {

--- a/src/Provider/Mapbox/composer.json
+++ b/src/Provider/Mapbox/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Mapzen/composer.json
+++ b/src/Provider/Mapzen/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/MaxMind/MaxMind.php
+++ b/src/Provider/MaxMind/MaxMind.php
@@ -146,8 +146,8 @@ final class MaxMind extends AbstractHttpProvider implements Provider
     {
         $adminLevels = [];
 
-        $region = \igorw\get_in($data, ['region']);
-        $regionCode = \igorw\get_in($data, ['regionCode']);
+        $region = $data['region'] ?? null;
+        $regionCode = $data['regionCode'] ?? null;
         unset($data['region'], $data['regionCode']);
 
         if (null !== $region || null !== $regionCode) {

--- a/src/Provider/MaxMind/composer.json
+++ b/src/Provider/MaxMind/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "igorw/get-in": "^1.0",
         "willdurand/geocoder": "^4.1|^5.0"
     },
     "provide": {

--- a/src/Provider/MaxMind/composer.json
+++ b/src/Provider/MaxMind/composer.json
@@ -22,7 +22,7 @@
         "geocoder-php/common-http": "^4.0",
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/MaxMindBinary/composer.json
+++ b/src/Provider/MaxMindBinary/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Nominatim/composer.json
+++ b/src/Provider/Nominatim/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/OpenCage/composer.json
+++ b/src/Provider/OpenCage/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/OpenRouteService/composer.json
+++ b/src/Provider/OpenRouteService/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Pelias/composer.json
+++ b/src/Provider/Pelias/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.7",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Photon/composer.json
+++ b/src/Provider/Photon/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "autoload": {
         "psr-4": {

--- a/src/Provider/PickPoint/composer.json
+++ b/src/Provider/PickPoint/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/TomTom/composer.json
+++ b/src/Provider/TomTom/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {

--- a/src/Provider/Yandex/composer.json
+++ b/src/Provider/Yandex/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.6.3",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6.11"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
- Drop `igorw/get-in` dependency and use PHP null-coalescing instead;
- Use phpunit `assertObjectHasProperty(...)` over deprecated `assertObjectHasAttribute(...)`;
- Use phpunit `->willReturn(...)` over `->will($this->returnValue(...))`;
- Use phpunit `->willReturnCallback(...)` over `->will($this->returnCallback(...))`;
- Use phpunit `createPartialMock` over deprecated `getMockBuilder::setMethods(...)`;
- Remove deprecated phpstan `checkGenericClassInNonGenericObjectType` option;
- Bump phpunit to 9.6.11 (this will be consistent across codebase, also `assertObjectHasProperty` was introduced only in 9.6);